### PR TITLE
feat: 닉네임 중복 체크

### DIFF
--- a/src/main/kotlin/pmeet/pmeetserver/user/controller/UserController.kt
+++ b/src/main/kotlin/pmeet/pmeetserver/user/controller/UserController.kt
@@ -1,0 +1,25 @@
+package pmeet.pmeetserver.user.controller
+
+import jakarta.validation.Valid
+import org.springframework.http.HttpStatus
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RequestBody
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.ResponseStatus
+import org.springframework.web.bind.annotation.RestController
+import pmeet.pmeetserver.user.dto.request.CheckNickNameRequestDto
+import pmeet.pmeetserver.user.service.UserFacadeService
+import pmeet.pmeetserver.user.service.UserService
+
+@RestController
+@RequestMapping("/api/v1/users")
+class UserController(
+  private val userService: UserService,
+  private val userFacadeService: UserFacadeService
+) {
+  @PostMapping("/nickname/duplicate")
+  @ResponseStatus(HttpStatus.OK)
+  suspend fun getNickname(@RequestBody @Valid requestDto: CheckNickNameRequestDto): Boolean {
+    return userFacadeService.isDuplicateNickName(requestDto)
+  }
+}

--- a/src/main/kotlin/pmeet/pmeetserver/user/dto/request/CheckNickNameRequestDto.kt
+++ b/src/main/kotlin/pmeet/pmeetserver/user/dto/request/CheckNickNameRequestDto.kt
@@ -1,0 +1,11 @@
+package pmeet.pmeetserver.user.dto.request
+
+import jakarta.validation.constraints.Pattern
+import jakarta.validation.constraints.Size
+
+data class CheckNickNameRequestDto(
+  @field:Size(min = 1, max = 30, message = "닉네임은 1자부터 30자까지 가능합니다.")
+  @field:Pattern(regexp = "^[가-힣ㄱ-ㅎㅏ-ㅣA-Za-z]+\$", message = "닉네임은 문자만 입력 가능합니다.")
+  val nickname: String
+)
+

--- a/src/main/kotlin/pmeet/pmeetserver/user/service/UserFacadeService.kt
+++ b/src/main/kotlin/pmeet/pmeetserver/user/service/UserFacadeService.kt
@@ -1,0 +1,23 @@
+package pmeet.pmeetserver.user.service
+
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+import pmeet.pmeetserver.common.ErrorCode
+import pmeet.pmeetserver.common.exception.EntityDuplicateException
+import pmeet.pmeetserver.user.dto.request.CheckNickNameRequestDto
+
+@Service
+class UserFacadeService(
+  private val userService: UserService
+) {
+
+  @Transactional(readOnly = true)
+  suspend fun isDuplicateNickName(requestDto: CheckNickNameRequestDto): Boolean {
+    userService.getUserByNickname(requestDto.nickname)?.let {
+      throw EntityDuplicateException(ErrorCode.USER_DUPLICATE_BY_NICKNAME)
+    }
+    return false
+  }
+
+}
+

--- a/src/main/kotlin/pmeet/pmeetserver/user/service/UserService.kt
+++ b/src/main/kotlin/pmeet/pmeetserver/user/service/UserService.kt
@@ -43,4 +43,9 @@ class UserService(
 
     return UserResponseDto.from(user)
   }
+
+  @Transactional(readOnly = true)
+  suspend fun getUserByNickname(nickname: String): User? {
+    return userRepository.findByNickname(nickname).awaitSingleOrNull();
+  }
 }


### PR DESCRIPTION
## Related issue
resolves #12

## Description
- Json Body에 담고자 PostMapping 사용
## Changes detail
- 재사용성을 위해 getUserByNickName() 메서드 자체에서 익셉션을 던지지 않게함

### Checklist
- [ ] Test case
- [x] End of work
