### PR TITLE
feat: aws S3 presigned-URL

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -10,6 +10,7 @@ plugins {
 
 val kotestVersion = "5.8.1"
 val mockVersion = "1.13.10"
+val awsVersion = "2.25.23"
 group = "Pmeet"
 version = "0.0.1-SNAPSHOT"
 
@@ -63,12 +64,16 @@ dependencies {
   // redis
   implementation("org.springframework.boot:spring-boot-starter-data-redis-reactive")
 
-  // SMTP
+  // smtp
   implementation("org.springframework.boot:spring-boot-starter-mail")
   implementation("io.netty:netty-resolver-dns-native-macos:4.1.106.Final:osx-aarch_64")
 
   // oauth
   implementation("com.auth0:java-jwt:3.18.1")
+
+  // aws
+  implementation("software.amazon.awssdk:s3:$awsVersion")
+
 }
 
 tasks.withType<KotlinCompile> {

--- a/src/main/kotlin/pmeet/pmeetserver/auth/service/EmailService.kt
+++ b/src/main/kotlin/pmeet/pmeetserver/auth/service/EmailService.kt
@@ -21,10 +21,10 @@ class EmailService(
 ) {
 
   companion object {
-    private val VERIFICATION_CODE_TIME_TO_LIVE by lazy { 5L }
-    private val VERIFICATION_CONFIRMED_TIME_TO_LIVE by lazy { 5L }
-    private val SUBJECT_MESSAGE by lazy { "pmeet 회원가입 인증 번호" }
-    private val EMAIL_BODY_TEMPLATE by lazy {
+    private const val VERIFICATION_CODE_TIME_TO_LIVE = 5L
+    private const val VERIFICATION_CONFIRMED_TIME_TO_LIVE = 5L
+    private const val SUBJECT_MESSAGE = "pmeet 회원가입 인증 번호"
+    private val EMAIL_BODY_TEMPLATE: String =
       """
             <div style="font-family: Arial, '맑은 고딕', sans-serif; color: #333;">
                 <h2>회원가입 인증 코드</h2>
@@ -34,7 +34,7 @@ class EmailService(
                 <p>본인이 요청하지 않았다면, 이 이메일을 무시해 주세요.</p>
             </div>
         """.trimIndent()
-    }
+
   }
 
   @Transactional

--- a/src/main/kotlin/pmeet/pmeetserver/common/generator/VerificationCodeGenerator.kt
+++ b/src/main/kotlin/pmeet/pmeetserver/common/generator/VerificationCodeGenerator.kt
@@ -3,8 +3,8 @@ package pmeet.pmeetserver.common.generator
 class VerificationCodeGenerator {
 
   companion object {
-    private val VERIFICATION_CODE_LENGTH by lazy { 6 }
-    private val VERIFICATION_CODE_CHARACTERS by lazy { ('0'..'9') + ('A'..'Z') + ('a'..'z') }
+    private const val VERIFICATION_CODE_LENGTH = 6
+    private val VERIFICATION_CODE_CHARACTERS = ('0'..'9') + ('A'..'Z') + ('a'..'z')
 
     fun generateVerificationCode(): String {
       return List(VERIFICATION_CODE_LENGTH) { VERIFICATION_CODE_CHARACTERS.random() }.joinToString("")

--- a/src/main/kotlin/pmeet/pmeetserver/config/AwsS3Config.kt
+++ b/src/main/kotlin/pmeet/pmeetserver/config/AwsS3Config.kt
@@ -1,0 +1,25 @@
+package pmeet.pmeetserver.config
+
+import org.springframework.beans.factory.annotation.Value
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+import software.amazon.awssdk.auth.credentials.AwsBasicCredentials
+import software.amazon.awssdk.auth.credentials.AwsCredentials
+import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider
+
+@Configuration
+class AwsS3Config(
+  @Value("\${amazon.aws.access-key}") private val accessKey: String,
+  @Value("\${amazon.aws.secret-key}") private val secretKey: String
+) {
+
+  @Bean
+  fun awsCredentials(): AwsCredentials {
+    return AwsBasicCredentials.create(accessKey, secretKey)
+  }
+
+  @Bean
+  fun credentialsProvider(): AwsCredentialsProvider {
+    return AwsCredentialsProvider { awsCredentials() }
+  }
+}

--- a/src/main/kotlin/pmeet/pmeetserver/file/controller/FileController.kt
+++ b/src/main/kotlin/pmeet/pmeetserver/file/controller/FileController.kt
@@ -1,0 +1,33 @@
+package pmeet.pmeetserver.file.controller
+
+import org.springframework.http.HttpStatus
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RequestParam
+import org.springframework.web.bind.annotation.ResponseStatus
+import org.springframework.web.bind.annotation.RestController
+import pmeet.pmeetserver.file.dto.response.FileUrlResponseDto
+import pmeet.pmeetserver.file.service.FileService
+
+@RestController
+@RequestMapping("/api/v1/file")
+class FileController(
+  private val fileService: FileService
+) {
+
+  @GetMapping("/presigned-url/upload")
+  @ResponseStatus(HttpStatus.OK)
+  suspend fun getPreSignedUrlToUpload(
+    @RequestParam("filename") fileName: String,
+    @RequestParam("filedomain") fileDomain: String
+  ): FileUrlResponseDto {
+    return fileService.generatePreSignedUrlToUpload(fileName, fileDomain)
+  }
+
+
+  @GetMapping("/presigned-url/download")
+  @ResponseStatus(HttpStatus.OK)
+  suspend fun getPreSignedUrlToDownload(@RequestParam("objectname") objectName: String): FileUrlResponseDto {
+    return fileService.generatePreSignedUrlToDownload(objectName)
+  }
+}

--- a/src/main/kotlin/pmeet/pmeetserver/file/dto/response/FileUrlResponseDto.kt
+++ b/src/main/kotlin/pmeet/pmeetserver/file/dto/response/FileUrlResponseDto.kt
@@ -1,0 +1,12 @@
+package pmeet.pmeetserver.file.dto.response
+
+data class FileUrlResponseDto(
+  val presignedUrl: String
+) {
+  companion object {
+    fun from(presignedUrl: String): FileUrlResponseDto {
+      return FileUrlResponseDto(presignedUrl)
+    }
+  }
+
+}

--- a/src/main/kotlin/pmeet/pmeetserver/file/service/FileService.kt
+++ b/src/main/kotlin/pmeet/pmeetserver/file/service/FileService.kt
@@ -1,0 +1,75 @@
+package pmeet.pmeetserver.file.service
+
+import org.springframework.beans.factory.annotation.Value
+import org.springframework.stereotype.Service
+import pmeet.pmeetserver.file.dto.response.FileUrlResponseDto
+import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider
+import software.amazon.awssdk.regions.Region
+import software.amazon.awssdk.services.s3.model.GetObjectRequest
+import software.amazon.awssdk.services.s3.model.PutObjectRequest
+import software.amazon.awssdk.services.s3.presigner.S3Presigner
+import software.amazon.awssdk.services.s3.presigner.model.GetObjectPresignRequest
+import software.amazon.awssdk.services.s3.presigner.model.PutObjectPresignRequest
+import java.time.Duration
+import java.time.LocalDate
+import java.util.UUID
+
+
+@Service
+class FileService(
+  @Value("\${amazon.aws.bucket}") private val bucketName: String,
+  @Value("\${amazon.aws.region}") private val region: String,
+  private val awsCredentialsProvider: AwsCredentialsProvider,
+) {
+
+  companion object {
+    private const val DURATION_OF_PRESIGNED_URL_MINUTE = 30L
+  }
+
+  suspend fun generatePreSignedUrlToUpload(fileName: String, fileDomain: String): FileUrlResponseDto {
+    val encodedFileName = "${createUUID()}_${fileName}"
+    val objectName = "${LocalDate.now()}/$fileDomain/$encodedFileName"
+    S3Presigner.builder()
+      .credentialsProvider(awsCredentialsProvider)
+      .region(Region.of(region))
+      .build().use { presigner ->
+        PutObjectPresignRequest.builder()
+          .signatureDuration(Duration.ofMinutes(DURATION_OF_PRESIGNED_URL_MINUTE))
+          .putObjectRequest(
+            PutObjectRequest.builder()
+              .bucket(bucketName)
+              .key(objectName)
+              .build()
+          )
+          .build().run {
+            return FileUrlResponseDto.from(presigner.presignPutObject(this).url().toExternalForm())
+          }
+      }
+  }
+
+  suspend fun generatePreSignedUrlToDownload(objectName: String): FileUrlResponseDto {
+    S3Presigner.builder()
+      .credentialsProvider(awsCredentialsProvider)
+      .region(Region.of(region))
+      .build().use { presigner ->
+        GetObjectPresignRequest.builder()
+          .signatureDuration(Duration.ofMinutes(DURATION_OF_PRESIGNED_URL_MINUTE))
+          .getObjectRequest(
+            GetObjectRequest.builder()
+              .bucket(bucketName)
+              .key(objectName)
+              .build()
+          )
+          .build().run {
+            return FileUrlResponseDto.from(presigner.presignGetObject(this).url().toExternalForm())
+          }
+      }
+  }
+
+  /**
+   * 파일 고유 ID를 생성
+   * @return 36자리의 UUID
+   */
+  private suspend fun createUUID() = UUID.randomUUID().toString()
+
+}


### PR DESCRIPTION
## Related issue
resolves #15 

## Description
 - 서버리스 presingedUrl 방식의 업로드 다운로드
 - 파일 저장 Path는 YYYY-MM-DD/domain/filename
 - 다운로드는 Path 전체를 포함한 ObjectName을 파라미터로 받음
 - presingedUrl의 유효 기간은 30분
 
## Changes detail

### Checklist
- [ ] Test case
- [x] End of work
