### PR TITLE
feat: 이메일 인증 코드 확인

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -55,6 +55,8 @@ dependencies {
   // SMTP
   implementation("org.springframework.boot:spring-boot-starter-mail")
 
+  implementation("io.netty:netty-resolver-dns-native-macos:4.1.106.Final:osx-aarch_64")
+
 }
 
 tasks.withType<KotlinCompile> {

--- a/src/main/kotlin/pmeet/pmeetserver/auth/service/EmailService.kt
+++ b/src/main/kotlin/pmeet/pmeetserver/auth/service/EmailService.kt
@@ -1,12 +1,15 @@
 package pmeet.pmeetserver.auth.service
 
 import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.reactor.awaitSingleOrNull
 import kotlinx.coroutines.withContext
 import org.springframework.data.redis.core.ReactiveRedisTemplate
 import org.springframework.mail.javamail.JavaMailSender
 import org.springframework.mail.javamail.MimeMessageHelper
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
+import pmeet.pmeetserver.common.ErrorCode
+import pmeet.pmeetserver.common.exception.UnauthorizedException
 import pmeet.pmeetserver.common.generator.VerificationCodeGenerator
 import java.time.Duration
 
@@ -18,14 +21,15 @@ class EmailService(
 ) {
 
   companion object {
-    private val VERIFICATION_CODE_TIME_TO_LIVE by lazy { Duration.ofMinutes(5L) }
+    private val VERIFICATION_CODE_TIME_TO_LIVE by lazy { 5L }
+    private val SUBJECT_MESSAGE by lazy { "pmeet 회원가입 인증 번호" }
     private val EMAIL_BODY_TEMPLATE by lazy {
       """
             <div style="font-family: Arial, '맑은 고딕', sans-serif; color: #333;">
                 <h2>회원가입 인증 코드</h2>
                 <p><b>pmeet</b>에 등록해 주셔서 감사합니다. 다음 코드를 사용하여 등록을 완료해 주세요:</p>
                 <p><b style="font-size: 24px; color: #555;">{verificationCode}</b></p>
-                <p>이 코드는 <b>5분 동안</b> 유효합니다.</p>
+                <p>이 코드는 <b>${VERIFICATION_CODE_TIME_TO_LIVE}분 동안</b> 유효합니다.</p>
                 <p>본인이 요청하지 않았다면, 이 이메일을 무시해 주세요.</p>
             </div>
         """.trimIndent()
@@ -39,13 +43,24 @@ class EmailService(
       val helper = MimeMessageHelper(message, true, "UTF-8")
       val verificationCode = VerificationCodeGenerator.generateVerificationCode()
       helper.setTo(email)
-      helper.setSubject("pmeet 회원가입 인증 번호")
+      helper.setSubject(SUBJECT_MESSAGE)
 
       val htmlMsg = EMAIL_BODY_TEMPLATE.replace("{verificationCode}", verificationCode)
 
       helper.setText(htmlMsg, true)
       javaMailSender.send(message)
-      reactiveRedisTemplate.opsForValue().set(email, verificationCode, VERIFICATION_CODE_TIME_TO_LIVE).subscribe()
+      reactiveRedisTemplate.opsForValue()
+        .set(email, verificationCode, Duration.ofMinutes(VERIFICATION_CODE_TIME_TO_LIVE)).subscribe()
     }
+  }
+
+  @Transactional
+  suspend fun verifyVerificationCode(email: String, verificationCode: String): Boolean {
+    reactiveRedisTemplate.opsForValue().get(email).awaitSingleOrNull()?.also { storedCode ->
+      if (storedCode != verificationCode) {
+        throw UnauthorizedException(ErrorCode.VERIFICATION_CODE_NOT_MATCH)
+      }
+    } ?: throw UnauthorizedException(ErrorCode.VERIFICATION_CODE_EXPIRED)
+    return true
   }
 }

--- a/src/main/kotlin/pmeet/pmeetserver/common/ErrorCode.kt
+++ b/src/main/kotlin/pmeet/pmeetserver/common/ErrorCode.kt
@@ -6,7 +6,9 @@ enum class ErrorCode(private val code: String, private val message: String) {
   USER_DUPLICATE_BY_EMAIL("USER-40000", "중복된 이메일입니다."),
   USER_DUPLICATE_BY_NICKNAME("USER-40001", "중복된 닉네임입니다."),
   USER_NOT_FOUND_BY_EMAIL("USER-40002", "해당하는 이메일의 유저를 찾을 수 없습니다."),
-  INVALID_PASSWORD("USER-40003", "비밀번호를 다시 입력해 주세요.")
+  INVALID_PASSWORD("USER-40003", "비밀번호를 다시 입력해 주세요."),
+  VERIFICATION_CODE_NOT_MATCH("USER-40004", "인증번호가 일치하지 않습니다."),
+  VERIFICATION_CODE_EXPIRED("USER-40005", "인증번호가 만료되었습니다.")
 
   ;
 

--- a/src/main/kotlin/pmeet/pmeetserver/config/MailConfig.kt
+++ b/src/main/kotlin/pmeet/pmeetserver/config/MailConfig.kt
@@ -1,0 +1,43 @@
+package pmeet.pmeetserver.config
+
+import org.springframework.beans.factory.annotation.Value
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+import org.springframework.mail.javamail.JavaMailSender
+import org.springframework.mail.javamail.JavaMailSenderImpl
+
+
+@Configuration
+class MailConfig(
+  @Value("\${spring.mail.host}") val host: String,
+  @Value("\${spring.mail.port}") val port: Int,
+  @Value("\${spring.mail.username}") val username: String,
+  @Value("\${spring.mail.password}") val password: String,
+  @Value("\${spring.mail.default-encoding}") val defaultEncoding: String,
+  @Value("\${spring.mail.properties.mail.smtp.auth}") val smtpAuth: Boolean,
+  @Value("\${spring.mail.properties.mail.smtp.ssl.enable}") val sslEnable: Boolean,
+  @Value("\${spring.mail.properties.mail.smtp.connectiontimeout}") val connectionTimeout: Int,
+  @Value("\${spring.mail.properties.mail.smtp.starttls.enable}") val startTlsEnable: Boolean,
+  @Value("\${spring.mail.properties.mail.smtp.timeout}") val timeout: Int,
+  @Value("\${spring.mail.properties.mail.smtp.writtentimeout}") val writtenTimeout: Int,
+  @Value("\${spring.mail.properties.mail.auth-code-expiration-millis}") val authCodeExpirationMillis: Long
+) {
+
+  @Bean
+  fun javaMailSender(): JavaMailSender = JavaMailSenderImpl().apply {
+    this.host = this@MailConfig.host
+    this.port = this@MailConfig.port
+    this.username = this@MailConfig.username
+    this.password = this@MailConfig.password
+    this.defaultEncoding = this@MailConfig.defaultEncoding
+    javaMailProperties.apply {
+      put("mail.smtp.auth", smtpAuth.toString())
+      put("mail.smtp.ssl.enable", sslEnable.toString())
+      put("mail.smtp.connectiontimeout", connectionTimeout)
+      put("mail.smtp.starttls.enable", startTlsEnable.toString())
+      put("mail.smtp.timeout", timeout)
+      put("mail.smtp.writtentimeout", writtenTimeout)
+      put("mail.auth-code-expiration-millis", authCodeExpirationMillis)
+    }
+  }
+}

--- a/src/main/kotlin/pmeet/pmeetserver/user/controller/AuthController.kt
+++ b/src/main/kotlin/pmeet/pmeetserver/user/controller/AuthController.kt
@@ -11,6 +11,7 @@ import pmeet.pmeetserver.user.dto.request.CheckNickNameRequestDto
 import pmeet.pmeetserver.user.dto.request.SendVerificationCodeRequestDto
 import pmeet.pmeetserver.user.dto.request.SignInRequestDto
 import pmeet.pmeetserver.user.dto.request.SignUpRequestDto
+import pmeet.pmeetserver.user.dto.request.VerifyVerificationCodeRequestDto
 import pmeet.pmeetserver.user.dto.response.UserResponseDto
 import pmeet.pmeetserver.user.service.UserFacadeService
 
@@ -41,6 +42,12 @@ class AuthController(
   @ResponseStatus(HttpStatus.OK)
   suspend fun sendVerificationCode(@RequestBody @Valid requestDto: SendVerificationCodeRequestDto): Boolean {
     return userFacadeService.sendVerificationCode(requestDto)
+  }
+
+  @PostMapping("/verification-code/verify")
+  @ResponseStatus(HttpStatus.OK)
+  suspend fun verifyVerificationCode(@RequestBody @Valid requestDto: VerifyVerificationCodeRequestDto): Boolean {
+    return userFacadeService.verifyVerificationCode(requestDto)
   }
 }
 

--- a/src/main/kotlin/pmeet/pmeetserver/user/dto/request/VerifyVerificationCodeRequestDto.kt
+++ b/src/main/kotlin/pmeet/pmeetserver/user/dto/request/VerifyVerificationCodeRequestDto.kt
@@ -1,0 +1,14 @@
+package pmeet.pmeetserver.user.dto.request
+
+import jakarta.validation.constraints.Email
+import jakarta.validation.constraints.NotBlank
+import jakarta.validation.constraints.Size
+
+data class VerifyVerificationCodeRequestDto(
+  @field:Email(message = "이메일 형식이 아닙니다. 다시 입력해 주세요.")
+  @field:NotBlank(message = "이메일을 입력해 주세요.")
+  val email: String,
+  @field:Size(min = 6, max = 6, message = "인증번호는 6자리입니다.")
+  @field:NotBlank(message = "인증번호를 입력해 주세요.")
+  val verificationCode: String,
+)

--- a/src/main/kotlin/pmeet/pmeetserver/user/service/UserFacadeService.kt
+++ b/src/main/kotlin/pmeet/pmeetserver/user/service/UserFacadeService.kt
@@ -14,6 +14,7 @@ import pmeet.pmeetserver.user.dto.request.CheckNickNameRequestDto
 import pmeet.pmeetserver.user.dto.request.SendVerificationCodeRequestDto
 import pmeet.pmeetserver.user.dto.request.SignInRequestDto
 import pmeet.pmeetserver.user.dto.request.SignUpRequestDto
+import pmeet.pmeetserver.user.dto.request.VerifyVerificationCodeRequestDto
 import pmeet.pmeetserver.user.dto.response.UserResponseDto
 
 @Service
@@ -62,6 +63,11 @@ class UserFacadeService(
   suspend fun sendVerificationCode(requestDto: SendVerificationCodeRequestDto): Boolean {
     emailService.sendEmailWithVerificationCode(requestDto.email)
     return true
+  }
+
+  @Transactional(readOnly = true)
+  suspend fun verifyVerificationCode(requestDto: VerifyVerificationCodeRequestDto): Boolean {
+    return emailService.verifyVerificationCode(requestDto.email, requestDto.verificationCode)
   }
 }
 


### PR DESCRIPTION
## Related issue
resolves #11 

## Description
- 이메일로 redis에 조회하여 인증 코드 매칭
- redis 조회 결과가 null이면 인증 시간 만료 예외
## Changes detail
- yml 파일 분리로 인해 JavaMailSender Bean을 런타임 전에 생성하지 못해 직접 Bean으로 등록
- application-secret.yml 수정
- M1 MacBook 이상에서 발생하는 예외(런타임에 지장X) 제거를 위해 의존성 추가
### Checklist
- [ ] Test case
- [x] End of work
