### PR TITLE
[WIP] 직무 등록 및 직무 검색

### DIFF
--- a/src/main/kotlin/pmeet/pmeetserver/common/ErrorCode.kt
+++ b/src/main/kotlin/pmeet/pmeetserver/common/ErrorCode.kt
@@ -9,13 +9,17 @@ enum class ErrorCode(private val code: String, private val message: String) {
 
   INVALID_INPUT_PARAMETER("COMMON-40000", "유효하지 않은 입력값입니다."),
 
+  // User
   USER_DUPLICATE_BY_EMAIL("USER-40000", "중복된 이메일입니다."),
   USER_DUPLICATE_BY_NICKNAME("USER-40001", "중복된 닉네임입니다."),
   USER_NOT_FOUND_BY_EMAIL("USER-40002", "해당하는 이메일의 유저를 찾을 수 없습니다."),
   INVALID_PASSWORD("USER-40003", "비밀번호를 다시 입력해 주세요."),
   USER_NOT_FOUND_BY_NICKNAME("USER-40006", "해당하는 닉네임의 유저를 찾을 수 없습니다."),
   USER_NOT_FOUND_BY_ID("USER-40007", "해당하는 ID의 유저를 찾을 수 없습니다."),
-  IS_DELETED_USER("USER-40008", "탈퇴한 유저입니다.")
+  IS_DELETED_USER("USER-40008", "탈퇴한 유저입니다."),
+
+  // Job
+  JOB_DUPLICATE_BY_NAME("JOB-40000", "중복된 직무명입니다.")
   ;
 
 

--- a/src/main/kotlin/pmeet/pmeetserver/common/utils/page/SliceResponse.kt
+++ b/src/main/kotlin/pmeet/pmeetserver/common/utils/page/SliceResponse.kt
@@ -1,0 +1,20 @@
+package pmeet.pmeetserver.common.utils.page
+
+import org.springframework.data.domain.Pageable
+import org.springframework.data.domain.Slice
+import org.springframework.data.domain.SliceImpl
+
+class SliceResponse {
+  companion object {
+    fun <T> of(
+      content: MutableList<T>,
+      pageable: Pageable
+    ): Slice<T> {
+      val hasNext = content.size > pageable.pageSize
+      if (hasNext) {
+        content.removeLast()
+      }
+      return SliceImpl(content, pageable, hasNext)
+    }
+  }
+}

--- a/src/main/kotlin/pmeet/pmeetserver/user/controller/JobController.kt
+++ b/src/main/kotlin/pmeet/pmeetserver/user/controller/JobController.kt
@@ -1,16 +1,18 @@
 package pmeet.pmeetserver.user.controller
 
+import org.springframework.data.domain.PageRequest
+import org.springframework.data.domain.Slice
 import org.springframework.http.HttpStatus
-import org.springframework.security.core.annotation.AuthenticationPrincipal
+import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RequestParam
 import org.springframework.web.bind.annotation.ResponseStatus
 import org.springframework.web.bind.annotation.RestController
 import pmeet.pmeetserver.user.dto.job.request.CreateJobRequestDto
 import pmeet.pmeetserver.user.dto.job.response.JobResponseDto
 import pmeet.pmeetserver.user.service.job.JobFacadeService
-import reactor.core.publisher.Mono
 
 @RestController
 @RequestMapping("/api/v1/jobs")
@@ -21,9 +23,18 @@ class JobController(
   @PostMapping
   @ResponseStatus(HttpStatus.CREATED)
   suspend fun createJob(
-    @AuthenticationPrincipal userId: Mono<String>,
     @RequestBody requestDto: CreateJobRequestDto
   ): JobResponseDto {
     return jobFacadeService.createJob(requestDto)
+  }
+
+  @GetMapping("/search")
+  @ResponseStatus(HttpStatus.OK)
+  suspend fun searchJobByName(
+    @RequestParam(required = false) name: String?,
+    @RequestParam(defaultValue = "0") page: Int,
+    @RequestParam(defaultValue = "10") size: Int
+  ): Slice<JobResponseDto> {
+    return jobFacadeService.searchJobByName(name, PageRequest.of(page, size))
   }
 }

--- a/src/main/kotlin/pmeet/pmeetserver/user/controller/JobController.kt
+++ b/src/main/kotlin/pmeet/pmeetserver/user/controller/JobController.kt
@@ -1,0 +1,29 @@
+package pmeet.pmeetserver.user.controller
+
+import org.springframework.http.HttpStatus
+import org.springframework.security.core.annotation.AuthenticationPrincipal
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RequestBody
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.ResponseStatus
+import org.springframework.web.bind.annotation.RestController
+import pmeet.pmeetserver.user.dto.job.request.CreateJobRequestDto
+import pmeet.pmeetserver.user.dto.job.response.JobResponseDto
+import pmeet.pmeetserver.user.service.job.JobFacadeService
+import reactor.core.publisher.Mono
+
+@RestController
+@RequestMapping("/api/v1/jobs")
+class JobController(
+  private val jobFacadeService: JobFacadeService
+) {
+
+  @PostMapping
+  @ResponseStatus(HttpStatus.CREATED)
+  suspend fun createJob(
+    @AuthenticationPrincipal userId: Mono<String>,
+    @RequestBody requestDto: CreateJobRequestDto
+  ): JobResponseDto {
+    return jobFacadeService.createJob(requestDto)
+  }
+}

--- a/src/main/kotlin/pmeet/pmeetserver/user/domain/job/Job.kt
+++ b/src/main/kotlin/pmeet/pmeetserver/user/domain/job/Job.kt
@@ -1,0 +1,12 @@
+package pmeet.pmeetserver.user.domain.job
+
+import org.springframework.data.annotation.Id
+import org.springframework.data.mongodb.core.mapping.Document
+
+@Document
+class Job(
+  @Id
+  val id: String? = null,
+  val name: String
+) {
+}

--- a/src/main/kotlin/pmeet/pmeetserver/user/dto/job/request/CreateJobRequestDto.kt
+++ b/src/main/kotlin/pmeet/pmeetserver/user/dto/job/request/CreateJobRequestDto.kt
@@ -1,0 +1,8 @@
+package pmeet.pmeetserver.user.dto.job.request
+
+import jakarta.validation.constraints.NotBlank
+
+data class CreateJobRequestDto(
+  @field:NotBlank(message = "직무를 입력해 주세요.")
+  val name: String
+)

--- a/src/main/kotlin/pmeet/pmeetserver/user/dto/job/response/JobResponseDto.kt
+++ b/src/main/kotlin/pmeet/pmeetserver/user/dto/job/response/JobResponseDto.kt
@@ -1,0 +1,17 @@
+package pmeet.pmeetserver.user.dto.job.response
+
+import pmeet.pmeetserver.user.domain.job.Job
+
+data class JobResponseDto(
+  val id: String,
+  val name: String
+) {
+  companion object {
+    fun from(job: Job): JobResponseDto {
+      return JobResponseDto(
+        id = job.id!!,
+        name = job.name
+      )
+    }
+  }
+}

--- a/src/main/kotlin/pmeet/pmeetserver/user/repository/job/CustomJobRepository.kt
+++ b/src/main/kotlin/pmeet/pmeetserver/user/repository/job/CustomJobRepository.kt
@@ -1,0 +1,10 @@
+package pmeet.pmeetserver.user.repository.job
+
+import org.springframework.data.domain.Pageable
+import pmeet.pmeetserver.user.domain.job.Job
+import reactor.core.publisher.Flux
+
+interface CustomJobRepository {
+
+  fun findByNameSearchSlice(name: String?, pageable: Pageable): Flux<Job>
+}

--- a/src/main/kotlin/pmeet/pmeetserver/user/repository/job/CustomJobRepositoryImpl.kt
+++ b/src/main/kotlin/pmeet/pmeetserver/user/repository/job/CustomJobRepositoryImpl.kt
@@ -1,0 +1,43 @@
+package pmeet.pmeetserver.user.repository.job
+
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.data.domain.Pageable
+import org.springframework.data.domain.Sort
+import org.springframework.data.mongodb.core.ReactiveMongoTemplate
+import org.springframework.data.mongodb.core.aggregation.Aggregation
+import org.springframework.data.mongodb.core.query.Criteria
+import pmeet.pmeetserver.user.domain.job.Job
+import reactor.core.publisher.Flux
+
+class CustomJobRepositoryImpl(
+  @Autowired private val mongoTemplate: ReactiveMongoTemplate
+) : CustomJobRepository {
+
+  override fun findByNameSearchSlice(name: String?, pageable: Pageable): Flux<Job> {
+    val criteria = if (name != null) {
+      Criteria.where("name").regex(".*${name}.*")
+    } else {
+      Criteria()
+    }
+
+    val match = Aggregation.match(criteria)
+
+    val addFields = Aggregation.project("name")
+      .andExpression("strLenCP(name)").`as`("nameLength")
+
+    val sort = Aggregation.sort(
+      Sort.by(
+        Sort.Order(Sort.Direction.ASC, "nameLength")
+      ).and(
+        Sort.by(Sort.Direction.ASC, "name")
+      )
+    )
+
+    val limit = Aggregation.limit(pageable.pageSize.toLong() + 1)
+    val skip = Aggregation.skip((pageable.pageNumber * pageable.pageSize).toLong())
+
+    val aggregation = Aggregation.newAggregation(match, addFields, sort, skip, limit)
+
+    return mongoTemplate.aggregate(aggregation, "job", Job::class.java)
+  }
+}

--- a/src/main/kotlin/pmeet/pmeetserver/user/repository/job/JobRepository.kt
+++ b/src/main/kotlin/pmeet/pmeetserver/user/repository/job/JobRepository.kt
@@ -4,7 +4,7 @@ import org.springframework.data.mongodb.repository.ReactiveMongoRepository
 import pmeet.pmeetserver.user.domain.job.Job
 import reactor.core.publisher.Mono
 
-interface JobRepository : ReactiveMongoRepository<Job, String> {
+interface JobRepository : ReactiveMongoRepository<Job, String>, CustomJobRepository {
 
   fun findByName(name: String): Mono<Job>
 }

--- a/src/main/kotlin/pmeet/pmeetserver/user/repository/job/JobRepository.kt
+++ b/src/main/kotlin/pmeet/pmeetserver/user/repository/job/JobRepository.kt
@@ -1,0 +1,10 @@
+package pmeet.pmeetserver.user.repository.job
+
+import org.springframework.data.mongodb.repository.ReactiveMongoRepository
+import pmeet.pmeetserver.user.domain.job.Job
+import reactor.core.publisher.Mono
+
+interface JobRepository : ReactiveMongoRepository<Job, String> {
+
+  fun findByName(name: String): Mono<Job>
+}

--- a/src/main/kotlin/pmeet/pmeetserver/user/service/job/JobFacadeService.kt
+++ b/src/main/kotlin/pmeet/pmeetserver/user/service/job/JobFacadeService.kt
@@ -1,6 +1,9 @@
 package pmeet.pmeetserver.user.service.job
 
+import org.springframework.data.domain.Pageable
+import org.springframework.data.domain.Slice
 import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
 import pmeet.pmeetserver.user.domain.job.Job
 import pmeet.pmeetserver.user.dto.job.request.CreateJobRequestDto
 import pmeet.pmeetserver.user.dto.job.response.JobResponseDto
@@ -9,10 +12,17 @@ import pmeet.pmeetserver.user.dto.job.response.JobResponseDto
 class JobFacadeService(
   private val jobService: JobService
 ) {
+
+  @Transactional
   suspend fun createJob(requestDto: CreateJobRequestDto): JobResponseDto {
     val job = Job(
       name = requestDto.name
     )
     return JobResponseDto.from(jobService.save(job))
+  }
+
+  @Transactional(readOnly = true)
+  suspend fun searchJobByName(name: String?, pageable: Pageable): Slice<JobResponseDto> {
+    return jobService.searchByJobName(name, pageable).map { JobResponseDto.from(it) }
   }
 }

--- a/src/main/kotlin/pmeet/pmeetserver/user/service/job/JobFacadeService.kt
+++ b/src/main/kotlin/pmeet/pmeetserver/user/service/job/JobFacadeService.kt
@@ -1,0 +1,18 @@
+package pmeet.pmeetserver.user.service.job
+
+import org.springframework.stereotype.Service
+import pmeet.pmeetserver.user.domain.job.Job
+import pmeet.pmeetserver.user.dto.job.request.CreateJobRequestDto
+import pmeet.pmeetserver.user.dto.job.response.JobResponseDto
+
+@Service
+class JobFacadeService(
+  private val jobService: JobService
+) {
+  suspend fun createJob(requestDto: CreateJobRequestDto): JobResponseDto {
+    val job = Job(
+      name = requestDto.name
+    )
+    return JobResponseDto.from(jobService.save(job))
+  }
+}

--- a/src/main/kotlin/pmeet/pmeetserver/user/service/job/JobService.kt
+++ b/src/main/kotlin/pmeet/pmeetserver/user/service/job/JobService.kt
@@ -2,10 +2,13 @@ package pmeet.pmeetserver.user.service.job
 
 import kotlinx.coroutines.reactor.awaitSingle
 import kotlinx.coroutines.reactor.awaitSingleOrNull
+import org.springframework.data.domain.Pageable
+import org.springframework.data.domain.Slice
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 import pmeet.pmeetserver.common.ErrorCode
 import pmeet.pmeetserver.common.exception.EntityDuplicateException
+import pmeet.pmeetserver.common.utils.page.SliceResponse
 import pmeet.pmeetserver.user.domain.job.Job
 import pmeet.pmeetserver.user.repository.job.JobRepository
 
@@ -20,4 +23,13 @@ class JobService(
       ?.let { throw EntityDuplicateException(ErrorCode.JOB_DUPLICATE_BY_NAME) }
     return jobRepository.save(job).awaitSingle()
   }
+
+  @Transactional(readOnly = true)
+  suspend fun searchByJobName(name: String?, pageable: Pageable): Slice<Job> {
+    return SliceResponse.of(
+      jobRepository.findByNameSearchSlice(name, pageable).collectList().awaitSingle(),
+      pageable
+    )
+  }
 }
+

--- a/src/main/kotlin/pmeet/pmeetserver/user/service/job/JobService.kt
+++ b/src/main/kotlin/pmeet/pmeetserver/user/service/job/JobService.kt
@@ -1,0 +1,23 @@
+package pmeet.pmeetserver.user.service.job
+
+import kotlinx.coroutines.reactor.awaitSingle
+import kotlinx.coroutines.reactor.awaitSingleOrNull
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+import pmeet.pmeetserver.common.ErrorCode
+import pmeet.pmeetserver.common.exception.EntityDuplicateException
+import pmeet.pmeetserver.user.domain.job.Job
+import pmeet.pmeetserver.user.repository.job.JobRepository
+
+@Service
+class JobService(
+  private val jobRepository: JobRepository
+) {
+
+  @Transactional
+  suspend fun save(job: Job): Job {
+    jobRepository.findByName(job.name).awaitSingleOrNull()
+      ?.let { throw EntityDuplicateException(ErrorCode.JOB_DUPLICATE_BY_NAME) }
+    return jobRepository.save(job).awaitSingle()
+  }
+}

--- a/src/test/kotlin/pmeet/pmeetserver/config/MongoTestConfig.kt
+++ b/src/test/kotlin/pmeet/pmeetserver/config/MongoTestConfig.kt
@@ -4,6 +4,7 @@ import com.mongodb.reactivestreams.client.MongoClients
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
+import org.springframework.context.annotation.Primary
 import org.springframework.core.env.Environment
 import org.springframework.data.mongodb.core.ReactiveMongoTemplate
 
@@ -15,6 +16,7 @@ class MongoTestConfig {
   private lateinit var environment: Environment
 
   @Bean("testMongoTemplate")
+  @Primary
   fun mongoTemplateConfig(): ReactiveMongoTemplate {
     val mongoUri = environment.getRequiredProperty("spring.data.mongodb.uri", String::class.java)
     val mongoClient = MongoClients.create(mongoUri)

--- a/src/test/kotlin/pmeet/pmeetserver/user/job/JobIntegrationTest.kt
+++ b/src/test/kotlin/pmeet/pmeetserver/user/job/JobIntegrationTest.kt
@@ -1,0 +1,94 @@
+package pmeet.pmeetserver.user.job
+
+import io.kotest.core.spec.Spec
+import io.kotest.core.spec.style.DescribeSpec
+import io.kotest.matchers.shouldBe
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.withContext
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.autoconfigure.web.reactive.AutoConfigureWebTestClient
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.http.MediaType
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken
+import org.springframework.security.test.web.reactive.server.SecurityMockServerConfigurers.mockAuthentication
+import org.springframework.test.web.reactive.server.WebTestClient
+import org.springframework.test.web.reactive.server.expectBody
+import org.testcontainers.containers.MongoDBContainer
+import org.testcontainers.junit.jupiter.Container
+import pmeet.pmeetserver.user.domain.job.Job
+import pmeet.pmeetserver.user.dto.job.request.CreateJobRequestDto
+import pmeet.pmeetserver.user.dto.job.response.JobResponseDto
+import pmeet.pmeetserver.user.repository.job.JobRepository
+
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+@AutoConfigureWebTestClient
+@ExperimentalCoroutinesApi
+internal class JobIntegrationTest : DescribeSpec() {
+
+  @Autowired
+  lateinit var webTestClient: WebTestClient
+
+  @Autowired
+  lateinit var jobRepository: JobRepository
+
+  val job = Job(
+    name = "testName",
+  )
+
+  override suspend fun beforeSpec(spec: Spec) {
+    withContext(Dispatchers.IO) {
+      jobRepository.save(job).block()
+    }
+  }
+
+  override suspend fun afterSpec(spec: Spec) {
+    withContext(Dispatchers.IO) {
+      jobRepository.deleteAll().block()
+    }
+  }
+
+  init {
+    describe("POST /api/v1/jobs") {
+      context("인증된 유저의 직무 생성 요청이 들어오면") {
+        val userId = "1234"
+        val mockAuthentication = UsernamePasswordAuthenticationToken(userId, null, null)
+        val requestDto = CreateJobRequestDto("TestJob")
+
+        val performRequest = webTestClient
+          .mutateWith(mockAuthentication(mockAuthentication))
+          .post()
+          .uri("/api/v1/jobs")
+          .accept(MediaType.APPLICATION_JSON)
+          .bodyValue(requestDto)
+          .exchange()
+
+        it("요청은 성공한다") {
+          performRequest.expectStatus().isCreated
+        }
+
+        it("생성된 직무 정보를 반환한다") {
+          performRequest.expectBody<JobResponseDto>().consumeWith { response ->
+            response.responseBody?.name shouldBe requestDto.name
+          }
+        }
+      }
+    }
+  }
+
+  companion object {
+    @Container
+    val mongoDBContainer = MongoDBContainer("mongo:latest").apply {
+      withExposedPorts(27017)
+      start()
+    }
+
+    init {
+      System.setProperty(
+        "spring.data.mongodb.uri",
+        "mongodb://localhost:${mongoDBContainer.getMappedPort(27017)}/test"
+      )
+    }
+  }
+
+}

--- a/src/test/kotlin/pmeet/pmeetserver/user/job/JobIntegrationTest.kt
+++ b/src/test/kotlin/pmeet/pmeetserver/user/job/JobIntegrationTest.kt
@@ -6,12 +6,14 @@ import io.kotest.matchers.shouldBe
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.withContext
+import org.junit.jupiter.api.extension.ExtendWith
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.autoconfigure.web.reactive.AutoConfigureWebTestClient
 import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.http.MediaType
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken
 import org.springframework.security.test.web.reactive.server.SecurityMockServerConfigurers.mockAuthentication
+import org.springframework.test.context.junit.jupiter.SpringExtension
 import org.springframework.test.web.reactive.server.WebTestClient
 import org.springframework.test.web.reactive.server.expectBody
 import org.testcontainers.containers.MongoDBContainer
@@ -21,6 +23,7 @@ import pmeet.pmeetserver.user.dto.job.request.CreateJobRequestDto
 import pmeet.pmeetserver.user.dto.job.response.JobResponseDto
 import pmeet.pmeetserver.user.repository.job.JobRepository
 
+@ExtendWith(SpringExtension::class)
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 @AutoConfigureWebTestClient
 @ExperimentalCoroutinesApi
@@ -32,11 +35,12 @@ internal class JobIntegrationTest : DescribeSpec() {
   @Autowired
   lateinit var jobRepository: JobRepository
 
-  val job = Job(
-    name = "testName",
-  )
+  lateinit var job: Job
 
   override suspend fun beforeSpec(spec: Spec) {
+    job = Job(
+      name = "testName",
+    )
     withContext(Dispatchers.IO) {
       jobRepository.save(job).block()
     }
@@ -54,7 +58,6 @@ internal class JobIntegrationTest : DescribeSpec() {
         val userId = "1234"
         val mockAuthentication = UsernamePasswordAuthenticationToken(userId, null, null)
         val requestDto = CreateJobRequestDto("TestJob")
-
         val performRequest = webTestClient
           .mutateWith(mockAuthentication(mockAuthentication))
           .post()
@@ -72,6 +75,48 @@ internal class JobIntegrationTest : DescribeSpec() {
             response.responseBody?.name shouldBe requestDto.name
           }
         }
+      }
+    }
+
+    describe("GET /api/v1/search") {
+      val name = "testName"
+      withContext(Dispatchers.IO) {
+        for (i in 1..10) {
+          jobRepository.save(Job(name = name + i)).block()
+        }
+      }
+      context("인증된 유저가 직무 이름과 페이지 정보가 주어지면") {
+        val userId = "1234"
+        val mockAuthentication = UsernamePasswordAuthenticationToken(userId, null, null)
+
+        val performRequest = webTestClient
+          .mutateWith(mockAuthentication(mockAuthentication))
+          .get()
+          .uri {
+            it.path("/api/v1/jobs/search")
+              .queryParam("name", name)
+              .queryParam("page", 0)
+              .queryParam("size", 10)
+              .build()
+          }
+          .accept(MediaType.APPLICATION_JSON)
+          .exchange()
+
+        it("요청은 성공한다") {
+          performRequest.expectStatus().isOk
+        }
+
+//        it("이름을 포함하는 직무들을 Slice로 반환한다") {
+//          performRequest.expectBody<Slice<JobResponseDto>>().consumeWith {
+//            it.responseBody?.content?.size shouldBe 10
+//            it.responseBody?.isFirst shouldBe true
+//            it.responseBody?.isLast shouldBe false
+//            it.responseBody?.content?.forEachIndexed { index, jobResponseDto ->
+//              jobResponseDto.name shouldBe name + index
+//            }
+//            it.responseBody?.hasNext() shouldBe true
+//          }
+//        }
       }
     }
   }

--- a/src/test/kotlin/pmeet/pmeetserver/user/job/controller/JobControllerUnitTest.kt
+++ b/src/test/kotlin/pmeet/pmeetserver/user/job/controller/JobControllerUnitTest.kt
@@ -1,0 +1,76 @@
+package pmeet.pmeetserver.user.job.controller
+
+import com.ninjasquad.springmockk.MockkBean
+import io.kotest.core.spec.style.DescribeSpec
+import io.kotest.matchers.shouldBe
+import io.mockk.coEvery
+import io.mockk.coVerify
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.autoconfigure.web.reactive.WebFluxTest
+import org.springframework.context.annotation.Import
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken
+import org.springframework.security.test.web.reactive.server.SecurityMockServerConfigurers.mockAuthentication
+import org.springframework.test.web.reactive.server.WebTestClient
+import org.springframework.test.web.reactive.server.expectBody
+import pmeet.pmeetserver.config.TestSecurityConfig
+import pmeet.pmeetserver.user.controller.JobController
+import pmeet.pmeetserver.user.dto.job.request.CreateJobRequestDto
+import pmeet.pmeetserver.user.dto.job.response.JobResponseDto
+import pmeet.pmeetserver.user.service.job.JobFacadeService
+
+@WebFluxTest(JobController::class)
+@Import(TestSecurityConfig::class)
+internal class JobControllerUnitTest : DescribeSpec() {
+
+  @Autowired
+  private lateinit var webTestClient: WebTestClient
+
+  @MockkBean
+  lateinit var jobFacadeService: JobFacadeService
+
+  init {
+    describe("POST api/v1/jobs") {
+      context("인증된 유저의 직무 생성 요청이 들어오면") {
+        val userId = "1234"
+        val requestDto = CreateJobRequestDto("TestJob")
+        val responseDto = JobResponseDto("1234", "TestJob")
+        coEvery { jobFacadeService.createJob(requestDto) } answers { responseDto }
+        val mockAuthentication = UsernamePasswordAuthenticationToken(userId, null, null)
+        val performRequest =
+          webTestClient
+            .mutateWith(mockAuthentication(mockAuthentication))
+            .post()
+            .uri("/api/v1/jobs")
+            .bodyValue(requestDto)
+            .exchange()
+
+        it("서비스를 통해 데이터를 생성한다") {
+          coVerify(exactly = 1) { jobFacadeService.createJob(requestDto) }
+        }
+
+        it("요청은 성공한다") {
+          performRequest.expectStatus().isCreated
+        }
+
+        it("생성된 직무 정보를 반환한다") {
+          performRequest.expectBody<JobResponseDto>().consumeWith { response ->
+            response.responseBody?.id shouldBe responseDto.id
+            response.responseBody?.name shouldBe responseDto.name
+          }
+        }
+      }
+      context("인증되지 않은 유저의 직무 생성 요청이 들어오면") {
+        val requestDto = CreateJobRequestDto("TestJob")
+        val performRequest =
+          webTestClient
+            .post()
+            .uri("/api/v1/jobs")
+            .bodyValue(requestDto)
+            .exchange()
+        it("요청은 실패한다") {
+          performRequest.expectStatus().isUnauthorized
+        }
+      }
+    }
+  }
+}

--- a/src/test/kotlin/pmeet/pmeetserver/user/job/repository/JobRepositoryUnitTest.kt
+++ b/src/test/kotlin/pmeet/pmeetserver/user/job/repository/JobRepositoryUnitTest.kt
@@ -1,5 +1,6 @@
 package pmeet.pmeetserver.user.job.repository
 
+import io.kotest.core.spec.IsolationMode
 import io.kotest.core.spec.style.DescribeSpec
 import io.kotest.matchers.shouldBe
 import kotlinx.coroutines.Dispatchers
@@ -10,6 +11,7 @@ import kotlinx.coroutines.test.runTest
 import kotlinx.coroutines.test.setMain
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.beans.factory.annotation.Qualifier
+import org.springframework.data.domain.PageRequest
 import org.springframework.data.mongodb.core.ReactiveMongoTemplate
 import org.springframework.data.mongodb.repository.support.ReactiveMongoRepositoryFactory
 import org.springframework.test.context.ContextConfiguration
@@ -17,6 +19,7 @@ import org.testcontainers.containers.MongoDBContainer
 import org.testcontainers.junit.jupiter.Container
 import pmeet.pmeetserver.config.MongoTestConfig
 import pmeet.pmeetserver.user.domain.job.Job
+import pmeet.pmeetserver.user.repository.job.CustomJobRepositoryImpl
 import pmeet.pmeetserver.user.repository.job.JobRepository
 
 @ExperimentalCoroutinesApi
@@ -25,10 +28,13 @@ internal class JobRepositoryUnitTest(
   @Autowired @Qualifier("testMongoTemplate") private val template: ReactiveMongoTemplate
 ) : DescribeSpec({
 
+  isolationMode = IsolationMode.InstancePerLeaf
+
   val testDispatcher = StandardTestDispatcher()
 
   val factory = ReactiveMongoRepositoryFactory(template)
-  val jobRepository = factory.getRepository(JobRepository::class.java)
+  val customJobRepository = CustomJobRepositoryImpl(template)
+  val jobRepository = factory.getRepository(JobRepository::class.java, customJobRepository)
 
   lateinit var job: Job
 
@@ -54,6 +60,43 @@ internal class JobRepositoryUnitTest(
           val result = jobRepository.findByName(job.name).block()
 
           result?.name shouldBe job.name
+        }
+      }
+    }
+  }
+
+  describe("findByNameSearchSlice") {
+    context("직무 이름과 페이징 정보가 주어지면") {
+      val name = "testName"
+      val pageNumber = 0
+      val pageSize = 10
+      for (i in 1..pageSize) {
+        jobRepository.save(Job(name = name + i)).block()
+      }
+      it("이름을 포함하는 직무들을 이름 오름차순, 이름 길이 오름차순으로 반환한다") {
+        runTest {
+          val result =
+            jobRepository.findByNameSearchSlice(name, PageRequest.of(pageNumber, pageSize)).collectList().block()
+
+          result?.size shouldBe pageSize + 1
+          result?.first()?.name shouldBe name
+          result?.last()?.name shouldBe name + pageSize
+        }
+      }
+    }
+
+    context("직무 이름이 주어지지 않으면") {
+      val name = "testName"
+      for (i in 1..10) {
+        jobRepository.save(Job(name = name + (11 - i))).block()
+      }
+      it("모든 직무들을 이름 오름차순, 이름 길이 오름차순으로 반환한다") {
+        runTest {
+          val result = jobRepository.findByNameSearchSlice(null, PageRequest.of(0, 10)).collectList().block()
+
+          result?.size shouldBe 11
+          result?.first()?.name shouldBe name
+          result?.last()?.name shouldBe name + 10
         }
       }
     }

--- a/src/test/kotlin/pmeet/pmeetserver/user/job/repository/JobRepositoryUnitTest.kt
+++ b/src/test/kotlin/pmeet/pmeetserver/user/job/repository/JobRepositoryUnitTest.kt
@@ -1,0 +1,78 @@
+package pmeet.pmeetserver.user.job.repository
+
+import io.kotest.core.spec.style.DescribeSpec
+import io.kotest.matchers.shouldBe
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.setMain
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.beans.factory.annotation.Qualifier
+import org.springframework.data.mongodb.core.ReactiveMongoTemplate
+import org.springframework.data.mongodb.repository.support.ReactiveMongoRepositoryFactory
+import org.springframework.test.context.ContextConfiguration
+import org.testcontainers.containers.MongoDBContainer
+import org.testcontainers.junit.jupiter.Container
+import pmeet.pmeetserver.config.MongoTestConfig
+import pmeet.pmeetserver.user.domain.job.Job
+import pmeet.pmeetserver.user.repository.job.JobRepository
+
+@ExperimentalCoroutinesApi
+@ContextConfiguration(classes = [MongoTestConfig::class])
+internal class JobRepositoryUnitTest(
+  @Autowired @Qualifier("testMongoTemplate") private val template: ReactiveMongoTemplate
+) : DescribeSpec({
+
+  val testDispatcher = StandardTestDispatcher()
+
+  val factory = ReactiveMongoRepositoryFactory(template)
+  val jobRepository = factory.getRepository(JobRepository::class.java)
+
+  lateinit var job: Job
+
+  beforeSpec {
+    job = Job(
+      name = "testName",
+    )
+    jobRepository.save(job).block()
+
+    Dispatchers.setMain(testDispatcher)
+  }
+
+  afterSpec {
+    Dispatchers.resetMain()
+    jobRepository.deleteAll().block()
+  }
+
+  describe("findByName") {
+    context("직무 이름이 주어지면") {
+      it("해당하는 이름의 직무를 반환한다") {
+        runTest {
+
+          val result = jobRepository.findByName(job.name).block()
+
+          result?.name shouldBe job.name
+        }
+      }
+    }
+  }
+
+}) {
+  companion object {
+    @Container
+    val mongoDBContainer = MongoDBContainer("mongo:latest").apply {
+      withExposedPorts(27017)
+      start()
+    }
+
+    init {
+      System.setProperty(
+        "spring.data.mongodb.uri",
+        "mongodb://localhost:${mongoDBContainer.getMappedPort(27017)}/test"
+      )
+    }
+  }
+}
+

--- a/src/test/kotlin/pmeet/pmeetserver/user/job/service/JobFacadeServiceUnitTest.kt
+++ b/src/test/kotlin/pmeet/pmeetserver/user/job/service/JobFacadeServiceUnitTest.kt
@@ -1,0 +1,59 @@
+package pmeet.pmeetserver.user.job.service
+
+import io.kotest.core.spec.style.DescribeSpec
+import io.kotest.matchers.shouldBe
+import io.mockk.coEvery
+import io.mockk.mockk
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.setMain
+import org.springframework.test.util.ReflectionTestUtils
+import pmeet.pmeetserver.user.domain.job.Job
+import pmeet.pmeetserver.user.dto.job.request.CreateJobRequestDto
+import pmeet.pmeetserver.user.service.job.JobFacadeService
+import pmeet.pmeetserver.user.service.job.JobService
+
+@ExperimentalCoroutinesApi
+internal class JobFacadeServiceUnitTest : DescribeSpec({
+
+  val testDispatcher = StandardTestDispatcher()
+
+  val jobService = mockk<JobService>(relaxed = true)
+  lateinit var jobFacadeService: JobFacadeService
+
+  lateinit var job: Job
+
+  beforeSpec {
+    Dispatchers.setMain(testDispatcher)
+    jobFacadeService = JobFacadeService(jobService)
+
+    job = Job(
+      name = "Software Engineer",
+    )
+    ReflectionTestUtils.setField(job, "id", "testId")
+  }
+
+  afterSpec {
+    Dispatchers.resetMain()
+  }
+
+  describe("cratedJob") {
+    context("createJobRequestDto가 주어지면") {
+      val requestDto = CreateJobRequestDto(
+        name = "test"
+      )
+      it("JobResponseDto를 반환한다") {
+        runTest {
+          coEvery { jobService.save(any()) } answers { job }
+          val result = jobFacadeService.createJob(requestDto)
+
+          result.name shouldBe job.name
+        }
+      }
+    }
+  }
+
+})

--- a/src/test/kotlin/pmeet/pmeetserver/user/job/service/JobFacadeServiceUnitTest.kt
+++ b/src/test/kotlin/pmeet/pmeetserver/user/job/service/JobFacadeServiceUnitTest.kt
@@ -10,6 +10,8 @@ import kotlinx.coroutines.test.StandardTestDispatcher
 import kotlinx.coroutines.test.resetMain
 import kotlinx.coroutines.test.runTest
 import kotlinx.coroutines.test.setMain
+import org.springframework.data.domain.PageRequest
+import org.springframework.data.domain.SliceImpl
 import org.springframework.test.util.ReflectionTestUtils
 import pmeet.pmeetserver.user.domain.job.Job
 import pmeet.pmeetserver.user.dto.job.request.CreateJobRequestDto
@@ -22,6 +24,7 @@ internal class JobFacadeServiceUnitTest : DescribeSpec({
   val testDispatcher = StandardTestDispatcher()
 
   val jobService = mockk<JobService>(relaxed = true)
+
   lateinit var jobFacadeService: JobFacadeService
 
   lateinit var job: Job
@@ -31,7 +34,7 @@ internal class JobFacadeServiceUnitTest : DescribeSpec({
     jobFacadeService = JobFacadeService(jobService)
 
     job = Job(
-      name = "Software Engineer",
+      name = "testName",
     )
     ReflectionTestUtils.setField(job, "id", "testId")
   }
@@ -43,7 +46,7 @@ internal class JobFacadeServiceUnitTest : DescribeSpec({
   describe("cratedJob") {
     context("createJobRequestDto가 주어지면") {
       val requestDto = CreateJobRequestDto(
-        name = "test"
+        name = "testName"
       )
       it("JobResponseDto를 반환한다") {
         runTest {
@@ -51,6 +54,39 @@ internal class JobFacadeServiceUnitTest : DescribeSpec({
           val result = jobFacadeService.createJob(requestDto)
 
           result.name shouldBe job.name
+        }
+      }
+    }
+  }
+
+  describe("searchJobByName") {
+    context("직무 이름과 페이징 정보가 주어지면") {
+      val name = "Test"
+      val pageNumber = 0
+      val pageSize = 10
+      val jobs = mutableListOf<Job>()
+      for (i in 1..pageSize * 2) {
+        jobs.add(Job(name = name + i))
+        ReflectionTestUtils.setField(jobs[i - 1], "id", "testId$i")
+      }
+      it("이름을 포함하는 직무들을 Slice로 반환한다") {
+        runTest {
+          coEvery { jobService.searchByJobName(name, any()) } answers {
+            SliceImpl(
+              jobs.subList(0, pageSize),
+              PageRequest.of(pageNumber, pageSize),
+              true
+            )
+          }
+          val result = jobFacadeService.searchJobByName(name, PageRequest.of(pageNumber, pageSize))
+
+          result.size shouldBe pageSize
+          result.isFirst shouldBe true
+          result.isLast shouldBe false
+          result.hasNext() shouldBe true
+          result.forEachIndexed { index, jobResponseDto ->
+            jobResponseDto.name shouldBe name + (index + 1)
+          }
         }
       }
     }

--- a/src/test/kotlin/pmeet/pmeetserver/user/job/service/JobServiceUnitTest.kt
+++ b/src/test/kotlin/pmeet/pmeetserver/user/job/service/JobServiceUnitTest.kt
@@ -1,6 +1,7 @@
 package pmeet.pmeetserver.user.job.service
 
 import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.core.spec.IsolationMode
 import io.kotest.core.spec.style.DescribeSpec
 import io.kotest.matchers.shouldBe
 import io.mockk.every
@@ -11,19 +12,24 @@ import kotlinx.coroutines.test.StandardTestDispatcher
 import kotlinx.coroutines.test.resetMain
 import kotlinx.coroutines.test.runTest
 import kotlinx.coroutines.test.setMain
+import org.springframework.data.domain.PageRequest
 import pmeet.pmeetserver.common.ErrorCode
 import pmeet.pmeetserver.common.exception.EntityDuplicateException
 import pmeet.pmeetserver.user.domain.job.Job
 import pmeet.pmeetserver.user.repository.job.JobRepository
 import pmeet.pmeetserver.user.service.job.JobService
+import reactor.core.publisher.Flux
 import reactor.core.publisher.Mono
 
 @ExperimentalCoroutinesApi
 internal class JobServiceUnitTest : DescribeSpec({
 
+  isolationMode = IsolationMode.InstancePerLeaf
+
   val testDispatcher = StandardTestDispatcher()
 
   val jobRepository = mockk<JobRepository>(relaxed = true)
+
   lateinit var jobService: JobService
   lateinit var job: Job
 
@@ -67,4 +73,40 @@ internal class JobServiceUnitTest : DescribeSpec({
       }
     }
   }
+
+  describe("searchByJobName") {
+    context("직무 이름과 페이징 정보가 주어지면") {
+      val name = "Test"
+      val pageNumber = 0
+      val pageSize = 10
+      val jobs = mutableListOf<Job>()
+      for (i in 1..pageSize * 2) {
+        jobs.add(Job(name = name + i))
+      }
+
+      it("이름을 포함하는 직무들을 Slice로 반환한다") {
+        runTest {
+          every { jobRepository.findByNameSearchSlice(name, any()) } answers {
+            Flux.fromIterable(
+              jobs.subList(
+                0,
+                pageSize + 1
+              )
+            )
+          }
+
+          val result = jobService.searchByJobName(name, PageRequest.of(pageNumber, pageSize))
+
+          result.size shouldBe pageSize
+          result.isFirst shouldBe true
+          result.isLast shouldBe false
+          result.content.size shouldBe pageSize
+          result.content.first().name shouldBe name + 1
+          result.content.last().name shouldBe name + pageSize
+          result.hasNext() shouldBe true
+        }
+      }
+    }
+  }
+
 })

--- a/src/test/kotlin/pmeet/pmeetserver/user/job/service/JobServiceUnitTest.kt
+++ b/src/test/kotlin/pmeet/pmeetserver/user/job/service/JobServiceUnitTest.kt
@@ -1,0 +1,70 @@
+package pmeet.pmeetserver.user.job.service
+
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.core.spec.style.DescribeSpec
+import io.kotest.matchers.shouldBe
+import io.mockk.every
+import io.mockk.mockk
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.setMain
+import pmeet.pmeetserver.common.ErrorCode
+import pmeet.pmeetserver.common.exception.EntityDuplicateException
+import pmeet.pmeetserver.user.domain.job.Job
+import pmeet.pmeetserver.user.repository.job.JobRepository
+import pmeet.pmeetserver.user.service.job.JobService
+import reactor.core.publisher.Mono
+
+@ExperimentalCoroutinesApi
+internal class JobServiceUnitTest : DescribeSpec({
+
+  val testDispatcher = StandardTestDispatcher()
+
+  val jobRepository = mockk<JobRepository>(relaxed = true)
+  lateinit var jobService: JobService
+  lateinit var job: Job
+
+  beforeSpec {
+    Dispatchers.setMain(testDispatcher)
+    jobService = JobService(jobRepository)
+
+    job = Job(
+      name = "testName",
+    )
+  }
+
+  afterSpec {
+    Dispatchers.resetMain()
+  }
+
+  describe("save") {
+    context("직무 정보가 주어지면") {
+      it("저장 후 직무를 반환한다") {
+        runTest {
+          every { jobRepository.save(any()) } answers { Mono.just(job) }
+          every { jobRepository.findByName(job.name) } answers { Mono.empty() }
+
+          val result = jobService.save(job)
+
+          result.name shouldBe job.name
+        }
+      }
+    }
+
+    context("이미 존재하는 직무 이름이 주어지면") {
+      every { jobRepository.findByName(job.name) } answers { Mono.just(job) }
+      it("EntityDuplicateException을 던진다") {
+        runTest {
+          val exception = shouldThrow<EntityDuplicateException> {
+            jobService.save(job)
+          }
+
+          exception.errorCode shouldBe ErrorCode.JOB_DUPLICATE_BY_NAME
+        }
+      }
+    }
+  }
+})


### PR DESCRIPTION
## Related issue
resolves #56 

## Description
 - 직무를 따로 조회하는 경우가 있어 Embedding 스키마를 사용하지 않았음
 - Aggregation을 작성하기 위해 JobCustomRepo 추가
 - JobRepo 단위테스트에 template으로 JobCustomRepo 생성 후 factort로 JobRepo생성시 추가
 - Flux를 Slice로 변환하는 로직을 SliceResponse의 정적 메서드 of로 추출
 - 정렬 규칙은 1순위 직무이름 길이 오름차순 , 2순위 직무이름 오름차순
 - 입력으로 들어온 이름이 null인 경우 전체 기준 페이징
## Changes detail
 - 통합테스트시 ReactiveMongoTemplate Bean이 2개라서 Test용 Template에 Primary추가
### Checklist
- [ ] Test case
- [ ] End of work
