### PR TITLE
feat: O-Auth 로그인 기능 구현

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -58,9 +58,10 @@ dependencies {
 
   // SMTP
   implementation("org.springframework.boot:spring-boot-starter-mail")
-
   implementation("io.netty:netty-resolver-dns-native-macos:4.1.106.Final:osx-aarch_64")
 
+  // oauth
+  implementation("com.auth0:java-jwt:3.18.1")
 }
 
 tasks.withType<KotlinCompile> {

--- a/src/main/kotlin/pmeet/pmeetserver/auth/service/oauth/GoogleOauthService.kt
+++ b/src/main/kotlin/pmeet/pmeetserver/auth/service/oauth/GoogleOauthService.kt
@@ -1,0 +1,32 @@
+package pmeet.pmeetserver.auth.service.oauth
+
+import kotlinx.coroutines.reactor.awaitSingle
+import org.springframework.beans.factory.annotation.Value
+import org.springframework.http.MediaType
+import org.springframework.stereotype.Service
+import org.springframework.web.reactive.function.BodyInserters
+import org.springframework.web.reactive.function.client.WebClient
+import org.springframework.web.reactive.function.client.bodyToMono
+
+@Service
+class GoogleOauthService(
+  private val webClient: WebClient,
+  @Value("\${google.oauth.client-id}") private val clientId: String,
+  @Value("\${google.oauth.client-secret}") private val clientSecret: String,
+  @Value("\${google.oauth.redirect-uri}") private val redirectUri: String
+) {
+  suspend fun getIdToken(code: String): String {
+    val responseBody: Map<String, Any> = webClient.post()
+      .uri("https://oauth2.googleapis.com/token")
+      .contentType(MediaType.APPLICATION_FORM_URLENCODED)
+      .body(BodyInserters.fromFormData("code", code)
+        .with("client_id", clientId)
+        .with("client_secret", clientSecret)
+        .with("redirect_uri", redirectUri)
+        .with("grant_type", "authorization_code"))
+      .retrieve()
+      .bodyToMono<Map<String, Any>>()
+      .awaitSingle()
+    return responseBody["id_token"] as String
+  }
+}

--- a/src/main/kotlin/pmeet/pmeetserver/auth/service/oauth/KakaoOauthService.kt
+++ b/src/main/kotlin/pmeet/pmeetserver/auth/service/oauth/KakaoOauthService.kt
@@ -1,0 +1,55 @@
+package pmeet.pmeetserver.auth.service.oauth
+
+import kotlinx.coroutines.reactor.awaitSingle
+import org.springframework.beans.factory.annotation.Value
+import org.springframework.http.MediaType
+import org.springframework.stereotype.Service
+import org.springframework.web.reactive.function.BodyInserters
+import org.springframework.web.reactive.function.client.WebClient
+import org.springframework.web.reactive.function.client.bodyToMono
+
+@Service
+class KakaoOauthService(
+
+  private val webClient: WebClient,
+  @Value("\${kakao.oauth.client-id}") private val clientId: String,
+  @Value("\${kakao.oauth.redirect-uri}") private val redirectUri: String
+) {
+  suspend fun getAccessToken(code: String): String {
+    val responseBody: Map<String, Any> = webClient.post()
+      .uri("https://kauth.kakao.com/oauth/token")
+      .contentType(MediaType.APPLICATION_FORM_URLENCODED)
+      .body(BodyInserters.fromFormData("code", code)
+        .with("client_id", clientId)
+        .with("redirect_uri", redirectUri)
+        .with("grant_type", "authorization_code"))
+      .retrieve()
+      .bodyToMono<Map<String, Any>>()
+      .awaitSingle()
+    return responseBody["access_token"].toString()
+  }
+
+  suspend fun getProfile(accessToken: String): UserInfo {
+    val kakaoResponse = webClient.post()
+      .uri("https://kapi.kakao.com/v2/user/me")
+      .contentType(MediaType.APPLICATION_FORM_URLENCODED)
+      .header("Authorization", "Bearer " + accessToken)
+      .retrieve()
+      .bodyToMono(KakaoResponse::class.java)
+      .awaitSingle()
+    return UserInfo(kakaoResponse.kakao_account.profile.nickname, kakaoResponse.kakao_account.email)
+  }
+}
+
+data class KakaoResponse(
+  val kakao_account: KakaoAccount
+)
+
+data class KakaoAccount(
+  val email: String,
+  val profile: KakaoProfile
+)
+
+data class KakaoProfile(
+  val nickname: String
+)

--- a/src/main/kotlin/pmeet/pmeetserver/auth/service/oauth/KakaoOauthService.kt
+++ b/src/main/kotlin/pmeet/pmeetserver/auth/service/oauth/KakaoOauthService.kt
@@ -7,6 +7,7 @@ import org.springframework.stereotype.Service
 import org.springframework.web.reactive.function.BodyInserters
 import org.springframework.web.reactive.function.client.WebClient
 import org.springframework.web.reactive.function.client.bodyToMono
+import pmeet.pmeetserver.user.dto.UserInfo
 
 @Service
 class KakaoOauthService(

--- a/src/main/kotlin/pmeet/pmeetserver/auth/service/oauth/NaverOauthService.kt
+++ b/src/main/kotlin/pmeet/pmeetserver/auth/service/oauth/NaverOauthService.kt
@@ -1,0 +1,54 @@
+package pmeet.pmeetserver.auth.service.oauth
+
+import kotlinx.coroutines.reactor.awaitSingle
+import org.springframework.beans.factory.annotation.Value
+import org.springframework.http.MediaType
+import org.springframework.stereotype.Service
+import org.springframework.web.reactive.function.BodyInserters
+import org.springframework.web.reactive.function.client.WebClient
+import org.springframework.web.reactive.function.client.bodyToMono
+
+@Service
+class NaverOauthService(
+
+  private val webClient: WebClient,
+  @Value("\${naver.oauth.client-id}") private val clientId: String,
+  @Value("\${naver.oauth.client-secret}") private val clientSecret: String
+) {
+  suspend fun getAccessToken(code: String, state: String): String {
+    val responseBody: Map<String, Any> = webClient.post()
+      .uri("https://nid.naver.com/oauth2.0/token/")
+      .contentType(MediaType.APPLICATION_FORM_URLENCODED)
+      .body(BodyInserters.fromFormData("code", code)
+        .with("client_id", clientId)
+        .with("client_secret", clientSecret)
+        .with("state", state)
+        .with("grant_type", "authorization_code"))
+      .retrieve()
+      .bodyToMono<Map<String, Any>>()
+      .awaitSingle()
+    return responseBody["access_token"].toString()
+  }
+
+  suspend fun getProfile(accessToken: String): UserInfo {
+    val NaverResponse = webClient.post()
+      .uri("https://openapi.naver.com/v1/nid/me")
+      .header("Authorization", "Bearer " + accessToken)
+      .retrieve()
+      .bodyToMono(NaverResponse::class.java)
+      .awaitSingle()
+    return UserInfo(NaverResponse.response.name, NaverResponse.response.email)
+  }
+}
+
+data class NaverResponse(
+  val resultcode: String,
+  val message: String,
+  val response: Response
+)
+
+data class Response(
+  val id: String,
+  val email: String,
+  val name: String
+)

--- a/src/main/kotlin/pmeet/pmeetserver/auth/service/oauth/NaverOauthService.kt
+++ b/src/main/kotlin/pmeet/pmeetserver/auth/service/oauth/NaverOauthService.kt
@@ -7,6 +7,7 @@ import org.springframework.stereotype.Service
 import org.springframework.web.reactive.function.BodyInserters
 import org.springframework.web.reactive.function.client.WebClient
 import org.springframework.web.reactive.function.client.bodyToMono
+import pmeet.pmeetserver.user.dto.UserInfo
 
 @Service
 class NaverOauthService(
@@ -44,10 +45,10 @@ class NaverOauthService(
 data class NaverResponse(
   val resultcode: String,
   val message: String,
-  val response: Response
+  val response: NaverAccount
 )
 
-data class Response(
+data class NaverAccount(
   val id: String,
   val email: String,
   val name: String

--- a/src/main/kotlin/pmeet/pmeetserver/auth/service/oauth/OauthFacadeService.kt
+++ b/src/main/kotlin/pmeet/pmeetserver/auth/service/oauth/OauthFacadeService.kt
@@ -5,6 +5,7 @@ import com.auth0.jwt.interfaces.DecodedJWT
 import org.springframework.stereotype.Service
 import pmeet.pmeetserver.common.utils.jwt.JwtUtil
 import pmeet.pmeetserver.user.domain.User
+import pmeet.pmeetserver.user.dto.UserInfo
 import pmeet.pmeetserver.user.dto.response.UserJwtDto
 import pmeet.pmeetserver.user.service.UserService
 
@@ -24,7 +25,15 @@ class OauthFacadeService(
     if (user != null) {
       return jwtUtil.createToken(user.id!!)
     } else {
-      val savedUser = userService.save(User(email = userInfo.email, name = userInfo.name, provider = "google", nickname = "google"))
+      // TODO 동시성 문제 해결 추후 도입
+      val nickNameNumber = generateNicknameNumber()
+      val nickname = "Pmeet#${String.format("%04d", nickNameNumber)}"
+      val savedUser = userService.save(User(
+        email = userInfo.email,
+        name = userInfo.name,
+        provider = "google",
+        nickname = nickname,
+        nicknameNumber = nickNameNumber))
       return jwtUtil.createToken(savedUser.id!!)
     }
   }
@@ -37,7 +46,15 @@ class OauthFacadeService(
     if (user != null) {
       return jwtUtil.createToken(user.id!!)
     } else {
-      val savedUser = userService.save(User(email = userInfo.email, name = userInfo.name, provider = "naver", nickname = "naver"))
+      // TODO 동시성 문제 해결 추후 도입
+      val nickNameNumber = generateNicknameNumber()
+      val nickname = "Pmeet#${String.format("%04d", nickNameNumber)}"
+      val savedUser = userService.save(User(
+        email = userInfo.email,
+        name = userInfo.name,
+        provider = "naver",
+        nickname = nickname,
+        nicknameNumber = nickNameNumber))
       return jwtUtil.createToken(savedUser.id!!)
     }
   }
@@ -50,20 +67,28 @@ class OauthFacadeService(
     if (user != null) {
       return jwtUtil.createToken(user.id!!)
     } else {
-      val savedUser = userService.save(User(email = userInfo.email, name = userInfo.name, provider = "kakao", nickname = "kakao"))
+      // TODO 동시성 문제 해결 추후 도입
+      val nickNameNumber = generateNicknameNumber()
+      val nickname = "Pmeet#${String.format("%04d", nickNameNumber)}"
+      val savedUser = userService.save(User(
+        email = userInfo.email,
+        name = userInfo.name,
+        provider = "kakao",
+        nickname = nickname,
+        nicknameNumber = nickNameNumber))
       return jwtUtil.createToken(savedUser.id!!)
     }
   }
 
-  fun decodeIdToken(idToken: String): UserInfo {
+  private suspend fun decodeIdToken(idToken: String): UserInfo {
     val decodedJWT: DecodedJWT = JWT.decode(idToken)
     val name = decodedJWT.getClaim("name").asString()
     val email = decodedJWT.getClaim("email").asString()
     return UserInfo(name, email)
   }
-}
 
-data class UserInfo(
-  val name: String,
-  val email: String
-)
+  private suspend fun generateNicknameNumber(): Int {
+    val highestNicknameNumber = userService.findUserWithHighestNicknameNumber()?.nicknameNumber ?: 0
+    return highestNicknameNumber + 1
+  }
+}

--- a/src/main/kotlin/pmeet/pmeetserver/auth/service/oauth/OauthFacadeService.kt
+++ b/src/main/kotlin/pmeet/pmeetserver/auth/service/oauth/OauthFacadeService.kt
@@ -1,0 +1,73 @@
+package pmeet.pmeetserver.auth.service.oauth
+
+import com.auth0.jwt.JWT
+import com.auth0.jwt.interfaces.DecodedJWT
+import org.springframework.stereotype.Service
+import pmeet.pmeetserver.user.domain.User
+import pmeet.pmeetserver.user.dto.response.UserResponseDto
+import pmeet.pmeetserver.user.service.UserService
+
+@Service
+class OauthFacadeService(
+  private val googleAuthService: GoogleOauthService,
+  private val naverAuthService: NaverOauthService,
+  private val kakaoAuthService: KakaoOauthService,
+  private val userService: UserService
+) {
+  suspend fun loginGoogleOauth(code: String): UserResponseDto {
+    val idToken = googleAuthService.getIdToken(code)
+    val userInfo = decodeIdToken(idToken)
+
+    val user = userService.findUserByEmail(userInfo.email)
+    if (user != null) {
+      // TODO JWT 반환으로 변경
+      return UserResponseDto.from(user)
+    } else {
+      // TODO nickName 부분 변경, JWT 반환
+      val savedUser = userService.save(User(email = userInfo.email, name = userInfo.name, provider = "google", nickname = "google"))
+      return UserResponseDto.from(savedUser)
+    }
+  }
+
+  suspend fun loginNaverOauth(code: String, state: String): UserResponseDto {
+    val accessToken = naverAuthService.getAccessToken(code, state)
+    val userInfo = naverAuthService.getProfile(accessToken)
+
+    val user = userService.findUserByEmail(userInfo.email)
+    if (user != null) {
+      // TODO JWT 반환으로 변경
+      return UserResponseDto.from(user)
+    } else {
+      // TODO nickName 부분 변경, JWT 반환
+      val savedUser = userService.save(User(email = userInfo.email, name = userInfo.name, provider = "naver", nickname = "naver"))
+      return UserResponseDto.from(savedUser)
+    }
+  }
+
+  suspend fun loginKakaoOauth(code: String): UserResponseDto {
+    val accessToken = kakaoAuthService.getAccessToken(code)
+    val userInfo = kakaoAuthService.getProfile(accessToken)
+
+    val user = userService.findUserByEmail(userInfo.email)
+    if (user != null) {
+      // TODO JWT 반환으로 변경
+      return UserResponseDto.from(user)
+    } else {
+      // TODO nickName 부분 변경, JWT 반환
+      val savedUser = userService.save(User(email = userInfo.email, name = userInfo.name, provider = "kakao", nickname = "kakao"))
+      return UserResponseDto.from(savedUser)
+    }
+  }
+
+  fun decodeIdToken(idToken: String): UserInfo {
+    val decodedJWT: DecodedJWT = JWT.decode(idToken)
+    val name = decodedJWT.getClaim("name").asString()
+    val email = decodedJWT.getClaim("email").asString()
+    return UserInfo(name, email)
+  }
+}
+
+data class UserInfo(
+  val name: String,
+  val email: String
+)

--- a/src/main/kotlin/pmeet/pmeetserver/auth/service/oauth/OauthFacadeService.kt
+++ b/src/main/kotlin/pmeet/pmeetserver/auth/service/oauth/OauthFacadeService.kt
@@ -21,11 +21,9 @@ class OauthFacadeService(
     val idToken = googleAuthService.getIdToken(code)
     val userInfo = decodeIdToken(idToken)
 
-    val user = userService.findUserByEmail(userInfo.email)
-    if (user != null) {
-      return jwtUtil.createToken(user.id!!)
-    } else {
-      // TODO 동시성 문제 해결 추후 도입
+    return userService.findUserByEmail(userInfo.email)?.let { existingUser ->
+      jwtUtil.createToken(existingUser.id!!)
+    } ?: run {
       val nickNameNumber = generateNicknameNumber()
       val nickname = "Pmeet#${String.format("%04d", nickNameNumber)}"
       val savedUser = userService.save(User(
@@ -34,7 +32,7 @@ class OauthFacadeService(
         provider = "google",
         nickname = nickname,
         nicknameNumber = nickNameNumber))
-      return jwtUtil.createToken(savedUser.id!!)
+      jwtUtil.createToken(savedUser.id!!)
     }
   }
 
@@ -42,11 +40,9 @@ class OauthFacadeService(
     val accessToken = naverAuthService.getAccessToken(code, state)
     val userInfo = naverAuthService.getProfile(accessToken)
 
-    val user = userService.findUserByEmail(userInfo.email)
-    if (user != null) {
-      return jwtUtil.createToken(user.id!!)
-    } else {
-      // TODO 동시성 문제 해결 추후 도입
+    return userService.findUserByEmail(userInfo.email)?.let { existingUser ->
+      jwtUtil.createToken(existingUser.id!!)
+    } ?: run {
       val nickNameNumber = generateNicknameNumber()
       val nickname = "Pmeet#${String.format("%04d", nickNameNumber)}"
       val savedUser = userService.save(User(
@@ -55,7 +51,7 @@ class OauthFacadeService(
         provider = "naver",
         nickname = nickname,
         nicknameNumber = nickNameNumber))
-      return jwtUtil.createToken(savedUser.id!!)
+      jwtUtil.createToken(savedUser.id!!)
     }
   }
 
@@ -63,11 +59,9 @@ class OauthFacadeService(
     val accessToken = kakaoAuthService.getAccessToken(code)
     val userInfo = kakaoAuthService.getProfile(accessToken)
 
-    val user = userService.findUserByEmail(userInfo.email)
-    if (user != null) {
-      return jwtUtil.createToken(user.id!!)
-    } else {
-      // TODO 동시성 문제 해결 추후 도입
+    return userService.findUserByEmail(userInfo.email)?.let { existingUser ->
+      jwtUtil.createToken(existingUser.id!!)
+    } ?: run {
       val nickNameNumber = generateNicknameNumber()
       val nickname = "Pmeet#${String.format("%04d", nickNameNumber)}"
       val savedUser = userService.save(User(
@@ -76,7 +70,7 @@ class OauthFacadeService(
         provider = "kakao",
         nickname = nickname,
         nicknameNumber = nickNameNumber))
-      return jwtUtil.createToken(savedUser.id!!)
+      jwtUtil.createToken(savedUser.id!!)
     }
   }
 

--- a/src/main/kotlin/pmeet/pmeetserver/auth/service/oauth/OauthFacadeService.kt
+++ b/src/main/kotlin/pmeet/pmeetserver/auth/service/oauth/OauthFacadeService.kt
@@ -3,8 +3,9 @@ package pmeet.pmeetserver.auth.service.oauth
 import com.auth0.jwt.JWT
 import com.auth0.jwt.interfaces.DecodedJWT
 import org.springframework.stereotype.Service
+import pmeet.pmeetserver.common.utils.jwt.JwtUtil
 import pmeet.pmeetserver.user.domain.User
-import pmeet.pmeetserver.user.dto.response.UserResponseDto
+import pmeet.pmeetserver.user.dto.response.UserJwtDto
 import pmeet.pmeetserver.user.service.UserService
 
 @Service
@@ -12,50 +13,45 @@ class OauthFacadeService(
   private val googleAuthService: GoogleOauthService,
   private val naverAuthService: NaverOauthService,
   private val kakaoAuthService: KakaoOauthService,
-  private val userService: UserService
+  private val userService: UserService,
+  private val jwtUtil: JwtUtil
 ) {
-  suspend fun loginGoogleOauth(code: String): UserResponseDto {
+  suspend fun loginGoogleOauth(code: String): UserJwtDto {
     val idToken = googleAuthService.getIdToken(code)
     val userInfo = decodeIdToken(idToken)
 
     val user = userService.findUserByEmail(userInfo.email)
     if (user != null) {
-      // TODO JWT 반환으로 변경
-      return UserResponseDto.from(user)
+      return jwtUtil.createToken(user.id!!)
     } else {
-      // TODO nickName 부분 변경, JWT 반환
       val savedUser = userService.save(User(email = userInfo.email, name = userInfo.name, provider = "google", nickname = "google"))
-      return UserResponseDto.from(savedUser)
+      return jwtUtil.createToken(savedUser.id!!)
     }
   }
 
-  suspend fun loginNaverOauth(code: String, state: String): UserResponseDto {
+  suspend fun loginNaverOauth(code: String, state: String): UserJwtDto {
     val accessToken = naverAuthService.getAccessToken(code, state)
     val userInfo = naverAuthService.getProfile(accessToken)
 
     val user = userService.findUserByEmail(userInfo.email)
     if (user != null) {
-      // TODO JWT 반환으로 변경
-      return UserResponseDto.from(user)
+      return jwtUtil.createToken(user.id!!)
     } else {
-      // TODO nickName 부분 변경, JWT 반환
       val savedUser = userService.save(User(email = userInfo.email, name = userInfo.name, provider = "naver", nickname = "naver"))
-      return UserResponseDto.from(savedUser)
+      return jwtUtil.createToken(savedUser.id!!)
     }
   }
 
-  suspend fun loginKakaoOauth(code: String): UserResponseDto {
+  suspend fun loginKakaoOauth(code: String): UserJwtDto {
     val accessToken = kakaoAuthService.getAccessToken(code)
     val userInfo = kakaoAuthService.getProfile(accessToken)
 
     val user = userService.findUserByEmail(userInfo.email)
     if (user != null) {
-      // TODO JWT 반환으로 변경
-      return UserResponseDto.from(user)
+      return jwtUtil.createToken(user.id!!)
     } else {
-      // TODO nickName 부분 변경, JWT 반환
       val savedUser = userService.save(User(email = userInfo.email, name = userInfo.name, provider = "kakao", nickname = "kakao"))
-      return UserResponseDto.from(savedUser)
+      return jwtUtil.createToken(savedUser.id!!)
     }
   }
 

--- a/src/main/kotlin/pmeet/pmeetserver/config/MongoConfig.kt
+++ b/src/main/kotlin/pmeet/pmeetserver/config/MongoConfig.kt
@@ -1,17 +1,24 @@
 package pmeet.pmeetserver.config
 
-//@Configuration
-//@EnableReactiveMongoRepositories(basePackages = ["pmeet.pmeetserver"])
-//class MongoConfig {
-//
-//  @Bean
-//  fun transactionManager(reactiveMongoDatabaseFactory: ReactiveMongoDatabaseFactory): ReactiveMongoTransactionManager {
-//    return ReactiveMongoTransactionManager(reactiveMongoDatabaseFactory)
-//  }
-//
-//  @Bean
-//  fun transactionalOperator(reactiveTransactionManager: ReactiveMongoTransactionManager): TransactionalOperator {
-//    return TransactionalOperator.create(reactiveTransactionManager)
-//  }
-//
-//}
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+import org.springframework.data.mongodb.ReactiveMongoDatabaseFactory
+import org.springframework.data.mongodb.ReactiveMongoTransactionManager
+import org.springframework.data.mongodb.repository.config.EnableReactiveMongoRepositories
+import org.springframework.transaction.reactive.TransactionalOperator
+
+@Configuration
+@EnableReactiveMongoRepositories(basePackages = ["pmeet.pmeetserver"])
+class MongoConfig {
+
+  @Bean
+  fun transactionManager(reactiveMongoDatabaseFactory: ReactiveMongoDatabaseFactory): ReactiveMongoTransactionManager {
+    return ReactiveMongoTransactionManager(reactiveMongoDatabaseFactory)
+  }
+
+  @Bean
+  fun transactionalOperator(reactiveTransactionManager: ReactiveMongoTransactionManager): TransactionalOperator {
+    return TransactionalOperator.create(reactiveTransactionManager)
+  }
+
+}

--- a/src/main/kotlin/pmeet/pmeetserver/config/MongoConfig.kt
+++ b/src/main/kotlin/pmeet/pmeetserver/config/MongoConfig.kt
@@ -1,24 +1,17 @@
 package pmeet.pmeetserver.config
 
-import org.springframework.context.annotation.Bean
-import org.springframework.context.annotation.Configuration
-import org.springframework.data.mongodb.ReactiveMongoDatabaseFactory
-import org.springframework.data.mongodb.ReactiveMongoTransactionManager
-import org.springframework.data.mongodb.repository.config.EnableReactiveMongoRepositories
-import org.springframework.transaction.reactive.TransactionalOperator
-
-@Configuration
-@EnableReactiveMongoRepositories(basePackages = ["pmeet.pmeetserver"])
-class MongoConfig {
-
-  @Bean
-  fun transactionManager(reactiveMongoDatabaseFactory: ReactiveMongoDatabaseFactory): ReactiveMongoTransactionManager {
-    return ReactiveMongoTransactionManager(reactiveMongoDatabaseFactory)
-  }
-
-  @Bean
-  fun transactionalOperator(reactiveTransactionManager: ReactiveMongoTransactionManager): TransactionalOperator {
-    return TransactionalOperator.create(reactiveTransactionManager)
-  }
-
-}
+//@Configuration
+//@EnableReactiveMongoRepositories(basePackages = ["pmeet.pmeetserver"])
+//class MongoConfig {
+//
+//  @Bean
+//  fun transactionManager(reactiveMongoDatabaseFactory: ReactiveMongoDatabaseFactory): ReactiveMongoTransactionManager {
+//    return ReactiveMongoTransactionManager(reactiveMongoDatabaseFactory)
+//  }
+//
+//  @Bean
+//  fun transactionalOperator(reactiveTransactionManager: ReactiveMongoTransactionManager): TransactionalOperator {
+//    return TransactionalOperator.create(reactiveTransactionManager)
+//  }
+//
+//}

--- a/src/main/kotlin/pmeet/pmeetserver/config/WebClientConfig.kt
+++ b/src/main/kotlin/pmeet/pmeetserver/config/WebClientConfig.kt
@@ -1,0 +1,20 @@
+package pmeet.pmeetserver.config
+
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+import org.springframework.web.reactive.function.client.WebClient
+import org.springframework.web.reactive.function.client.WebClient.Builder
+
+@Configuration
+class WebClientConfig {
+
+  @Bean
+  fun webClientBuilder(): WebClient.Builder {
+    return WebClient.builder()
+  }
+
+  @Bean
+  fun webClient(webClientBuilder: Builder): WebClient {
+    return webClientBuilder.build()
+  }
+}

--- a/src/main/kotlin/pmeet/pmeetserver/user/controller/AuthController.kt
+++ b/src/main/kotlin/pmeet/pmeetserver/user/controller/AuthController.kt
@@ -42,19 +42,19 @@ class AuthController(
 
   @GetMapping("/sign-in/google")
   @ResponseStatus(HttpStatus.OK)
-  suspend fun signInGoogle(@RequestParam code: String): UserResponseDto {
+  suspend fun signInGoogle(@RequestParam code: String): UserJwtDto {
     return oauthFacadeService.loginGoogleOauth(code)
   }
 
   @GetMapping("/sign-in/naver")
   @ResponseStatus(HttpStatus.OK)
-  suspend fun signInNaver(@RequestParam code: String, @RequestParam state: String): UserResponseDto {
+  suspend fun signInNaver(@RequestParam code: String, @RequestParam state: String): UserJwtDto {
     return oauthFacadeService.loginNaverOauth(code, state)
   }
 
   @GetMapping("/sign-in/kakao")
   @ResponseStatus(HttpStatus.OK)
-  suspend fun signInKakao(@RequestParam code: String): UserResponseDto {
+  suspend fun signInKakao(@RequestParam code: String): UserJwtDto {
     return oauthFacadeService.loginKakaoOauth(code)
   }
 

--- a/src/main/kotlin/pmeet/pmeetserver/user/controller/AuthController.kt
+++ b/src/main/kotlin/pmeet/pmeetserver/user/controller/AuthController.kt
@@ -2,12 +2,15 @@ package pmeet.pmeetserver.user.controller
 
 import jakarta.validation.Valid
 import org.springframework.http.HttpStatus
+import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.PutMapping
 import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RequestParam
 import org.springframework.web.bind.annotation.ResponseStatus
 import org.springframework.web.bind.annotation.RestController
+import pmeet.pmeetserver.auth.service.oauth.OauthFacadeService
 import pmeet.pmeetserver.user.dto.request.CheckMailRequestDto
 import pmeet.pmeetserver.user.dto.request.CheckNickNameRequestDto
 import pmeet.pmeetserver.user.dto.request.SendVerificationCodeRequestDto
@@ -22,7 +25,8 @@ import pmeet.pmeetserver.user.service.UserFacadeService
 @RestController
 @RequestMapping("/api/v1/auth")
 class AuthController(
-  private val userFacadeService: UserFacadeService
+  private val userFacadeService: UserFacadeService,
+  private val oauthFacadeService: OauthFacadeService
 ) {
   @PostMapping("/sign-up")
   @ResponseStatus(HttpStatus.CREATED)
@@ -34,6 +38,24 @@ class AuthController(
   @ResponseStatus(HttpStatus.OK)
   suspend fun signIn(@RequestBody @Valid requestDto: SignInRequestDto): UserJwtDto {
     return userFacadeService.signIn(requestDto)
+  }
+
+  @GetMapping("/sign-in/google")
+  @ResponseStatus(HttpStatus.OK)
+  suspend fun signInGoogle(@RequestParam code: String): UserResponseDto {
+    return oauthFacadeService.loginGoogleOauth(code)
+  }
+
+  @GetMapping("/sign-in/naver")
+  @ResponseStatus(HttpStatus.OK)
+  suspend fun signInNaver(@RequestParam code: String, @RequestParam state: String): UserResponseDto {
+    return oauthFacadeService.loginNaverOauth(code, state)
+  }
+
+  @GetMapping("/sign-in/kakao")
+  @ResponseStatus(HttpStatus.OK)
+  suspend fun signInKakao(@RequestParam code: String): UserResponseDto {
+    return oauthFacadeService.loginKakaoOauth(code)
   }
 
   @PostMapping("/nickname/duplicate")
@@ -65,4 +87,3 @@ class AuthController(
     return userFacadeService.setPassword(requestDto)
   }
 }
-

--- a/src/main/kotlin/pmeet/pmeetserver/user/domain/User.kt
+++ b/src/main/kotlin/pmeet/pmeetserver/user/domain/User.kt
@@ -12,6 +12,7 @@ class User(
   var name: String,
   var password: String? = null,
   var nickname: String,
+  var nicknameNumber: Int? = null,
   var isEmployed: Boolean = false,
   var profileImageUrl: String? = null
 ) {

--- a/src/main/kotlin/pmeet/pmeetserver/user/dto/UserInfo.kt
+++ b/src/main/kotlin/pmeet/pmeetserver/user/dto/UserInfo.kt
@@ -1,0 +1,6 @@
+package pmeet.pmeetserver.user.dto
+
+data class UserInfo(
+  val name: String,
+  val email: String
+)

--- a/src/main/kotlin/pmeet/pmeetserver/user/repository/UserRepository.kt
+++ b/src/main/kotlin/pmeet/pmeetserver/user/repository/UserRepository.kt
@@ -7,5 +7,5 @@ import reactor.core.publisher.Mono
 interface UserRepository : ReactiveMongoRepository<User, String> {
   fun findByEmail(email: String): Mono<User>
   fun findByNickname(nickname: String): Mono<User>
-
+  fun findTopByOrderByNicknameNumberDesc(): Mono<User>
 }

--- a/src/main/kotlin/pmeet/pmeetserver/user/service/UserService.kt
+++ b/src/main/kotlin/pmeet/pmeetserver/user/service/UserService.kt
@@ -60,3 +60,4 @@ class UserService(
     return userRepository.save(user).awaitSingle()
   }
 }
+

--- a/src/main/kotlin/pmeet/pmeetserver/user/service/UserService.kt
+++ b/src/main/kotlin/pmeet/pmeetserver/user/service/UserService.kt
@@ -59,5 +59,10 @@ class UserService(
   suspend fun update(user: User): User {
     return userRepository.save(user).awaitSingle()
   }
+
+  @Transactional(readOnly = true)
+  suspend fun findUserWithHighestNicknameNumber(): User? {
+    return userRepository.findTopByOrderByNicknameNumberDesc().awaitSingleOrNull()
+  }
 }
 

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -5,3 +5,19 @@ spring:
 logging:
   level:
     root: debug
+
+google:
+  oauth:
+    client-id: ${GOOGLE_OAUTH_CLIENT_ID}
+    client-secret: ${GOOGLE_OAUTH_CLIENT_SECRET}
+    redirect-uri: ${GOOGLE_OAUTH_REDIRECT_URI}
+
+naver:
+  oauth:
+    client-id: ${NAVER_OAUTH_CLIENT_ID}
+    client-secret: ${NAVER_OAUTH_CLIENT_SECRET}
+
+kakao:
+  oauth:
+    client-id: ${KAKAO_OAUTH_CLIENT_ID}
+    redirect-uri: ${KAKAO_OAUTH_REDIRECT_URI}


### PR DESCRIPTION
## Related issue
resolves #20 #21 #22

## Description
- 구글,네이버,카카오 Oauth 추가
  - DB에 User가 존재하면 JWT 토큰 발급
  - 없으면 DB에 User save 후 JWT 토큰 발급
- 닉네임 부여 로직
  - "Pmeet#{숫자4자리}"
  - 랜덤 부여 할 경우 유저가 많아지면 중복 처리로 인한 리소스 낭비
  - User엔티티에 nicknameNumber를 추가하여 새로운 User 저장 시 가장 큰 nicknameNumber를 가져와서 + 1을함
  - "Pmeet#0001" -> "Pmeet#0002" -> "Pmeet#0003" ->->-> "Pmeet#9999"

## Changes detail
- 
-
### Checklist
- [ ] Test case
- [ ] End of work
