### PR TITLE
chore: 유저 정보 응답에서 패스워드 필드 제거

### DIFF
--- a/src/main/kotlin/pmeet/pmeetserver/user/dto/UserResponseDto.kt
+++ b/src/main/kotlin/pmeet/pmeetserver/user/dto/UserResponseDto.kt
@@ -7,7 +7,6 @@ data class UserResponseDto(
   val provider: String?,
   val email: String,
   val name: String,
-  val password: String?,
   val nickname: String
 ) {
   companion object {
@@ -17,7 +16,6 @@ data class UserResponseDto(
         provider = user.provider,
         email = user.email,
         name = user.name,
-        password = user.password,
         nickname = user.nickname
       )
     }


### PR DESCRIPTION
## Related issue

## Description
UserResponseDto의 PassWord Field 제거

## Changes detail
- 
-
### Checklist
- [ ] Test case
- [x] End of work
