### PR TITLE
refac: getuser method 재사용을 위한 refactoring

### DIFF
--- a/src/main/kotlin/pmeet/pmeetserver/common/ErrorCode.kt
+++ b/src/main/kotlin/pmeet/pmeetserver/common/ErrorCode.kt
@@ -8,7 +8,8 @@ enum class ErrorCode(private val code: String, private val message: String) {
   USER_NOT_FOUND_BY_EMAIL("USER-40002", "해당하는 이메일의 유저를 찾을 수 없습니다."),
   INVALID_PASSWORD("USER-40003", "비밀번호를 다시 입력해 주세요."),
   VERIFICATION_CODE_NOT_MATCH("USER-40004", "인증번호가 일치하지 않습니다."),
-  VERIFICATION_CODE_EXPIRED("USER-40005", "인증번호가 만료되었습니다.")
+  VERIFICATION_CODE_EXPIRED("USER-40005", "인증번호가 만료되었습니다."),
+  USER_NOT_FOUND_BY_NICKNAME("USER-40006", "해당하는 닉네임의 유저를 찾을 수 없습니다.")
 
   ;
 

--- a/src/main/kotlin/pmeet/pmeetserver/user/service/UserService.kt
+++ b/src/main/kotlin/pmeet/pmeetserver/user/service/UserService.kt
@@ -6,6 +6,7 @@ import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 import pmeet.pmeetserver.common.ErrorCode
 import pmeet.pmeetserver.common.exception.EntityDuplicateException
+import pmeet.pmeetserver.common.exception.EntityNotFoundException
 import pmeet.pmeetserver.user.domain.User
 import pmeet.pmeetserver.user.repository.UserRepository
 
@@ -27,12 +28,14 @@ class UserService(
   }
 
   @Transactional(readOnly = true)
-  suspend fun getUserByNickname(nickname: String): User? {
-    return userRepository.findByNickname(nickname).awaitSingleOrNull();
+  suspend fun getUserByNickname(nickname: String): User {
+    return userRepository.findByNickname(nickname).awaitSingleOrNull()
+      ?: throw EntityNotFoundException(ErrorCode.USER_NOT_FOUND_BY_NICKNAME)
   }
 
   @Transactional(readOnly = true)
-  suspend fun getUserByEmail(email: String): User? {
-    return userRepository.findByNickname(email).awaitSingleOrNull();
+  suspend fun getUserByEmail(email: String): User {
+    return userRepository.findByNickname(email).awaitSingleOrNull()
+      ?: throw EntityNotFoundException(ErrorCode.USER_NOT_FOUND_BY_EMAIL)
   }
 }


### PR DESCRIPTION
## Related issue
resolves #issue_number

## Description
getUser 관련 메서드 재사용성과 메서드의 책임을 고려한 refactoring

## Changes detail
- UserFacadeService에서 EntityNotFoundException을 던지면 매번 유저를 불러올 때 Facade에서 EntityNotFoundException관련 코드를 작성해야 함 -> 이 책임을 UserService에게 이관

### Checklist
- [ ] Test case
- [x] End of work
