### PR TITLE
chore: 클라우드 환경에 Mongo, Redis 구축

### DIFF
--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,12 +1,7 @@
 spring:
   config:
     import: classpath:application-secret.yml
-  data:
-    mongodb:
-      uri: mongodb://pmeet_user:pmeet_pwd@localhost:27017/pmeet?authSource=admin
-    redis:
-      host: localhost
-      port: 6379
+
 logging:
   level:
     root: debug


### PR DESCRIPTION
## Related issue
resolves #issue_number

## Description
- AWS EC2에 컨테이너 형식으로 띄움
- Mongo Replica Set에서 27017 포트를 사용하는 컨테이너가 Primary가 되도록 우선순위 변경하였음

## Changes detail
- 
-
### Checklist
- [ ] Test case
- [ ] End of work
