### PR TITLE
feat: 이메일 인증 완료 여부를 체크하는 기능

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -38,7 +38,7 @@ dependencies {
   // test
   testImplementation("org.springframework.boot:spring-boot-starter-test")
   testImplementation("io.projectreactor:reactor-test")
-  testImplementation("org.springframework.boot:spring-security-test")
+  testImplementation("org.springframework.security:spring-security-test")
 
   // validation
   implementation("org.springframework.boot:spring-boot-starter-validation")
@@ -46,9 +46,9 @@ dependencies {
   // security
   implementation("org.springframework.boot:spring-boot-starter-security")
 
-  implementation ("io.jsonwebtoken:jjwt-api:0.12.3")
-  runtimeOnly ("io.jsonwebtoken:jjwt-impl:0.12.3")
-  runtimeOnly ("io.jsonwebtoken:jjwt-jackson:0.12.3")
+  implementation("io.jsonwebtoken:jjwt-api:0.12.3")
+  runtimeOnly("io.jsonwebtoken:jjwt-impl:0.12.3")
+  runtimeOnly("io.jsonwebtoken:jjwt-jackson:0.12.3")
 
   // log
   implementation("io.github.oshai:kotlin-logging-jvm:5.1.1")

--- a/src/main/kotlin/pmeet/pmeetserver/common/ErrorCode.kt
+++ b/src/main/kotlin/pmeet/pmeetserver/common/ErrorCode.kt
@@ -3,6 +3,9 @@ package pmeet.pmeetserver.common
 enum class ErrorCode(private val code: String, private val message: String) {
   INVALID_TOKEN("AUTH-40100", "유효하지 않은 토큰입니다."),
   EXPIRED_TOKEN("AUTH-40101", "토큰의 유효기간이 만료되었습니다."),
+  VERIFICATION_CODE_NOT_MATCH("AUTH-40102", "인증번호가 일치하지 않습니다."),
+  VERIFICATION_CODE_EXPIRED("AUTH-40103", "인증번호가 만료되었습니다."),
+  NOT_VERIFIED_EMAIL("AUTH-40104", "인증을 다시 시도해 주세요."),
 
   INVALID_INPUT_PARAMETER("COMMON-40000", "유효하지 않은 입력값입니다."),
 
@@ -10,8 +13,6 @@ enum class ErrorCode(private val code: String, private val message: String) {
   USER_DUPLICATE_BY_NICKNAME("USER-40001", "중복된 닉네임입니다."),
   USER_NOT_FOUND_BY_EMAIL("USER-40002", "해당하는 이메일의 유저를 찾을 수 없습니다."),
   INVALID_PASSWORD("USER-40003", "비밀번호를 다시 입력해 주세요."),
-  VERIFICATION_CODE_NOT_MATCH("USER-40004", "인증번호가 일치하지 않습니다."),
-  VERIFICATION_CODE_EXPIRED("USER-40005", "인증번호가 만료되었습니다."),
   USER_NOT_FOUND_BY_NICKNAME("USER-40006", "해당하는 닉네임의 유저를 찾을 수 없습니다."),
   USER_NOT_FOUND_BY_ID("USER-40007", "해당하는 ID의 유저를 찾을 수 없습니다.")
 

--- a/src/main/kotlin/pmeet/pmeetserver/user/service/UserFacadeService.kt
+++ b/src/main/kotlin/pmeet/pmeetserver/user/service/UserFacadeService.kt
@@ -74,9 +74,11 @@ class UserFacadeService(
 
   @Transactional
   suspend fun setPassword(requestDto: SetPasswordRequestDto): Boolean {
-    val user = userService.getUserByEmail(requestDto.email)
-    user.changePassword(passwordEncoder.encode(requestDto.password))
-    userService.update(user)
+    userService.getUserByEmail(requestDto.email).apply {
+      emailService.validateVerifiedEmail(email)
+      changePassword(passwordEncoder.encode(requestDto.password))
+      userService.update(this)
+    }
     return true
   }
 


### PR DESCRIPTION
## Related issue
resolves #35 

## Description
- 인증코드 매칭 시 redis에 저장
- TTL은 5분
## Changes detail
 - 코틀린의 스코프를 활용해 리팩터링
 - security test 의존성 수정
 ### Checklist
- [ ] Test case
- [x] End of work
