### PR TITLE
🐛 fix: 이력서 업데이트 로직 변경 & ✨ feat: 이력서 삭제 요청 기능 구현

### DIFF
--- a/src/main/kotlin/pmeet/pmeetserver/common/ErrorCode.kt
+++ b/src/main/kotlin/pmeet/pmeetserver/common/ErrorCode.kt
@@ -27,7 +27,8 @@ enum class ErrorCode(private val code: String, private val message: String) {
   // Resume
   RESUME_NUMBER_EXCEEDED("RESUME-40000", "이력서는 5개까지만 생성 가능합니다."),
   RESUME_NOT_FOUND("RESUME-40001", "해당하는 ID 의 이력서를 찾을 수 없습니다."),
-  RESUME_UPDATE_UNAUTHORIZED("RESUME-40002", "해당하는 이력서를 수정할 권한이 없습니다.")
+  RESUME_UPDATE_UNAUTHORIZED("RESUME-40002", "해당하는 이력서를 수정할 권한이 없습니다."),
+  RESUME_DELETE_UNAUTHORIZED("RESUME-40003", "해당하는 이력서를 삭제할 권한이 없습니다.")
   ;
 
   fun getCode(): String {

--- a/src/main/kotlin/pmeet/pmeetserver/common/ErrorCode.kt
+++ b/src/main/kotlin/pmeet/pmeetserver/common/ErrorCode.kt
@@ -26,7 +26,8 @@ enum class ErrorCode(private val code: String, private val message: String) {
 
   // Resume
   RESUME_NUMBER_EXCEEDED("RESUME-40000", "이력서는 5개까지만 생성 가능합니다."),
-  RESUME_NOT_FOUND("RESUME-40001", "해당하는 ID 의 이력서를 찾을 수 없습니다.")
+  RESUME_NOT_FOUND("RESUME-40001", "해당하는 ID 의 이력서를 찾을 수 없습니다."),
+  RESUME_UPDATE_UNAUTHORIZED("RESUME-40002", "해당하는 이력서를 수정할 권한이 없습니다.")
   ;
 
   fun getCode(): String {

--- a/src/main/kotlin/pmeet/pmeetserver/user/controller/ResumeController.kt
+++ b/src/main/kotlin/pmeet/pmeetserver/user/controller/ResumeController.kt
@@ -53,14 +53,14 @@ class ResumeController(private val resumeFacadeService: ResumeFacadeService) {
   }
 
   @DeleteMapping
-  @ResponseStatus(HttpStatus.OK)
+  @ResponseStatus(HttpStatus.NO_CONTENT)
   suspend fun deleteResume(@AuthenticationPrincipal userId: Mono<String>, @RequestParam id: String): ResponseEntity<Void> {
     val requestUserId = userId.awaitSingle()
     if (!requestUserId.equals(resumeFacadeService.findResumeById(id).userId)) {
       throw UnauthorizedException(ErrorCode.RESUME_UPDATE_UNAUTHORIZED)
     }
     resumeFacadeService.deleteResume(DeleteResumeRequestDto(id, requestUserId))
-    return ResponseEntity.ok().build()
+    return ResponseEntity.noContent().build()
   }
 
 }

--- a/src/main/kotlin/pmeet/pmeetserver/user/controller/ResumeController.kt
+++ b/src/main/kotlin/pmeet/pmeetserver/user/controller/ResumeController.kt
@@ -1,5 +1,6 @@
 package pmeet.pmeetserver.user.controller
 
+import jakarta.validation.Valid
 import kotlinx.coroutines.reactor.awaitSingle
 import org.springframework.http.HttpStatus
 import org.springframework.security.core.annotation.AuthenticationPrincipal
@@ -26,7 +27,7 @@ class ResumeController(private val resumeFacadeService: ResumeFacadeService) {
   @PostMapping
   @ResponseStatus(HttpStatus.CREATED)
   suspend fun createResume(
-    @RequestBody requestDto: CreateResumeRequestDto
+    @Valid @RequestBody requestDto: CreateResumeRequestDto
   ): ResumeResponseDto {
     return resumeFacadeService.createResume(requestDto)
   }
@@ -41,7 +42,7 @@ class ResumeController(private val resumeFacadeService: ResumeFacadeService) {
 
   @PutMapping
   @ResponseStatus(HttpStatus.OK)
-  suspend fun updateResume(@AuthenticationPrincipal userId: Mono<String>, @RequestBody requestDto: UpdateResumeRequestDto): ResumeResponseDto {
+  suspend fun updateResume(@AuthenticationPrincipal userId: Mono<String>, @Valid @RequestBody requestDto: UpdateResumeRequestDto): ResumeResponseDto {
     val requestUserId = userId.awaitSingle()
     return resumeFacadeService.updateResume(requestUserId, requestDto)
   }

--- a/src/main/kotlin/pmeet/pmeetserver/user/controller/ResumeController.kt
+++ b/src/main/kotlin/pmeet/pmeetserver/user/controller/ResumeController.kt
@@ -13,8 +13,6 @@ import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RequestParam
 import org.springframework.web.bind.annotation.ResponseStatus
 import org.springframework.web.bind.annotation.RestController
-import pmeet.pmeetserver.common.ErrorCode
-import pmeet.pmeetserver.common.exception.UnauthorizedException
 import pmeet.pmeetserver.user.dto.resume.request.CreateResumeRequestDto
 import pmeet.pmeetserver.user.dto.resume.request.DeleteResumeRequestDto
 import pmeet.pmeetserver.user.dto.resume.request.UpdateResumeRequestDto
@@ -46,20 +44,14 @@ class ResumeController(private val resumeFacadeService: ResumeFacadeService) {
   @ResponseStatus(HttpStatus.OK)
   suspend fun updateResume(@AuthenticationPrincipal userId: Mono<String>, @RequestBody requestDto: UpdateResumeRequestDto): ResumeResponseDto {
     val requestUserId = userId.awaitSingle()
-    if (!requestUserId.equals(requestDto.userId)) {
-      throw UnauthorizedException(ErrorCode.RESUME_UPDATE_UNAUTHORIZED)
-    }
-    return resumeFacadeService.updateResume(requestDto)
+    return resumeFacadeService.updateResume(requestUserId, requestDto)
   }
 
   @DeleteMapping
   @ResponseStatus(HttpStatus.NO_CONTENT)
   suspend fun deleteResume(@AuthenticationPrincipal userId: Mono<String>, @RequestParam id: String): ResponseEntity<Void> {
     val requestUserId = userId.awaitSingle()
-    if (!requestUserId.equals(resumeFacadeService.findResumeById(id).userId)) {
-      throw UnauthorizedException(ErrorCode.RESUME_UPDATE_UNAUTHORIZED)
-    }
-    resumeFacadeService.deleteResume(DeleteResumeRequestDto(id, requestUserId))
+    resumeFacadeService.deleteResume(requestUserId, DeleteResumeRequestDto(id, requestUserId))
     return ResponseEntity.noContent().build()
   }
 

--- a/src/main/kotlin/pmeet/pmeetserver/user/controller/ResumeController.kt
+++ b/src/main/kotlin/pmeet/pmeetserver/user/controller/ResumeController.kt
@@ -2,7 +2,6 @@ package pmeet.pmeetserver.user.controller
 
 import kotlinx.coroutines.reactor.awaitSingle
 import org.springframework.http.HttpStatus
-import org.springframework.http.ResponseEntity
 import org.springframework.security.core.annotation.AuthenticationPrincipal
 import org.springframework.web.bind.annotation.DeleteMapping
 import org.springframework.web.bind.annotation.GetMapping
@@ -49,10 +48,9 @@ class ResumeController(private val resumeFacadeService: ResumeFacadeService) {
 
   @DeleteMapping
   @ResponseStatus(HttpStatus.NO_CONTENT)
-  suspend fun deleteResume(@AuthenticationPrincipal userId: Mono<String>, @RequestParam id: String): ResponseEntity<Void> {
+  suspend fun deleteResume(@AuthenticationPrincipal userId: Mono<String>, @RequestParam(required = true) id: String) {
     val requestUserId = userId.awaitSingle()
-    resumeFacadeService.deleteResume(requestUserId, DeleteResumeRequestDto(id, requestUserId))
-    return ResponseEntity.noContent().build()
+    resumeFacadeService.deleteResume(DeleteResumeRequestDto(id, requestUserId))
   }
 
 }

--- a/src/main/kotlin/pmeet/pmeetserver/user/controller/ResumeController.kt
+++ b/src/main/kotlin/pmeet/pmeetserver/user/controller/ResumeController.kt
@@ -2,7 +2,9 @@ package pmeet.pmeetserver.user.controller
 
 import kotlinx.coroutines.reactor.awaitSingle
 import org.springframework.http.HttpStatus
+import org.springframework.http.ResponseEntity
 import org.springframework.security.core.annotation.AuthenticationPrincipal
+import org.springframework.web.bind.annotation.DeleteMapping
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.PutMapping
@@ -14,6 +16,7 @@ import org.springframework.web.bind.annotation.RestController
 import pmeet.pmeetserver.common.ErrorCode
 import pmeet.pmeetserver.common.exception.UnauthorizedException
 import pmeet.pmeetserver.user.dto.resume.request.CreateResumeRequestDto
+import pmeet.pmeetserver.user.dto.resume.request.DeleteResumeRequestDto
 import pmeet.pmeetserver.user.dto.resume.request.UpdateResumeRequestDto
 import pmeet.pmeetserver.user.dto.resume.response.ResumeResponseDto
 import pmeet.pmeetserver.user.service.resume.ResumeFacadeService
@@ -48,4 +51,16 @@ class ResumeController(private val resumeFacadeService: ResumeFacadeService) {
     }
     return resumeFacadeService.updateResume(requestDto)
   }
+
+  @DeleteMapping
+  @ResponseStatus(HttpStatus.OK)
+  suspend fun deleteResume(@AuthenticationPrincipal userId: Mono<String>, @RequestParam id: String): ResponseEntity<Void> {
+    val requestUserId = userId.awaitSingle()
+    if (!requestUserId.equals(resumeFacadeService.findResumeById(id).userId)) {
+      throw UnauthorizedException(ErrorCode.RESUME_UPDATE_UNAUTHORIZED)
+    }
+    resumeFacadeService.deleteResume(DeleteResumeRequestDto(id, requestUserId))
+    return ResponseEntity.ok().build()
+  }
+
 }

--- a/src/main/kotlin/pmeet/pmeetserver/user/controller/ResumeController.kt
+++ b/src/main/kotlin/pmeet/pmeetserver/user/controller/ResumeController.kt
@@ -1,6 +1,8 @@
 package pmeet.pmeetserver.user.controller
 
+import kotlinx.coroutines.reactor.awaitSingle
 import org.springframework.http.HttpStatus
+import org.springframework.security.core.annotation.AuthenticationPrincipal
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.PutMapping
@@ -9,10 +11,13 @@ import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RequestParam
 import org.springframework.web.bind.annotation.ResponseStatus
 import org.springframework.web.bind.annotation.RestController
+import pmeet.pmeetserver.common.ErrorCode
+import pmeet.pmeetserver.common.exception.UnauthorizedException
 import pmeet.pmeetserver.user.dto.resume.request.CreateResumeRequestDto
 import pmeet.pmeetserver.user.dto.resume.request.UpdateResumeRequestDto
 import pmeet.pmeetserver.user.dto.resume.response.ResumeResponseDto
 import pmeet.pmeetserver.user.service.resume.ResumeFacadeService
+import reactor.core.publisher.Mono
 
 @RestController
 @RequestMapping("/api/v1/resumes")
@@ -36,8 +41,11 @@ class ResumeController(private val resumeFacadeService: ResumeFacadeService) {
 
   @PutMapping
   @ResponseStatus(HttpStatus.OK)
-  suspend fun updateResume(@RequestBody requestDto: UpdateResumeRequestDto): ResumeResponseDto {
+  suspend fun updateResume(@AuthenticationPrincipal userId: Mono<String>, @RequestBody requestDto: UpdateResumeRequestDto): ResumeResponseDto {
+    val requestUserId = userId.awaitSingle()
+    if (!requestUserId.equals(requestDto.userId)) {
+      throw UnauthorizedException(ErrorCode.RESUME_UPDATE_UNAUTHORIZED)
+    }
     return resumeFacadeService.updateResume(requestDto)
   }
-
 }

--- a/src/main/kotlin/pmeet/pmeetserver/user/domain/resume/Resume.kt
+++ b/src/main/kotlin/pmeet/pmeetserver/user/domain/resume/Resume.kt
@@ -2,8 +2,8 @@ package pmeet.pmeetserver.user.domain.resume
 
 import org.springframework.data.annotation.Id
 import org.springframework.data.mongodb.core.mapping.Document
-import pmeet.pmeetserver.user.domain.enum.Gender
 import pmeet.pmeetserver.user.domain.enum.ExperienceYear
+import pmeet.pmeetserver.user.domain.enum.Gender
 import pmeet.pmeetserver.user.domain.job.Job
 import pmeet.pmeetserver.user.domain.techStack.TechStack
 import java.time.LocalDate
@@ -24,42 +24,41 @@ data class ProjectExperience(
 class Resume(
   @Id
   val id: String? = null, // mongodb auto id generation
-  val title: String,
-  val isActive: Boolean = false,
+  var title: String,
+  var isActive: Boolean = false,
   val userId: String,
   val userName: String,
   val userGender: Gender,
   val userBirthDate: LocalDate,
   val userPhoneNumber: String,
   val userEmail: String,
-  val userProfileImageUrl: String?,
-  val desiredJobs: List<Job>,
-  val techStacks: List<TechStack>,
-  val jobExperiences: List<JobExperience>,
-  val projectExperiences: List<ProjectExperience>,
-  val portfolioFileUrl: String?,
-  val portfolioUrl: List<String>,
-  val selfDescription: String?
+  var userProfileImageUrl: String?,
+  var desiredJobs: List<Job>,
+  var techStacks: List<TechStack>,
+  var jobExperiences: List<JobExperience>,
+  var projectExperiences: List<ProjectExperience>,
+  var portfolioFileUrl: String?,
+  var portfolioUrl: List<String>,
+  var selfDescription: String?
 ) {
-  fun update(updatedResume: Resume): Resume {
-    return Resume(
-      id = this.id,
-      title = updatedResume.title,
-      isActive = updatedResume.isActive,
-      userId = this.userId,// 수정 불가 항목
-      userName = this.userName,// 수정 불가 항목
-      userGender = this.userGender,// 수정 불가 항목
-      userBirthDate = this.userBirthDate,// 수정 불가 항목
-      userPhoneNumber = this.userPhoneNumber,// 수정 불가 항목
-      userEmail = this.userEmail,// 수정 불가 항목
-      userProfileImageUrl = updatedResume.userProfileImageUrl,
-      desiredJobs = updatedResume.desiredJobs,
-      techStacks = updatedResume.techStacks,
-      jobExperiences = updatedResume.jobExperiences,
-      projectExperiences = updatedResume.projectExperiences,
-      portfolioFileUrl = updatedResume.portfolioFileUrl,
-      portfolioUrl = updatedResume.portfolioUrl,
-      selfDescription = updatedResume.selfDescription
-    )
+  fun update(title: String? = null, userProfileImageUrl: String? = null,
+             desiredJobs: List<Job>? = emptyList(),
+             techStacks: List<TechStack>? = emptyList(),
+             jobExperiences: List<JobExperience>? = emptyList(),
+             projectExperiences: List<ProjectExperience>? = emptyList(),
+             portfolioFileUrl: String? = null,
+             portfolioUrl: List<String>? = emptyList(),
+             selfDescription: String? = null
+  ): Resume {
+    if (title != null) this.title = title
+    if (userProfileImageUrl != null) this.userProfileImageUrl = userProfileImageUrl
+    if (desiredJobs != null) this.desiredJobs = desiredJobs
+    if (techStacks != null) this.techStacks = techStacks
+    if (jobExperiences != null) this.jobExperiences = jobExperiences
+    if (projectExperiences != null) this.projectExperiences = projectExperiences
+    if (portfolioFileUrl != null) this.portfolioFileUrl = portfolioFileUrl
+    if (portfolioUrl != null) this.portfolioUrl = portfolioUrl
+    if (selfDescription != null) this.selfDescription = selfDescription
+    return this;
   }
 }

--- a/src/main/kotlin/pmeet/pmeetserver/user/dto/resume/request/CreateResumeRequestDto.kt
+++ b/src/main/kotlin/pmeet/pmeetserver/user/dto/resume/request/CreateResumeRequestDto.kt
@@ -2,6 +2,7 @@ package pmeet.pmeetserver.user.dto.resume.request
 
 import jakarta.validation.constraints.Email
 import jakarta.validation.constraints.NotBlank
+import jakarta.validation.constraints.NotNull
 import jakarta.validation.constraints.Pattern
 import jakarta.validation.constraints.Size
 import pmeet.pmeetserver.user.domain.enum.Gender
@@ -12,7 +13,7 @@ data class CreateResumeRequestDto(
   @field:NotBlank(message = "제목은 필수입니다.")
   @field:Size(min = 1, max = 30, message = "제목은 1글자에서 30글자 사이여야 합니다.")
   @field:Pattern(
-    regexp = "^[가-힣a-zA-Z0-9\\p{Punct}]*$",
+    regexp = "^[가-힣a-zA-Z0-9\\p{Punct}\\s]*$",
     message = "제목은 한글, 영어, 숫자, 문장부호만 입력 가능합니다."
   )
   val title: String,
@@ -21,9 +22,9 @@ data class CreateResumeRequestDto(
   val userId: String,
   @field:NotBlank(message = "사용자 이름은 필수입니다.")
   val userName: String,
-  @field:NotBlank(message = "사용자 성별은 필수입니다.")
+  @field:NotNull(message = "사용자 성별은 필수입니다.")
   val userGender: Gender,
-  @field:NotBlank(message = "사용자 생년월일은 필수입니다.")
+  @field:NotNull(message = "사용자 성별은 필수입니다.")
   val userBirthDate: LocalDate,
   @field:NotBlank(message = "사용자 전화 번호는 필수입니다.")
   val userPhoneNumber: String,

--- a/src/main/kotlin/pmeet/pmeetserver/user/dto/resume/request/DeleteResumeRequestDto.kt
+++ b/src/main/kotlin/pmeet/pmeetserver/user/dto/resume/request/DeleteResumeRequestDto.kt
@@ -2,4 +2,6 @@ package pmeet.pmeetserver.user.dto.resume.request
 
 import jakarta.validation.constraints.NotBlank
 
-data class DeleteResumeRequestDto(@NotBlank val id: String, val userId: String) {}
+data class DeleteResumeRequestDto(
+  @field:NotBlank(message = "이력서 id 는 필수입니다.") val id: String,
+  @field:NotBlank(message = "이력서 생성자 id 는 필수입니다.") val userId: String) {}

--- a/src/main/kotlin/pmeet/pmeetserver/user/dto/resume/request/DeleteResumeRequestDto.kt
+++ b/src/main/kotlin/pmeet/pmeetserver/user/dto/resume/request/DeleteResumeRequestDto.kt
@@ -1,3 +1,5 @@
 package pmeet.pmeetserver.user.dto.resume.request
 
-data class DeleteResumeRequestDto(val id: String, val userId: String) {}
+import jakarta.validation.constraints.NotBlank
+
+data class DeleteResumeRequestDto(@NotBlank val id: String, val userId: String) {}

--- a/src/main/kotlin/pmeet/pmeetserver/user/dto/resume/request/DeleteResumeRequestDto.kt
+++ b/src/main/kotlin/pmeet/pmeetserver/user/dto/resume/request/DeleteResumeRequestDto.kt
@@ -1,0 +1,3 @@
+package pmeet.pmeetserver.user.dto.resume.request
+
+data class DeleteResumeRequestDto(val id: String, val userId: String) {}

--- a/src/main/kotlin/pmeet/pmeetserver/user/dto/resume/request/UpdateResumeRequestDto.kt
+++ b/src/main/kotlin/pmeet/pmeetserver/user/dto/resume/request/UpdateResumeRequestDto.kt
@@ -2,9 +2,6 @@ package pmeet.pmeetserver.user.dto.resume.request
 import jakarta.validation.constraints.NotBlank
 import jakarta.validation.constraints.Pattern
 import jakarta.validation.constraints.Size
-import pmeet.pmeetserver.user.domain.enum.Gender
-import pmeet.pmeetserver.user.domain.resume.Resume
-import java.time.LocalDate
 
 data class UpdateResumeRequestDto(
   val id: String,
@@ -16,12 +13,6 @@ data class UpdateResumeRequestDto(
   )
   val title: String,
   val isActive: Boolean,
-  val userId: String,
-  val userName: String,
-  val userGender: Gender,
-  val userBirthDate: LocalDate,
-  val userPhoneNumber: String,
-  val userEmail: String,
   val userProfileImageUrl: String?,
   @field:Size(max = 5, message = "최대 5개의 희망 직무만 입력 가능합니다.")
   val desiredJobs: List<ResumeJobRequestDto>,
@@ -34,27 +25,4 @@ data class UpdateResumeRequestDto(
   val portfolioUrl: List<String>,
   @field:Size(max = 500, message = "자기소개는 최대 500자까지 입력 가능합니다.")
   val selfDescription: String?
-) {
-  fun toEntity(): Resume {
-    return Resume(
-      id = this.id,
-      title = this.title,
-      isActive = this.isActive,
-      userId = this.userId,
-      userName = this.userName,
-      userGender = this.userGender,
-      userBirthDate = this.userBirthDate,
-      userPhoneNumber = this.userPhoneNumber,
-      userEmail = this.userEmail,
-      userProfileImageUrl = this.userProfileImageUrl,
-      desiredJobs = this.desiredJobs.map { it.toEntity() },
-      techStacks = this.techStacks.map { it.toEntity() },
-      jobExperiences = this.jobExperiences.map { it.toEntity() },
-      projectExperiences = this.projectExperiences.map { it.toEntity() },
-      portfolioFileUrl = this.portfolioFileUrl,
-      portfolioUrl = this.portfolioUrl,
-      selfDescription = this.selfDescription
-    )
-  }
-
-}
+)

--- a/src/main/kotlin/pmeet/pmeetserver/user/dto/resume/request/UpdateResumeRequestDto.kt
+++ b/src/main/kotlin/pmeet/pmeetserver/user/dto/resume/request/UpdateResumeRequestDto.kt
@@ -8,7 +8,7 @@ data class UpdateResumeRequestDto(
   @field:NotBlank(message = "제목은 필수입니다.")
   @field:Size(min = 1, max = 30, message = "제목은 1글자에서 30글자 사이여야 합니다.")
   @field:Pattern(
-    regexp = "^[가-힣a-zA-Z0-9\\p{Punct}]*$",
+    regexp = "^[가-힣a-zA-Z0-9\\p{Punct}\\s]*$",
     message = "제목은 한글, 영어, 숫자, 문장부호만 입력 가능합니다."
   )
   val title: String,

--- a/src/main/kotlin/pmeet/pmeetserver/user/dto/resume/request/UpdateResumeRequestDto.kt
+++ b/src/main/kotlin/pmeet/pmeetserver/user/dto/resume/request/UpdateResumeRequestDto.kt
@@ -1,5 +1,4 @@
 package pmeet.pmeetserver.user.dto.resume.request
-import jakarta.validation.constraints.Email
 import jakarta.validation.constraints.NotBlank
 import jakarta.validation.constraints.Pattern
 import jakarta.validation.constraints.Size
@@ -38,6 +37,7 @@ data class UpdateResumeRequestDto(
 ) {
   fun toEntity(): Resume {
     return Resume(
+      id = this.id,
       title = this.title,
       isActive = this.isActive,
       userId = this.userId,

--- a/src/main/kotlin/pmeet/pmeetserver/user/dto/resume/response/ResumeResponseDto.kt
+++ b/src/main/kotlin/pmeet/pmeetserver/user/dto/resume/response/ResumeResponseDto.kt
@@ -26,14 +26,14 @@ data class ResumeJobExperienceResponseDto(
 }
 
 data class ResumeProjectExperienceResponseDto(
-  val companyName: String,
+  val projectName: String,
   val experiencePeriod: ExperienceYear,
   val responsibilities: String
 ) {
   companion object {
     fun from(projectExperience: ProjectExperience): ResumeProjectExperienceResponseDto {
       return ResumeProjectExperienceResponseDto(
-        companyName = projectExperience.projectName,
+        projectName = projectExperience.projectName,
         experiencePeriod = projectExperience.experiencePeriod,
         responsibilities = projectExperience.responsibilities
       )

--- a/src/main/kotlin/pmeet/pmeetserver/user/repository/resume/ResumeRepository.kt
+++ b/src/main/kotlin/pmeet/pmeetserver/user/repository/resume/ResumeRepository.kt
@@ -9,6 +9,4 @@ interface ResumeRepository : ReactiveMongoRepository<Resume, String> {
   fun countByUserId(userId: String): Mono<Long>
 
   fun findByIdAndUserId(id: String, userId: String): Mono<Resume>
-
-  fun deleteByIdAndUserId(id: String, userId: String): Mono<Void>
 }

--- a/src/main/kotlin/pmeet/pmeetserver/user/repository/resume/ResumeRepository.kt
+++ b/src/main/kotlin/pmeet/pmeetserver/user/repository/resume/ResumeRepository.kt
@@ -8,4 +8,5 @@ interface ResumeRepository : ReactiveMongoRepository<Resume, String> {
 
   fun countByUserId(userId: String): Mono<Long>
 
+  fun findByIdAndUserId(id: String, userId: String): Mono<Resume>
 }

--- a/src/main/kotlin/pmeet/pmeetserver/user/repository/resume/ResumeRepository.kt
+++ b/src/main/kotlin/pmeet/pmeetserver/user/repository/resume/ResumeRepository.kt
@@ -9,4 +9,6 @@ interface ResumeRepository : ReactiveMongoRepository<Resume, String> {
   fun countByUserId(userId: String): Mono<Long>
 
   fun findByIdAndUserId(id: String, userId: String): Mono<Resume>
+
+  fun deleteByIdAndUserId(id: String, userId: String): Mono<Void>
 }

--- a/src/main/kotlin/pmeet/pmeetserver/user/service/resume/ResumeFacadeService.kt
+++ b/src/main/kotlin/pmeet/pmeetserver/user/service/resume/ResumeFacadeService.kt
@@ -31,8 +31,17 @@ class ResumeFacadeService(
     if (!originalResume.userId.equals(userId)) {
       throw UnauthorizedException(ErrorCode.RESUME_UPDATE_UNAUTHORIZED)
     }
-    val resume = requestDto.toEntity()
-    return ResumeResponseDto.from(resumeService.update(originalResume.update(resume)))
+    val updateResume = originalResume.update(
+      title = requestDto.title,
+      userProfileImageUrl = requestDto.userProfileImageUrl,
+      desiredJobs = requestDto.desiredJobs.map { it.toEntity() },
+      techStacks = requestDto.techStacks.map { it.toEntity() },
+      jobExperiences = requestDto.jobExperiences.map { it.toEntity() },
+      projectExperiences = requestDto.projectExperiences.map { it.toEntity() },
+      portfolioFileUrl = requestDto.portfolioFileUrl,
+      portfolioUrl = requestDto.portfolioUrl,
+      selfDescription = requestDto.selfDescription)
+    return ResumeResponseDto.from(resumeService.update(updateResume))
   }
 
   @Transactional
@@ -41,6 +50,6 @@ class ResumeFacadeService(
     if (!originalResume.userId.equals(requestDto.userId)) {
       throw UnauthorizedException(ErrorCode.RESUME_DELETE_UNAUTHORIZED)
     }
-    resumeService.delete(requestDto.id, requestDto.userId)
+    resumeService.delete(originalResume)
   }
 }

--- a/src/main/kotlin/pmeet/pmeetserver/user/service/resume/ResumeFacadeService.kt
+++ b/src/main/kotlin/pmeet/pmeetserver/user/service/resume/ResumeFacadeService.kt
@@ -2,6 +2,8 @@ package pmeet.pmeetserver.user.service.resume
 
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
+import pmeet.pmeetserver.common.ErrorCode
+import pmeet.pmeetserver.common.exception.UnauthorizedException
 import pmeet.pmeetserver.user.dto.resume.request.CreateResumeRequestDto
 import pmeet.pmeetserver.user.dto.resume.request.DeleteResumeRequestDto
 import pmeet.pmeetserver.user.dto.resume.request.UpdateResumeRequestDto
@@ -24,13 +26,21 @@ class ResumeFacadeService(
   }
 
   @Transactional
-  suspend fun updateResume(requestDto: UpdateResumeRequestDto): ResumeResponseDto {
+  suspend fun updateResume(userId: String, requestDto: UpdateResumeRequestDto): ResumeResponseDto {
+    val originalResume = resumeService.findByResumeId(requestDto.id);
+    if (!originalResume.userId.equals(userId)) {
+      throw UnauthorizedException(ErrorCode.RESUME_UPDATE_UNAUTHORIZED)
+    }
     val resume = requestDto.toEntity()
-    return ResumeResponseDto.from(resumeService.update(resume, requestDto.id))
+    return ResumeResponseDto.from(resumeService.update(resume, originalResume))
   }
 
   @Transactional
-  suspend fun deleteResume(requestDto: DeleteResumeRequestDto) {
+  suspend fun deleteResume(userId: String, requestDto: DeleteResumeRequestDto) {
+    val originalResume = resumeService.findByResumeId(requestDto.id);
+    if (!originalResume.userId.equals(userId)) {
+      throw UnauthorizedException(ErrorCode.RESUME_DELETE_UNAUTHORIZED)
+    }
     resumeService.delete(requestDto.id, requestDto.userId)
   }
 }

--- a/src/main/kotlin/pmeet/pmeetserver/user/service/resume/ResumeFacadeService.kt
+++ b/src/main/kotlin/pmeet/pmeetserver/user/service/resume/ResumeFacadeService.kt
@@ -3,6 +3,7 @@ package pmeet.pmeetserver.user.service.resume
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 import pmeet.pmeetserver.user.dto.resume.request.CreateResumeRequestDto
+import pmeet.pmeetserver.user.dto.resume.request.DeleteResumeRequestDto
 import pmeet.pmeetserver.user.dto.resume.request.UpdateResumeRequestDto
 import pmeet.pmeetserver.user.dto.resume.response.ResumeResponseDto
 
@@ -26,5 +27,10 @@ class ResumeFacadeService(
   suspend fun updateResume(requestDto: UpdateResumeRequestDto): ResumeResponseDto {
     val resume = requestDto.toEntity()
     return ResumeResponseDto.from(resumeService.update(resume, requestDto.id))
+  }
+
+  @Transactional
+  suspend fun deleteResume(requestDto: DeleteResumeRequestDto) {
+    resumeService.delete(requestDto.id, requestDto.userId)
   }
 }

--- a/src/main/kotlin/pmeet/pmeetserver/user/service/resume/ResumeFacadeService.kt
+++ b/src/main/kotlin/pmeet/pmeetserver/user/service/resume/ResumeFacadeService.kt
@@ -22,23 +22,23 @@ class ResumeFacadeService(
 
   @Transactional(readOnly = true)
   suspend fun findResumeById(resumeId: String): ResumeResponseDto {
-    return ResumeResponseDto.from(resumeService.findByResumeId(resumeId))
+    return ResumeResponseDto.from(resumeService.getByResumeId(resumeId))
   }
 
   @Transactional
   suspend fun updateResume(userId: String, requestDto: UpdateResumeRequestDto): ResumeResponseDto {
-    val originalResume = resumeService.findByResumeId(requestDto.id);
+    val originalResume = resumeService.getByResumeId(requestDto.id);
     if (!originalResume.userId.equals(userId)) {
       throw UnauthorizedException(ErrorCode.RESUME_UPDATE_UNAUTHORIZED)
     }
     val resume = requestDto.toEntity()
-    return ResumeResponseDto.from(resumeService.update(resume, originalResume))
+    return ResumeResponseDto.from(resumeService.update(originalResume.update(resume)))
   }
 
   @Transactional
-  suspend fun deleteResume(userId: String, requestDto: DeleteResumeRequestDto) {
-    val originalResume = resumeService.findByResumeId(requestDto.id);
-    if (!originalResume.userId.equals(userId)) {
+  suspend fun deleteResume(requestDto: DeleteResumeRequestDto) {
+    val originalResume = resumeService.getByResumeId(requestDto.id);
+    if (!originalResume.userId.equals(requestDto.userId)) {
       throw UnauthorizedException(ErrorCode.RESUME_DELETE_UNAUTHORIZED)
     }
     resumeService.delete(requestDto.id, requestDto.userId)

--- a/src/main/kotlin/pmeet/pmeetserver/user/service/resume/ResumeService.kt
+++ b/src/main/kotlin/pmeet/pmeetserver/user/service/resume/ResumeService.kt
@@ -29,7 +29,7 @@ class ResumeService(private val resumeRepository: ResumeRepository) {
 
   @Transactional
   suspend fun update(resume: Resume, id: String): Resume {
-    val oldResume = resumeRepository.findById(id).awaitSingleOrNull()
+    val oldResume = resumeRepository.findByIdAndUserId(id, resume.userId).awaitSingleOrNull()
       ?: throw EntityNotFoundException(ErrorCode.RESUME_NOT_FOUND)
     val updatedResume = oldResume.update(resume)
     return resumeRepository.save(updatedResume).awaitSingle()

--- a/src/main/kotlin/pmeet/pmeetserver/user/service/resume/ResumeService.kt
+++ b/src/main/kotlin/pmeet/pmeetserver/user/service/resume/ResumeService.kt
@@ -23,15 +23,14 @@ class ResumeService(private val resumeRepository: ResumeRepository) {
   }
 
   @Transactional(readOnly = true)
-  suspend fun findByResumeId(resumeId: String): Resume {
+  suspend fun getByResumeId(resumeId: String): Resume {
     return resumeRepository.findById(resumeId).awaitSingleOrNull()
       ?: throw EntityNotFoundException(ErrorCode.RESUME_NOT_FOUND)
   }
 
   @Transactional
-  suspend fun update(resume: Resume, originalResume: Resume): Resume {
-    val updatedResume = originalResume.update(resume)
-    return resumeRepository.save(updatedResume).awaitSingle()
+  suspend fun update(updateResume: Resume): Resume {
+    return resumeRepository.save(updateResume).awaitSingle()
   }
 
   @Transactional

--- a/src/main/kotlin/pmeet/pmeetserver/user/service/resume/ResumeService.kt
+++ b/src/main/kotlin/pmeet/pmeetserver/user/service/resume/ResumeService.kt
@@ -34,4 +34,9 @@ class ResumeService(private val resumeRepository: ResumeRepository) {
     val updatedResume = oldResume.update(resume)
     return resumeRepository.save(updatedResume).awaitSingle()
   }
+
+  @Transactional
+  suspend fun delete(id: String, userId: String) {
+    resumeRepository.deleteByIdAndUserId(id, userId).awaitSingleOrNull()
+  }
 }

--- a/src/main/kotlin/pmeet/pmeetserver/user/service/resume/ResumeService.kt
+++ b/src/main/kotlin/pmeet/pmeetserver/user/service/resume/ResumeService.kt
@@ -34,7 +34,7 @@ class ResumeService(private val resumeRepository: ResumeRepository) {
   }
 
   @Transactional
-  suspend fun delete(id: String, userId: String) {
-    resumeRepository.deleteByIdAndUserId(id, userId).awaitSingleOrNull()
+  suspend fun delete(deleteResume: Resume) {
+    deleteResume.id?.let { resumeRepository.deleteById(it).awaitSingleOrNull() }
   }
 }

--- a/src/main/kotlin/pmeet/pmeetserver/user/service/resume/ResumeService.kt
+++ b/src/main/kotlin/pmeet/pmeetserver/user/service/resume/ResumeService.kt
@@ -24,14 +24,13 @@ class ResumeService(private val resumeRepository: ResumeRepository) {
 
   @Transactional(readOnly = true)
   suspend fun findByResumeId(resumeId: String): Resume {
-    return resumeRepository.findById(resumeId).awaitSingle()
+    return resumeRepository.findById(resumeId).awaitSingleOrNull()
+      ?: throw EntityNotFoundException(ErrorCode.RESUME_NOT_FOUND)
   }
 
   @Transactional
-  suspend fun update(resume: Resume, id: String): Resume {
-    val oldResume = resumeRepository.findByIdAndUserId(id, resume.userId).awaitSingleOrNull()
-      ?: throw EntityNotFoundException(ErrorCode.RESUME_NOT_FOUND)
-    val updatedResume = oldResume.update(resume)
+  suspend fun update(resume: Resume, originalResume: Resume): Resume {
+    val updatedResume = originalResume.update(resume)
     return resumeRepository.save(updatedResume).awaitSingle()
   }
 

--- a/src/test/kotlin/pmeet/pmeetserver/user/resume/ResumeGenerator.kt
+++ b/src/test/kotlin/pmeet/pmeetserver/user/resume/ResumeGenerator.kt
@@ -9,6 +9,7 @@ import pmeet.pmeetserver.user.domain.resume.Resume
 import pmeet.pmeetserver.user.domain.techStack.TechStack
 import pmeet.pmeetserver.user.dto.job.response.JobResponseDto
 import pmeet.pmeetserver.user.dto.resume.request.CreateResumeRequestDto
+import pmeet.pmeetserver.user.dto.resume.request.DeleteResumeRequestDto
 import pmeet.pmeetserver.user.dto.resume.request.ResumeJobExperienceRequestDto
 import pmeet.pmeetserver.user.dto.resume.request.ResumeJobRequestDto
 import pmeet.pmeetserver.user.dto.resume.request.ResumeProjectExperienceRequestDto
@@ -268,4 +269,10 @@ object ResumeGenerator {
     )
   }
 
+  internal fun createMockDeleteResumeRequestDto(): DeleteResumeRequestDto {
+    return DeleteResumeRequestDto(
+      id = "resume-id",
+      userId = "John-id",
+    )
+  }
 }

--- a/src/test/kotlin/pmeet/pmeetserver/user/resume/ResumeGenerator.kt
+++ b/src/test/kotlin/pmeet/pmeetserver/user/resume/ResumeGenerator.kt
@@ -212,12 +212,6 @@ object ResumeGenerator {
       id = "resume-id",
       title = "Engineer",
       isActive = false,
-      userId = "John-id",
-      userName = "John Doe",
-      userGender = Gender.MALE,
-      userBirthDate = LocalDate.of(1990, 1, 1),
-      userPhoneNumber = "010-1234-5678",
-      userEmail = "john.doe@example.com",
       userProfileImageUrl = "http://example.com/profile.jpg",
       desiredJobs = listOf(
         ResumeJobRequestDto(
@@ -258,6 +252,68 @@ object ResumeGenerator {
           responsibilities = "Led the project development"
         ),
         ResumeProjectExperienceRequestDto(
+          projectName = "Project B",
+          experiencePeriod = ExperienceYear.YEAR_02,
+          responsibilities = "Contributed to backend services"
+        )
+      ),
+      portfolioFileUrl = "http://example.com/portfolio.pdf",
+      portfolioUrl = listOf("http://example.com/project1", "http://example.com/project2"),
+      selfDescription = "Passionate software engineer with a focus on backend development."
+    )
+  }
+
+  internal fun generateUpdatedResume(): Resume {
+    return Resume(
+      id = "resume-id",
+      title = "Engineer",
+      isActive = false,
+      userId = "John-id",
+      userName = "John Doe",
+      userGender = Gender.MALE,
+      userBirthDate = LocalDate.of(1990, 1, 1),
+      userPhoneNumber = "010-1234-5678",
+      userEmail = "john.doe@example.com",
+      userProfileImageUrl = "http://example.com/profile.jpg",
+      desiredJobs = listOf(
+        Job(
+          id = "job1",
+          name = "Backend Developer"
+        ),
+        Job(
+          id = "job2",
+          name = "Frontend Developer"
+        )
+      ),
+      techStacks = listOf(
+        TechStack(
+          id = "tech1",
+          name = "Kotlin"
+        ),
+        TechStack(
+          id = "tech2",
+          name = "React"
+        )
+      ),
+      jobExperiences = listOf(
+        JobExperience(
+          companyName = "ABC Corp",
+          experiencePeriod = ExperienceYear.YEAR_03,
+          responsibilities = "Developed backend services"
+        ),
+        JobExperience(
+          companyName = "XYZ Inc",
+          experiencePeriod = ExperienceYear.YEAR_02,
+          responsibilities = "Worked on frontend development"
+        )
+      ),
+      projectExperiences = listOf(
+        ProjectExperience(
+          projectName = "Project A",
+          experiencePeriod = ExperienceYear.YEAR_01,
+          responsibilities = "Led the project development"
+        ),
+        ProjectExperience(
           projectName = "Project B",
           experiencePeriod = ExperienceYear.YEAR_02,
           responsibilities = "Contributed to backend services"

--- a/src/test/kotlin/pmeet/pmeetserver/user/resume/ResumeGenerator.kt
+++ b/src/test/kotlin/pmeet/pmeetserver/user/resume/ResumeGenerator.kt
@@ -130,12 +130,12 @@ object ResumeGenerator {
       ),
       projectExperiences = listOf(
         ResumeProjectExperienceResponseDto(
-          companyName = "Project A",
+          projectName = "Project A",
           experiencePeriod = ExperienceYear.YEAR_01,
           responsibilities = "Led the project development"
         ),
         ResumeProjectExperienceResponseDto(
-          companyName = "Project B",
+          projectName = "Project B",
           experiencePeriod = ExperienceYear.YEAR_02,
           responsibilities = "Contributed to backend services"
         )

--- a/src/test/kotlin/pmeet/pmeetserver/user/resume/ResumeIntegrationTest.kt
+++ b/src/test/kotlin/pmeet/pmeetserver/user/resume/ResumeIntegrationTest.kt
@@ -4,8 +4,6 @@ import io.kotest.core.spec.IsolationMode
 import io.kotest.core.spec.Spec
 import io.kotest.core.spec.style.DescribeSpec
 import io.kotest.matchers.shouldBe
-import io.mockk.coEvery
-import io.mockk.coVerify
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.withContext
@@ -16,6 +14,7 @@ import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.http.MediaType
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken
 import org.springframework.security.test.web.reactive.server.SecurityMockServerConfigurers
+import org.springframework.test.context.ActiveProfiles
 import org.springframework.test.context.junit.jupiter.SpringExtension
 import org.springframework.test.web.reactive.server.WebTestClient
 import org.springframework.test.web.reactive.server.expectBody
@@ -30,9 +29,9 @@ import pmeet.pmeetserver.user.repository.resume.ResumeRepository
 import pmeet.pmeetserver.user.repository.techStack.TechStackRepository
 import pmeet.pmeetserver.user.resume.ResumeGenerator.createMockCreateResumeRequestDto
 import pmeet.pmeetserver.user.resume.ResumeGenerator.createMockResumeResponseDto
-import pmeet.pmeetserver.user.resume.ResumeGenerator.generateResume
-import org.springframework.test.context.ActiveProfiles
 import pmeet.pmeetserver.user.resume.ResumeGenerator.createMockUpdateResumeRequestDto
+import pmeet.pmeetserver.user.resume.ResumeGenerator.generateResume
+import pmeet.pmeetserver.user.resume.ResumeGenerator.generateUpdatedResume
 
 @ExtendWith(SpringExtension::class)
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
@@ -192,9 +191,9 @@ class ResumeIntegrationTest : DescribeSpec() {
     describe("PUT /api/v1/resumes") {
       context("인증된 유저의 이력서 수정 요청이 들어오면") {
         val requestDto = createMockUpdateResumeRequestDto()
-        val userId = requestDto.userId
+        val userId = resume.userId
         val mockAuthentication = UsernamePasswordAuthenticationToken(userId, null, null)
-        val resumeResponse = requestDto.toEntity()
+        val resumeResponse = generateUpdatedResume()
         val performRequest = webTestClient
           .mutateWith(SecurityMockServerConfigurers.mockAuthentication(mockAuthentication))
           .put()

--- a/src/test/kotlin/pmeet/pmeetserver/user/resume/controller/ResumeControllerUnitTest.kt
+++ b/src/test/kotlin/pmeet/pmeetserver/user/resume/controller/ResumeControllerUnitTest.kt
@@ -224,7 +224,7 @@ internal class ResumeControllerUnitTest : DescribeSpec() {
         }
 
         it("요청은 성공한다") {
-          performRequest.expectStatus().isOk
+          performRequest.expectStatus().isNoContent
         }
       }
 

--- a/src/test/kotlin/pmeet/pmeetserver/user/resume/controller/ResumeControllerUnitTest.kt
+++ b/src/test/kotlin/pmeet/pmeetserver/user/resume/controller/ResumeControllerUnitTest.kt
@@ -146,9 +146,9 @@ internal class ResumeControllerUnitTest : DescribeSpec() {
     }
 
     describe("PUT api/v1/resumes") {
-      context("인증된 유저의 이력서 수정 요청이 들어오면") {
-        val userId = "1234"
+      context("인증된 유저이자 이력서의 소유주의 이력서 수정 요청이 들어오면") {
         val requestDto = createMockUpdateResumeRequestDto()
+        val userId = requestDto.userId
         val responseDto = createMockResumeResponseDto()
         coEvery { resumeFacadeService.updateResume(requestDto) } answers { responseDto }
         val mockAuthentication = UsernamePasswordAuthenticationToken(userId, null, null)
@@ -172,6 +172,22 @@ internal class ResumeControllerUnitTest : DescribeSpec() {
             response.responseBody?.id shouldBe responseDto.id
             response.responseBody?.title shouldBe responseDto.title
           }
+        }
+      }
+
+      context("인증된 유저지만, 이력서의 소유주가 아니라면") {
+        val requestDto = createMockUpdateResumeRequestDto()
+        val userId = "not-owner"
+        val responseDto = createMockResumeResponseDto()
+        coEvery { resumeFacadeService.updateResume(requestDto) } answers { responseDto }
+        val mockAuthentication = UsernamePasswordAuthenticationToken(userId, null, null)
+        val performRequest = webTestClient
+          .put()
+          .uri("/api/v1/resumes")
+          .bodyValue(requestDto)
+          .exchange()
+        it("요청은 실패한다") {
+          performRequest.expectStatus().isUnauthorized
         }
       }
 

--- a/src/test/kotlin/pmeet/pmeetserver/user/resume/controller/ResumeControllerUnitTest.kt
+++ b/src/test/kotlin/pmeet/pmeetserver/user/resume/controller/ResumeControllerUnitTest.kt
@@ -20,6 +20,7 @@ import pmeet.pmeetserver.user.resume.ResumeGenerator.createMockCreateResumeReque
 import pmeet.pmeetserver.user.resume.ResumeGenerator.createMockDeleteResumeRequestDto
 import pmeet.pmeetserver.user.resume.ResumeGenerator.createMockResumeResponseDto
 import pmeet.pmeetserver.user.resume.ResumeGenerator.createMockUpdateResumeRequestDto
+import pmeet.pmeetserver.user.resume.ResumeGenerator.generateUpdatedResume
 import pmeet.pmeetserver.user.service.resume.ResumeFacadeService
 
 @WebFluxTest(ResumeController::class)
@@ -149,7 +150,7 @@ internal class ResumeControllerUnitTest : DescribeSpec() {
     describe("PUT api/v1/resumes") {
       context("인증된 유저이자 이력서의 소유주의 이력서 수정 요청이 들어오면") {
         val requestDto = createMockUpdateResumeRequestDto()
-        val userId = requestDto.userId
+        val userId = generateUpdatedResume().userId
         val responseDto = createMockResumeResponseDto()
         coEvery { resumeFacadeService.updateResume(userId, requestDto) } answers { responseDto }
         val mockAuthentication = UsernamePasswordAuthenticationToken(userId, null, null)

--- a/src/test/kotlin/pmeet/pmeetserver/user/resume/repository/ResumeRepositoryUnitTest.kt
+++ b/src/test/kotlin/pmeet/pmeetserver/user/resume/repository/ResumeRepositoryUnitTest.kt
@@ -135,6 +135,32 @@ internal class ResumeRepositoryUnitTest(
     }
   }
 
+  describe("findByIdAndUserId") {
+    context("이력서 아이디와 user id 가 주어지면") {
+      it("해당하는 아이디의 이력서를 반환한다") {
+        runTest {
+          val result = resumeRepository.findByIdAndUserId(resume.id ?: "", resume.userId).block()
+
+          result?.title shouldBe resume.title
+          result?.userId shouldBe resume.userId
+          result?.userName shouldBe resume.userName
+          result?.userGender shouldBe resume.userGender
+          result?.userBirthDate shouldBe resume.userBirthDate
+          result?.userPhoneNumber shouldBe resume.userPhoneNumber
+          result?.userEmail shouldBe resume.userEmail
+          result?.userProfileImageUrl shouldBe resume.userProfileImageUrl
+          result?.desiredJobs?.first?.name shouldBe resume.desiredJobs.first.name
+          result?.techStacks?.first?.name shouldBe resume.techStacks.first.name
+          result?.jobExperiences?.first?.companyName shouldBe resume.jobExperiences.first.companyName
+          result?.projectExperiences?.first?.projectName shouldBe resume.projectExperiences.first.projectName
+          result?.portfolioFileUrl shouldBe resume.portfolioFileUrl
+          result?.portfolioUrl?.first shouldBe resume.portfolioUrl.first
+          result?.selfDescription shouldBe resume.selfDescription
+        }
+      }
+    }
+  }
+
 }) {
   companion object {
     @Container

--- a/src/test/kotlin/pmeet/pmeetserver/user/resume/service/ResumeFacadeServiceUnitTest.kt
+++ b/src/test/kotlin/pmeet/pmeetserver/user/resume/service/ResumeFacadeServiceUnitTest.kt
@@ -22,6 +22,7 @@ import pmeet.pmeetserver.user.resume.ResumeGenerator.createMockCreateResumeReque
 import pmeet.pmeetserver.user.resume.ResumeGenerator.createMockDeleteResumeRequestDto
 import pmeet.pmeetserver.user.resume.ResumeGenerator.createMockUpdateResumeRequestDto
 import pmeet.pmeetserver.user.resume.ResumeGenerator.generateResume
+import pmeet.pmeetserver.user.resume.ResumeGenerator.generateUpdatedResume
 import pmeet.pmeetserver.user.service.resume.ResumeFacadeService
 import pmeet.pmeetserver.user.service.resume.ResumeService
 
@@ -84,9 +85,9 @@ class ResumeFacadeServiceUnitTest : DescribeSpec({
         runTest {
           val updateRequest = createMockUpdateResumeRequestDto()
           coEvery { resumeService.getByResumeId(any()) } answers { resume }
-          coEvery { resumeService.update(any()) } answers { updateRequest.toEntity() }
+          coEvery { resumeService.update(any()) } answers { generateUpdatedResume() }
 
-          val result = resumeFacadeService.updateResume(updateRequest.userId, updateRequest)
+          val result = resumeFacadeService.updateResume(resume.userId, updateRequest)
           result.title shouldBe updateRequest.title
           result.isActive shouldBe updateRequest.isActive
           result.desiredJobs.first().name shouldBe updateRequest.desiredJobs.first().name
@@ -105,7 +106,7 @@ class ResumeFacadeServiceUnitTest : DescribeSpec({
           val updateRequest = createMockUpdateResumeRequestDto()
 
           val exception = shouldThrow<EntityNotFoundException> {
-            resumeFacadeService.updateResume(updateRequest.userId, updateRequest)
+            resumeFacadeService.updateResume("mock-id", updateRequest)
           }
           exception.errorCode shouldBe ErrorCode.RESUME_NOT_FOUND
         }
@@ -134,7 +135,7 @@ class ResumeFacadeServiceUnitTest : DescribeSpec({
 
           resumeFacadeService.deleteResume(deleteRequest)
 
-          coVerify { resumeService.delete(deleteRequest.id, deleteRequest.userId) }
+          coVerify { resumeService.delete(resume) }
         }
       }
       it("존재하지 않는 resume ID로 업데이트 시도 시 EntityNotFoundException 발생시킨다") {
@@ -144,7 +145,7 @@ class ResumeFacadeServiceUnitTest : DescribeSpec({
           val updateRequest = createMockUpdateResumeRequestDto()
 
           val exception = shouldThrow<EntityNotFoundException> {
-            resumeFacadeService.updateResume(updateRequest.userId, updateRequest)
+            resumeFacadeService.updateResume(generateUpdatedResume().userId, updateRequest)
           }
           exception.errorCode shouldBe ErrorCode.RESUME_NOT_FOUND
         }

--- a/src/test/kotlin/pmeet/pmeetserver/user/resume/service/ResumeFacadeServiceUnitTest.kt
+++ b/src/test/kotlin/pmeet/pmeetserver/user/resume/service/ResumeFacadeServiceUnitTest.kt
@@ -1,0 +1,166 @@
+package pmeet.pmeetserver.user.resume.service
+
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.core.spec.IsolationMode
+import io.kotest.core.spec.style.DescribeSpec
+import io.kotest.matchers.shouldBe
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.mockk
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.setMain
+import pmeet.pmeetserver.common.ErrorCode
+import pmeet.pmeetserver.common.exception.EntityNotFoundException
+import pmeet.pmeetserver.common.exception.UnauthorizedException
+import pmeet.pmeetserver.user.domain.resume.Resume
+import pmeet.pmeetserver.user.resume.ResumeGenerator.createMockCreateResumeRequestDto
+import pmeet.pmeetserver.user.resume.ResumeGenerator.createMockDeleteResumeRequestDto
+import pmeet.pmeetserver.user.resume.ResumeGenerator.createMockUpdateResumeRequestDto
+import pmeet.pmeetserver.user.resume.ResumeGenerator.generateResume
+import pmeet.pmeetserver.user.service.resume.ResumeFacadeService
+import pmeet.pmeetserver.user.service.resume.ResumeService
+
+@ExperimentalCoroutinesApi
+class ResumeFacadeServiceUnitTest : DescribeSpec({
+  isolationMode = IsolationMode.InstancePerLeaf
+
+  val testDispatcher = StandardTestDispatcher()
+
+  val resumeService = mockk<ResumeService>(relaxed = true)
+
+  lateinit var resumeFacadeService: ResumeFacadeService
+
+  lateinit var resume: Resume
+
+  beforeSpec {
+    Dispatchers.setMain(testDispatcher)
+
+    resumeFacadeService = ResumeFacadeService(resumeService)
+
+    resume = generateResume()
+  }
+
+  afterSpec {
+    Dispatchers.resetMain()
+  }
+
+  describe("createResume") {
+    context("이력서를 저장하는 경우") {
+      it("저장 후 이력서를 반환한다.") {
+        runTest {
+          coEvery { resumeService.save(any()) } answers { resume }
+          val resumeCreateRequest = createMockCreateResumeRequestDto()
+          val result = resumeFacadeService.createResume(resumeCreateRequest)
+
+          result.title shouldBe resume.title
+          result.isActive shouldBe resume.isActive
+          result.userId shouldBe resume.userId
+          result.userName shouldBe resume.userName
+          result.userGender shouldBe resume.userGender
+          result.userBirthDate shouldBe resume.userBirthDate
+          result.userPhoneNumber shouldBe resume.userPhoneNumber
+          result.userEmail shouldBe resume.userEmail
+          result.userProfileImageUrl shouldBe resume.userProfileImageUrl
+          result.desiredJobs.first().name shouldBe resume.desiredJobs.first().name
+          result.techStacks.first().name shouldBe resume.techStacks.first().name
+          result.jobExperiences.first().companyName shouldBe resume.jobExperiences.first().companyName
+          result.projectExperiences.first().projectName shouldBe resume.projectExperiences.first().projectName
+          result.portfolioFileUrl shouldBe resume.portfolioFileUrl
+          result.portfolioUrl.first() shouldBe resume.portfolioUrl.first()
+          result.selfDescription shouldBe resume.selfDescription
+        }
+      }
+    }
+  }
+
+  describe("updateResume") {
+    context("이력서를 업데이트하는 경우") {
+      it("저장 후 이력서를 반환한다") {
+        runTest {
+          val updateRequest = createMockUpdateResumeRequestDto()
+          coEvery { resumeService.findByResumeId(any()) } answers { resume }
+          coEvery { resumeService.update(any(), any()) } answers { updateRequest.toEntity() }
+
+          val result = resumeFacadeService.updateResume(updateRequest.userId, updateRequest)
+          result.title shouldBe updateRequest.title
+          result.isActive shouldBe updateRequest.isActive
+          result.desiredJobs.first().name shouldBe updateRequest.desiredJobs.first().name
+          result.techStacks.first().name shouldBe updateRequest.techStacks.first().name
+          result.jobExperiences.first().companyName shouldBe updateRequest.jobExperiences.first().companyName
+          result.projectExperiences.first().projectName shouldBe updateRequest.projectExperiences.first().projectName
+          result.portfolioFileUrl shouldBe updateRequest.portfolioFileUrl
+          result.portfolioUrl.first() shouldBe updateRequest.portfolioUrl.first()
+          result.selfDescription shouldBe updateRequest.selfDescription
+        }
+      }
+      it("존재하지 않는 resume ID로 업데이트 시도 시 EntityNotFoundException 발생시킨다") {
+        runTest {
+          coEvery { resumeService.findByResumeId(any()) } throws EntityNotFoundException(ErrorCode.RESUME_NOT_FOUND)
+
+          val updateRequest = createMockUpdateResumeRequestDto()
+
+          val exception = shouldThrow<EntityNotFoundException> {
+            resumeFacadeService.updateResume(updateRequest.userId, updateRequest)
+          }
+          exception.errorCode shouldBe ErrorCode.RESUME_NOT_FOUND
+        }
+      }
+      it("권한이 없는 userId 로 업데이트 시도 시 UnauthorizedException 발생시킨다") {
+        runTest {
+          coEvery { resumeService.findByResumeId(any()) } answers { resume }
+
+          val updateRequest = createMockUpdateResumeRequestDto()
+
+          val exception = shouldThrow<UnauthorizedException> {
+            resumeFacadeService.updateResume("no-auth-user", updateRequest)
+          }
+          exception.errorCode shouldBe ErrorCode.RESUME_UPDATE_UNAUTHORIZED
+        }
+      }
+    }
+  }
+
+  describe("deleteResume") {
+    context("이력서를 삭제하는 경우") {
+      it("이력서를 삭제한다.") {
+        runTest {
+          val deleteRequest = createMockDeleteResumeRequestDto()
+          coEvery { resumeService.findByResumeId(any()) } answers { resume }
+
+          resumeFacadeService.deleteResume(deleteRequest.userId, deleteRequest)
+
+          coVerify { resumeService.delete(deleteRequest.id, deleteRequest.userId) }
+        }
+      }
+      it("존재하지 않는 resume ID로 업데이트 시도 시 EntityNotFoundException 발생시킨다") {
+        runTest {
+          coEvery { resumeService.findByResumeId(any()) } throws EntityNotFoundException(ErrorCode.RESUME_NOT_FOUND)
+
+          val updateRequest = createMockUpdateResumeRequestDto()
+
+          val exception = shouldThrow<EntityNotFoundException> {
+            resumeFacadeService.updateResume(updateRequest.userId, updateRequest)
+          }
+          exception.errorCode shouldBe ErrorCode.RESUME_NOT_FOUND
+        }
+      }
+
+      it("권한이 없는 userId 로 삭제 시도 시 UnauthorizedException 발생시킨다") {
+        runTest {
+          coEvery { resumeService.findByResumeId(any()) } answers { resume }
+
+          val deleteRequest = createMockDeleteResumeRequestDto()
+
+          val exception = shouldThrow<UnauthorizedException> {
+            resumeFacadeService.deleteResume("no-auth-user", deleteRequest)
+          }
+          exception.errorCode shouldBe ErrorCode.RESUME_DELETE_UNAUTHORIZED
+        }
+      }
+    }
+  }
+})

--- a/src/test/kotlin/pmeet/pmeetserver/user/resume/service/ResumeServiceUnitTest.kt
+++ b/src/test/kotlin/pmeet/pmeetserver/user/resume/service/ResumeServiceUnitTest.kt
@@ -25,7 +25,6 @@ import pmeet.pmeetserver.user.domain.techStack.TechStack
 import pmeet.pmeetserver.user.repository.resume.ResumeRepository
 import pmeet.pmeetserver.user.resume.ResumeGenerator
 import pmeet.pmeetserver.user.resume.ResumeGenerator.createMockUpdateResumeRequestDto
-import pmeet.pmeetserver.user.resume.ResumeGenerator.generateResume
 import pmeet.pmeetserver.user.service.resume.ResumeService
 import reactor.core.publisher.Mono
 import java.time.LocalDate
@@ -147,7 +146,7 @@ internal class ResumeServiceUnitTest : DescribeSpec({
           every { resumeRepository.findByIdAndUserId("resume-id", "John-id") } answers { Mono.just(resume) }
           every { resumeRepository.save(any()) } answers { Mono.just(resumeUpdateRequestDto.toEntity()) }
 
-          val result = resumeService.update(resumeUpdateRequestDto.toEntity(), generateResume())
+          val result = resumeService.update(resumeUpdateRequestDto.toEntity())
 
           result.title shouldBe resumeUpdateRequestDto.title
           result.isActive shouldBe resumeUpdateRequestDto.isActive

--- a/src/test/kotlin/pmeet/pmeetserver/user/resume/service/ResumeServiceUnitTest.kt
+++ b/src/test/kotlin/pmeet/pmeetserver/user/resume/service/ResumeServiceUnitTest.kt
@@ -25,6 +25,7 @@ import pmeet.pmeetserver.user.domain.techStack.TechStack
 import pmeet.pmeetserver.user.repository.resume.ResumeRepository
 import pmeet.pmeetserver.user.resume.ResumeGenerator
 import pmeet.pmeetserver.user.resume.ResumeGenerator.createMockUpdateResumeRequestDto
+import pmeet.pmeetserver.user.resume.ResumeGenerator.generateUpdatedResume
 import pmeet.pmeetserver.user.service.resume.ResumeService
 import reactor.core.publisher.Mono
 import java.time.LocalDate
@@ -144,9 +145,9 @@ internal class ResumeServiceUnitTest : DescribeSpec({
         runTest {
           val resumeUpdateRequestDto = createMockUpdateResumeRequestDto();
           every { resumeRepository.findByIdAndUserId("resume-id", "John-id") } answers { Mono.just(resume) }
-          every { resumeRepository.save(any()) } answers { Mono.just(resumeUpdateRequestDto.toEntity()) }
+          every { resumeRepository.save(any()) } answers { Mono.just(generateUpdatedResume()) }
 
-          val result = resumeService.update(resumeUpdateRequestDto.toEntity())
+          val result = resumeService.update(generateUpdatedResume())
 
           result.title shouldBe resumeUpdateRequestDto.title
           result.isActive shouldBe resumeUpdateRequestDto.isActive
@@ -168,11 +169,11 @@ internal class ResumeServiceUnitTest : DescribeSpec({
       it("이력서를 삭제한다") {
         runTest {
           val resumeDeleteRequestDto = ResumeGenerator.createMockDeleteResumeRequestDto();
-          every { resumeRepository.deleteByIdAndUserId(resumeDeleteRequestDto.id, resumeDeleteRequestDto.userId) } answers { Mono.empty() }
+          every { resumeRepository.deleteById(resumeDeleteRequestDto.id) } answers { Mono.empty() }
 
-          resumeService.delete(resumeDeleteRequestDto.id, resumeDeleteRequestDto.userId)
+          resumeService.delete(resume)
 
-          coVerify { resumeRepository.deleteByIdAndUserId(resumeDeleteRequestDto.id, resumeDeleteRequestDto.userId) }
+          coVerify { resume.id?.let { resumeRepository.deleteById(it) } }
 
         }
       }

--- a/src/test/kotlin/pmeet/pmeetserver/user/resume/service/ResumeServiceUnitTest.kt
+++ b/src/test/kotlin/pmeet/pmeetserver/user/resume/service/ResumeServiceUnitTest.kt
@@ -4,6 +4,7 @@ import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.core.spec.IsolationMode
 import io.kotest.core.spec.style.DescribeSpec
 import io.kotest.matchers.shouldBe
+import io.mockk.coVerify
 import io.mockk.every
 import io.mockk.mockk
 import kotlinx.coroutines.Dispatchers
@@ -186,6 +187,22 @@ internal class ResumeServiceUnitTest : DescribeSpec({
             resumeService.update(resumeUpdateRequestDto.toEntity(), "resume-id")
           }
           exception.errorCode shouldBe ErrorCode.RESUME_NOT_FOUND
+
+        }
+      }
+    }
+  }
+
+  describe("delete") {
+    context("이력서를 삭제하는 경우") {
+      it("이력서를 삭제한다") {
+        runTest {
+          val resumeDeleteRequestDto = ResumeGenerator.createMockDeleteResumeRequestDto();
+          every { resumeRepository.deleteByIdAndUserId(resumeDeleteRequestDto.id, resumeDeleteRequestDto.userId) } answers { Mono.empty() }
+
+          resumeService.delete(resumeDeleteRequestDto.id, resumeDeleteRequestDto.userId)
+
+          coVerify { resumeRepository.deleteByIdAndUserId(resumeDeleteRequestDto.id, resumeDeleteRequestDto.userId) }
 
         }
       }


### PR DESCRIPTION
## Related issue
- #59 
- resolves #60 

## Description
- 🐛 fix: 이력서 업데이트 시, user Id 도 업데이트 조건으로 사용하며, 요청 사용자의 id 로 수정 권한 검증
- ✨ feat: 이력서 삭제 요청 기능 구현
- ♻️ refactor: pr review 반영

### Checklist
- [X] Test case
- [X] End of work
