### PR TITLE
test: 유저 컨트롤러 단위 테스트

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -11,6 +11,9 @@ plugins {
 val kotestVersion = "5.8.1"
 val mockVersion = "1.13.10"
 val awsVersion = "2.25.23"
+val springMockkVersion = "4.0.2"
+val kotestSpringExtensionVersion = "1.1.3"
+val testContainerVersion = "1.19.7"
 group = "Pmeet"
 version = "0.0.1-SNAPSHOT"
 
@@ -46,14 +49,16 @@ dependencies {
 
   testImplementation("io.kotest:kotest-runner-junit5:$kotestVersion")
   testImplementation("io.kotest:kotest-assertions-core:$kotestVersion")
-  testImplementation("io.kotest.extensions:kotest-extensions-spring:1.1.3")
 
   testImplementation("org.jetbrains.kotlinx:kotlinx-coroutines-test")
   testImplementation("io.mockk:mockk:$mockVersion")
+  testImplementation("com.ninja-squad:springmockk:$springMockkVersion")
+  testImplementation("io.kotest.extensions:kotest-extensions-spring:$kotestSpringExtensionVersion")
 
-  testImplementation("org.testcontainers:testcontainers:1.19.7")
-  testImplementation("org.testcontainers:junit-jupiter:1.19.7")
-  testImplementation("org.testcontainers:mongodb:1.19.7")
+
+  testImplementation("org.testcontainers:testcontainers:$testContainerVersion")
+  testImplementation("org.testcontainers:junit-jupiter:$testContainerVersion")
+  testImplementation("org.testcontainers:mongodb:$testContainerVersion")
 
   // validation
   implementation("org.springframework.boot:spring-boot-starter-validation")

--- a/src/test/kotlin/pmeet/pmeetserver/ProjectConfig.kt
+++ b/src/test/kotlin/pmeet/pmeetserver/ProjectConfig.kt
@@ -1,0 +1,9 @@
+package pmeet.pmeetserver
+
+import io.kotest.core.config.AbstractProjectConfig
+import io.kotest.core.extensions.Extension
+import io.kotest.extensions.spring.SpringExtension
+
+object ProjectConfig : AbstractProjectConfig() {
+  override fun extensions(): List<Extension> = listOf(SpringExtension)
+}

--- a/src/test/kotlin/pmeet/pmeetserver/auth/service/EmailServiceUnitTest.kt
+++ b/src/test/kotlin/pmeet/pmeetserver/auth/service/EmailServiceUnitTest.kt
@@ -22,7 +22,7 @@ import reactor.core.publisher.Mono
 import java.time.Duration
 
 @ExperimentalCoroutinesApi
-class EmailServiceUnitTest : DescribeSpec({
+internal class EmailServiceUnitTest : DescribeSpec({
 
   lateinit var javaMailSender: JavaMailSender
   lateinit var reactiveRedisTemplate: ReactiveRedisTemplate<String, String>

--- a/src/test/kotlin/pmeet/pmeetserver/user/controller/UserControllerUnitTest.kt
+++ b/src/test/kotlin/pmeet/pmeetserver/user/controller/UserControllerUnitTest.kt
@@ -1,0 +1,67 @@
+package pmeet.pmeetserver.user.controller
+
+import com.ninjasquad.springmockk.MockkBean
+import io.kotest.core.spec.style.DescribeSpec
+import io.kotest.matchers.shouldBe
+import io.mockk.coEvery
+import io.mockk.coVerify
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.autoconfigure.web.reactive.WebFluxTest
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken
+import org.springframework.security.test.web.reactive.server.SecurityMockServerConfigurers.mockAuthentication
+import org.springframework.test.web.reactive.server.WebTestClient
+import org.springframework.test.web.reactive.server.expectBody
+import pmeet.pmeetserver.user.dto.response.UserSummaryResponseDto
+import pmeet.pmeetserver.user.service.UserFacadeService
+
+
+@WebFluxTest(UserController::class)
+internal class UserControllerUnitTest : DescribeSpec() {
+
+  @MockkBean
+  lateinit var userFacadeService: UserFacadeService
+
+  @Autowired
+  lateinit var webTestClient: WebTestClient
+
+  init {
+    describe("getMySummaryInfo") {
+      val userId = "1234"
+      val expectedUserSummaryResponseDto = UserSummaryResponseDto(
+        userId, "test@test.com", "test", true, "test/test.jpg"
+      )
+      coEvery { userFacadeService.getMySummaryInfo(any<String>()) } answers { expectedUserSummaryResponseDto }
+      context("유저가 인증되면") {
+        val mockAuthentication = UsernamePasswordAuthenticationToken(userId, null, null)
+        val performRequest =
+          webTestClient.mutateWith(mockAuthentication(mockAuthentication)).get().uri("/api/v1/users/me/summary")
+            .exchange()
+
+        it("서비스를 통해 데이터를 조회한다") {
+          coVerify(exactly = 1) { userFacadeService.getMySummaryInfo(userId) }
+        }
+
+        it("요청은 성공한다") {
+          performRequest.expectStatus().isOk
+        }
+
+        it("유저 정보를 반환한다") {
+          performRequest.expectBody<UserSummaryResponseDto>().consumeWith { response ->
+            response.responseBody?.id shouldBe userId
+            response.responseBody?.email shouldBe expectedUserSummaryResponseDto.email
+            response.responseBody?.nickname shouldBe expectedUserSummaryResponseDto.nickname
+            response.responseBody?.isEmployed shouldBe expectedUserSummaryResponseDto.isEmployed
+            response.responseBody?.profileImageUrl shouldBe expectedUserSummaryResponseDto.profileImageUrl
+          }
+        }
+      }
+      context("유저가 인증되지 않으면") {
+        val performRequest = webTestClient.get().uri("/api/v1/users/me/summary").exchange()
+        it("요청은 실패한다") {
+          performRequest.expectStatus().isUnauthorized
+        }
+      }
+    }
+  }
+}
+


### PR DESCRIPTION


## Related issue

## Description
 - mockkbean 사용을 위해 springmockk의존성 추가
 - test에서 webtestClient 자동 주입이 되지 않아 SpringExtension 의존성과 object 추가
 - withMockUser를 사용할 수 없어 UsernamePasswordAuthenticationToken를 mockAuthentication에 추가
## Changes detail
### Checklist
- [x] Test case
- [x] End of work
