### PR TITLE
feat: 인증 코드 이메일 전송

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,3 +38,6 @@ out/
 
 ### Kotlin ###
 .kotlin
+
+### Resources ###
+application-secret.yml

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -52,6 +52,9 @@ dependencies {
   // redis
   implementation("org.springframework.boot:spring-boot-starter-data-redis-reactive")
 
+  // SMTP
+  implementation("org.springframework.boot:spring-boot-starter-mail")
+
 }
 
 tasks.withType<KotlinCompile> {

--- a/src/main/kotlin/pmeet/pmeetserver/auth/service/EmailService.kt
+++ b/src/main/kotlin/pmeet/pmeetserver/auth/service/EmailService.kt
@@ -1,0 +1,51 @@
+package pmeet.pmeetserver.auth.service
+
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.withContext
+import org.springframework.data.redis.core.ReactiveRedisTemplate
+import org.springframework.mail.javamail.JavaMailSender
+import org.springframework.mail.javamail.MimeMessageHelper
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+import pmeet.pmeetserver.common.generator.VerificationCodeGenerator
+import java.time.Duration
+
+@Service
+class EmailService(
+  private val javaMailSender: JavaMailSender,
+  private val reactiveRedisTemplate: ReactiveRedisTemplate<String, String>,
+  private val dispatcher: CoroutineDispatcher
+) {
+
+  companion object {
+    private val VERIFICATION_CODE_TIME_TO_LIVE by lazy { Duration.ofMinutes(5L) }
+    private val EMAIL_BODY_TEMPLATE by lazy {
+      """
+            <div style="font-family: Arial, '맑은 고딕', sans-serif; color: #333;">
+                <h2>회원가입 인증 코드</h2>
+                <p><b>pmeet</b>에 등록해 주셔서 감사합니다. 다음 코드를 사용하여 등록을 완료해 주세요:</p>
+                <p><b style="font-size: 24px; color: #555;">{verificationCode}</b></p>
+                <p>이 코드는 <b>5분 동안</b> 유효합니다.</p>
+                <p>본인이 요청하지 않았다면, 이 이메일을 무시해 주세요.</p>
+            </div>
+        """.trimIndent()
+    }
+  }
+
+  @Transactional
+  suspend fun sendEmailWithVerificationCode(email: String) {
+    withContext(dispatcher) {
+      val message = javaMailSender.createMimeMessage()
+      val helper = MimeMessageHelper(message, true, "UTF-8")
+      val verificationCode = VerificationCodeGenerator.generateVerificationCode()
+      helper.setTo(email)
+      helper.setSubject("pmeet 회원가입 인증 번호")
+
+      val htmlMsg = EMAIL_BODY_TEMPLATE.replace("{verificationCode}", verificationCode)
+
+      helper.setText(htmlMsg, true)
+      javaMailSender.send(message)
+      reactiveRedisTemplate.opsForValue().set(email, verificationCode, VERIFICATION_CODE_TIME_TO_LIVE).subscribe()
+    }
+  }
+}

--- a/src/main/kotlin/pmeet/pmeetserver/common/generator/VerificationCodeGenerator.kt
+++ b/src/main/kotlin/pmeet/pmeetserver/common/generator/VerificationCodeGenerator.kt
@@ -1,0 +1,14 @@
+package pmeet.pmeetserver.common.generator
+
+class VerificationCodeGenerator {
+
+  companion object {
+    private val VERIFICATION_CODE_LENGTH by lazy { 6 }
+    private val VERIFICATION_CODE_CHARACTERS by lazy { ('0'..'9') + ('A'..'Z') + ('a'..'z') }
+
+    fun generateVerificationCode(): String {
+      return List(VERIFICATION_CODE_LENGTH) { VERIFICATION_CODE_CHARACTERS.random() }.joinToString("")
+    }
+  }
+
+}

--- a/src/main/kotlin/pmeet/pmeetserver/config/CoroutineConfig.kt
+++ b/src/main/kotlin/pmeet/pmeetserver/config/CoroutineConfig.kt
@@ -1,0 +1,13 @@
+package pmeet.pmeetserver.config
+
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.Dispatchers
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+
+@Configuration
+class CoroutineConfig {
+
+  @Bean
+  fun ioDispatcher(): CoroutineDispatcher = Dispatchers.IO
+}

--- a/src/main/kotlin/pmeet/pmeetserver/user/controller/AuthController.kt
+++ b/src/main/kotlin/pmeet/pmeetserver/user/controller/AuthController.kt
@@ -8,6 +8,7 @@ import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.ResponseStatus
 import org.springframework.web.bind.annotation.RestController
 import pmeet.pmeetserver.user.dto.request.CheckNickNameRequestDto
+import pmeet.pmeetserver.user.dto.request.SendVerificationCodeRequestDto
 import pmeet.pmeetserver.user.dto.request.SignInRequestDto
 import pmeet.pmeetserver.user.dto.request.SignUpRequestDto
 import pmeet.pmeetserver.user.dto.response.UserResponseDto
@@ -34,6 +35,12 @@ class AuthController(
   @ResponseStatus(HttpStatus.OK)
   suspend fun getNickname(@RequestBody @Valid requestDto: CheckNickNameRequestDto): Boolean {
     return userFacadeService.isDuplicateNickName(requestDto)
+  }
+
+  @PostMapping("/verification-code")
+  @ResponseStatus(HttpStatus.OK)
+  suspend fun sendVerificationCode(@RequestBody @Valid requestDto: SendVerificationCodeRequestDto): Boolean {
+    return userFacadeService.sendVerificationCode(requestDto)
   }
 }
 

--- a/src/main/kotlin/pmeet/pmeetserver/user/dto/request/SendVerificationCodeRequestDto.kt
+++ b/src/main/kotlin/pmeet/pmeetserver/user/dto/request/SendVerificationCodeRequestDto.kt
@@ -1,0 +1,10 @@
+package pmeet.pmeetserver.user.dto.request
+
+import jakarta.validation.constraints.Email
+import jakarta.validation.constraints.NotBlank
+
+data class SendVerificationCodeRequestDto(
+  @field:Email(message = "이메일 형식이 아닙니다. 다시 입력해 주세요.")
+  @field:NotBlank(message = "이메일을 입력해 주세요.")
+  val email: String,
+)

--- a/src/main/kotlin/pmeet/pmeetserver/user/service/UserFacadeService.kt
+++ b/src/main/kotlin/pmeet/pmeetserver/user/service/UserFacadeService.kt
@@ -4,12 +4,14 @@ import org.springframework.data.redis.core.ReactiveRedisTemplate
 import org.springframework.security.crypto.password.PasswordEncoder
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
+import pmeet.pmeetserver.auth.service.EmailService
 import pmeet.pmeetserver.common.ErrorCode
 import pmeet.pmeetserver.common.exception.EntityDuplicateException
 import pmeet.pmeetserver.common.exception.EntityNotFoundException
 import pmeet.pmeetserver.common.exception.UnauthorizedException
 import pmeet.pmeetserver.user.domain.User
 import pmeet.pmeetserver.user.dto.request.CheckNickNameRequestDto
+import pmeet.pmeetserver.user.dto.request.SendVerificationCodeRequestDto
 import pmeet.pmeetserver.user.dto.request.SignInRequestDto
 import pmeet.pmeetserver.user.dto.request.SignUpRequestDto
 import pmeet.pmeetserver.user.dto.response.UserResponseDto
@@ -18,7 +20,8 @@ import pmeet.pmeetserver.user.dto.response.UserResponseDto
 class UserFacadeService(
   private val passwordEncoder: PasswordEncoder,
   private val userService: UserService,
-  private val reactiveRedisTemplate: ReactiveRedisTemplate<String, String>
+  private val reactiveRedisTemplate: ReactiveRedisTemplate<String, String>,
+  private val emailService: EmailService
 ) {
   @Transactional
   suspend fun save(requestDto: SignUpRequestDto): UserResponseDto {
@@ -53,6 +56,12 @@ class UserFacadeService(
       throw EntityDuplicateException(ErrorCode.USER_DUPLICATE_BY_NICKNAME)
     }
     return false
+  }
+
+  @Transactional
+  suspend fun sendVerificationCode(requestDto: SendVerificationCodeRequestDto): Boolean {
+    emailService.sendEmailWithVerificationCode(requestDto.email)
+    return true
   }
 }
 

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,4 +1,6 @@
 spring:
+  config:
+    import: classpath:application-secret.yml
   data:
     mongodb:
       uri: mongodb://pmeet_user:pmeet_pwd@localhost:27017/pmeet?authSource=admin


### PR DESCRIPTION
## Related issue
resolves #9 

## Description
- 인증 코드 전송 후 Redis에 (email, verificationCode) 로 저장 
- TTL은 5분
## Changes detail
- 민감 정보 유출 방지를 위해 yml 분리 후 gitignore 추가

### Checklist
- [ ] Test case
- [x] End of work
