### PR TITLE
feat: 프밋 모집 게시물 등록

### DIFF
--- a/src/main/kotlin/pmeet/pmeetserver/project/controller/ProjectController.kt
+++ b/src/main/kotlin/pmeet/pmeetserver/project/controller/ProjectController.kt
@@ -1,0 +1,31 @@
+package pmeet.pmeetserver.project.controller
+
+import jakarta.validation.Valid
+import kotlinx.coroutines.reactor.awaitSingle
+import org.springframework.http.HttpStatus
+import org.springframework.security.core.annotation.AuthenticationPrincipal
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RequestBody
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.ResponseStatus
+import org.springframework.web.bind.annotation.RestController
+import pmeet.pmeetserver.project.dto.request.CreateProjectRequestDto
+import pmeet.pmeetserver.project.dto.response.ProjectResponseDto
+import pmeet.pmeetserver.project.service.ProjectFacadeService
+import reactor.core.publisher.Mono
+
+@RestController
+@RequestMapping("/api/v1/projects")
+class ProjectController(
+  private val projectFacadeService: ProjectFacadeService
+) {
+
+  @PostMapping
+  @ResponseStatus(HttpStatus.CREATED)
+  suspend fun createProject(
+    @AuthenticationPrincipal userId: Mono<String>,
+    @RequestBody @Valid requestDto: CreateProjectRequestDto
+  ): ProjectResponseDto {
+    return projectFacadeService.createProject(userId.awaitSingle(), requestDto)
+  }
+}

--- a/src/main/kotlin/pmeet/pmeetserver/project/domain/Project.kt
+++ b/src/main/kotlin/pmeet/pmeetserver/project/domain/Project.kt
@@ -1,0 +1,30 @@
+package pmeet.pmeetserver.project.domain
+
+import org.springframework.data.annotation.Id
+import org.springframework.data.mongodb.core.mapping.Document
+import java.time.LocalDateTime
+
+
+data class Recruitment(
+  val jobName: String,
+  var numberOfRecruitment: Int,
+)
+
+@Document
+class Project(
+
+  @Id
+  val id: String? = null, // mongodb auto id generation
+  val userId: String,
+  var title: String,
+  var startDate: LocalDateTime,
+  var endDate: LocalDateTime,
+  var thumbNailUrl: String? = null,
+  var techStacks: List<String>? = mutableListOf(),
+  var recruitments: List<Recruitment>,
+  var description: String,
+  var isCompleted: Boolean = false,
+  var bookMarkers: List<String> = mutableListOf(), // 북마크를 한 유저 ID 리스트
+  val createdAt: LocalDateTime = LocalDateTime.now()
+) {
+}

--- a/src/main/kotlin/pmeet/pmeetserver/project/dto/request/CreateProjectRequestDto.kt
+++ b/src/main/kotlin/pmeet/pmeetserver/project/dto/request/CreateProjectRequestDto.kt
@@ -1,0 +1,39 @@
+package pmeet.pmeetserver.project.dto.request
+
+import jakarta.validation.Valid
+import jakarta.validation.constraints.NotBlank
+import jakarta.validation.constraints.NotEmpty
+import jakarta.validation.constraints.NotNull
+import jakarta.validation.constraints.Pattern
+import jakarta.validation.constraints.Size
+import org.hibernate.validator.constraints.UniqueElements
+import pmeet.pmeetserver.project.validation.annotation.TotalSumMax
+import pmeet.pmeetserver.project.validation.annotation.ValidDateRange
+import java.time.LocalDateTime
+
+@ValidDateRange
+data class CreateProjectRequestDto(
+  @field:NotBlank(message = "프로젝트 제목은 필수입니다.")
+  @field:Size(min = 1, max = 30, message = "프로젝트 제목은 1자에서 30자 사이여야 합니다.")
+  @field:Pattern(
+    regexp = "^[가-힣a-zA-Z0-9\\p{Punct}\\s]*$",
+    message = "프로젝트 제목은 한글, 영어, 숫자, 문장부호만 입력 가능합니다."
+  )
+  val title: String,
+  @field:NotNull(message = "프로젝트 시작일은 필수입니다.")
+  val startDate: LocalDateTime,
+  @field:NotNull(message = "프로젝트 종료일은 필수입니다.")
+  val endDate: LocalDateTime,
+  val thumbNailUrl: String? = null,
+  @field:Size(max = 5, message = "기술 스택은 5개까지만 입력 가능합니다.")
+  @field:UniqueElements(message = "기술 스택은 중복되지 않아야 합니다.")
+  val techStacks: List<String>? = mutableListOf(),
+  @field:NotEmpty(message = "프로젝트 모집 정보는 필수입니다.")
+  @field:Valid
+  @field:TotalSumMax(value = 30, element = "numberOfRecruitment", message = "모집 인원의 합은 30명을 초과할 수 없습니다.")
+  val recruitments: List<RecruitmentRequestDto>,
+  @field:NotBlank(message = "프로젝트 설명은 필수입니다.")
+  @field:Size(min = 1, max = 2000, message = "프로젝트 설명은 1자에서 2000자 사이여야 합니다.")
+  val description: String,
+) {
+}

--- a/src/main/kotlin/pmeet/pmeetserver/project/dto/request/CreateProjectRequestDto.kt
+++ b/src/main/kotlin/pmeet/pmeetserver/project/dto/request/CreateProjectRequestDto.kt
@@ -30,7 +30,7 @@ data class CreateProjectRequestDto(
   val techStacks: List<String>? = mutableListOf(),
   @field:NotEmpty(message = "프로젝트 모집 정보는 필수입니다.")
   @field:Valid
-  @field:TotalSumMax(value = 30, element = "numberOfRecruitment", message = "모집 인원의 합은 30명을 초과할 수 없습니다.")
+  @field:TotalSumMax(sum = 30, element = "numberOfRecruitment", message = "모집 인원의 합은 30명을 초과할 수 없습니다.")
   val recruitments: List<RecruitmentRequestDto>,
   @field:NotBlank(message = "프로젝트 설명은 필수입니다.")
   @field:Size(min = 1, max = 2000, message = "프로젝트 설명은 1자에서 2000자 사이여야 합니다.")

--- a/src/main/kotlin/pmeet/pmeetserver/project/dto/request/ProjectCommonRequestDto.kt
+++ b/src/main/kotlin/pmeet/pmeetserver/project/dto/request/ProjectCommonRequestDto.kt
@@ -1,10 +1,12 @@
 package pmeet.pmeetserver.project.dto.request
 
+import jakarta.validation.constraints.Min
 import jakarta.validation.constraints.NotBlank
 
 data class RecruitmentRequestDto(
   @field:NotBlank(message = "직무명은 필수입니다.")
   val jobName: String,
+  @field:Min(value = 1, message = "모집 인원은 1명 이상이어야 합니다.")
   var numberOfRecruitment: Int
 ) {
 }

--- a/src/main/kotlin/pmeet/pmeetserver/project/dto/request/ProjectCommonRequestDto.kt
+++ b/src/main/kotlin/pmeet/pmeetserver/project/dto/request/ProjectCommonRequestDto.kt
@@ -1,0 +1,11 @@
+package pmeet.pmeetserver.project.dto.request
+
+import jakarta.validation.constraints.NotBlank
+
+data class RecruitmentRequestDto(
+  @field:NotBlank(message = "직무명은 필수입니다.")
+  val jobName: String,
+  var numberOfRecruitment: Int
+) {
+}
+

--- a/src/main/kotlin/pmeet/pmeetserver/project/dto/response/ProjectResponseDto.kt
+++ b/src/main/kotlin/pmeet/pmeetserver/project/dto/response/ProjectResponseDto.kt
@@ -1,0 +1,44 @@
+package pmeet.pmeetserver.project.dto.response
+
+import pmeet.pmeetserver.project.domain.Project
+import java.time.LocalDateTime
+
+data class RecruitmentResponseDto(
+  val jobName: String,
+  var numberOfRecruitment: Int,
+) {
+}
+
+data class ProjectResponseDto(
+  val id: String,
+  val userId: String,
+  val title: String,
+  val startDate: LocalDateTime,
+  val endDate: LocalDateTime,
+  val thumbNailUrl: String?,
+  val techStacks: List<String>,
+  val recruitments: List<RecruitmentResponseDto>,
+  val description: String,
+  val isCompleted: Boolean,
+  val bookMarkers: List<String>,
+  val createdAt: LocalDateTime
+) {
+  companion object {
+    fun from(project: Project): ProjectResponseDto {
+      return ProjectResponseDto(
+        id = project.id!!,
+        userId = project.userId,
+        title = project.title,
+        startDate = project.startDate,
+        endDate = project.endDate,
+        thumbNailUrl = project.thumbNailUrl,
+        techStacks = project.techStacks!!,
+        recruitments = project.recruitments.map { RecruitmentResponseDto(it.jobName, it.numberOfRecruitment) },
+        description = project.description,
+        isCompleted = project.isCompleted,
+        bookMarkers = project.bookMarkers,
+        createdAt = project.createdAt
+      )
+    }
+  }
+}

--- a/src/main/kotlin/pmeet/pmeetserver/project/repository/ProjectRepository.kt
+++ b/src/main/kotlin/pmeet/pmeetserver/project/repository/ProjectRepository.kt
@@ -1,0 +1,7 @@
+package pmeet.pmeetserver.project.repository
+
+import org.springframework.data.mongodb.repository.ReactiveMongoRepository
+import pmeet.pmeetserver.project.domain.Project
+
+interface ProjectRepository : ReactiveMongoRepository<Project, String> {
+}

--- a/src/main/kotlin/pmeet/pmeetserver/project/service/ProjectFacadeService.kt
+++ b/src/main/kotlin/pmeet/pmeetserver/project/service/ProjectFacadeService.kt
@@ -1,0 +1,35 @@
+package pmeet.pmeetserver.project.service
+
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+import pmeet.pmeetserver.project.domain.Project
+import pmeet.pmeetserver.project.domain.Recruitment
+import pmeet.pmeetserver.project.dto.request.CreateProjectRequestDto
+import pmeet.pmeetserver.project.dto.response.ProjectResponseDto
+
+@Service
+class ProjectFacadeService(
+  private val projectService: ProjectService
+) {
+
+  @Transactional
+  suspend fun createProject(userId: String, requestDto: CreateProjectRequestDto): ProjectResponseDto {
+    val recruitments =
+      requestDto
+        .recruitments
+        .map { Recruitment(it.jobName, it.numberOfRecruitment) }
+        .toList()
+    val project = Project(
+      userId = userId,
+      title = requestDto.title,
+      startDate = requestDto.startDate,
+      endDate = requestDto.endDate,
+      thumbNailUrl = requestDto.thumbNailUrl,
+      techStacks = requestDto.techStacks,
+      recruitments = recruitments,
+      description = requestDto.description
+    )
+
+    return ProjectResponseDto.from(projectService.save(project))
+  }
+}

--- a/src/main/kotlin/pmeet/pmeetserver/project/service/ProjectService.kt
+++ b/src/main/kotlin/pmeet/pmeetserver/project/service/ProjectService.kt
@@ -1,0 +1,18 @@
+package pmeet.pmeetserver.project.service
+
+import kotlinx.coroutines.reactor.awaitSingle
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+import pmeet.pmeetserver.project.domain.Project
+import pmeet.pmeetserver.project.repository.ProjectRepository
+
+@Service
+class ProjectService(
+  private val projectRepository: ProjectRepository
+) {
+
+  @Transactional
+  suspend fun save(project: Project): Project {
+    return projectRepository.save(project).awaitSingle()
+  }
+}

--- a/src/main/kotlin/pmeet/pmeetserver/project/validation/DateRangeValidator.kt
+++ b/src/main/kotlin/pmeet/pmeetserver/project/validation/DateRangeValidator.kt
@@ -1,0 +1,39 @@
+package pmeet.pmeetserver.project.validation
+
+import jakarta.validation.ConstraintValidator
+import jakarta.validation.ConstraintValidatorContext
+import pmeet.pmeetserver.project.validation.annotation.ValidDateRange
+import java.time.LocalDateTime
+
+class DateRangeValidator : ConstraintValidator<ValidDateRange, Any> {
+
+  companion object {
+    private const val START_DATE_FIELD_NAME = "startDate"
+    private const val END_DATE_FIELD_NAME = "endDate"
+  }
+
+  override fun isValid(value: Any?, context: ConstraintValidatorContext?): Boolean {
+    if (value == null) return true
+
+    val startDate: LocalDateTime? = getPropertyValue(value, START_DATE_FIELD_NAME)
+    val endDate: LocalDateTime? = getPropertyValue(value, END_DATE_FIELD_NAME)
+
+    if (startDate == null || endDate == null) return true
+
+    if (startDate.isAfter(endDate) || startDate.isEqual(endDate)) {
+      context?.apply {
+        disableDefaultConstraintViolation()
+        buildConstraintViolationWithTemplate(defaultConstraintMessageTemplate)
+          .addPropertyNode(END_DATE_FIELD_NAME)
+          .addConstraintViolation()
+      }
+      return false
+    }
+    return true
+  }
+
+  private fun getPropertyValue(obj: Any, propertyName: String): LocalDateTime? {
+    val property = obj::class.members.find { it.name == propertyName } ?: return null
+    return property.call(obj) as? LocalDateTime
+  }
+}

--- a/src/main/kotlin/pmeet/pmeetserver/project/validation/DateRangeValidator.kt
+++ b/src/main/kotlin/pmeet/pmeetserver/project/validation/DateRangeValidator.kt
@@ -12,6 +12,12 @@ class DateRangeValidator : ConstraintValidator<ValidDateRange, Any> {
     private const val END_DATE_FIELD_NAME = "endDate"
   }
 
+  /**
+   * 종료일이 시작일보다 이후인지 검증합니다.
+   *
+   * 종료일 또는 시작일이 null이면 유효한 것으로 판단합니다.
+   *
+   */
   override fun isValid(value: Any?, context: ConstraintValidatorContext?): Boolean {
     if (value == null) return true
 
@@ -21,6 +27,9 @@ class DateRangeValidator : ConstraintValidator<ValidDateRange, Any> {
     if (startDate == null || endDate == null) return true
 
     if (startDate.isAfter(endDate) || startDate.isEqual(endDate)) {
+      /*
+        * 이 어노테이션은 클래스 레벨에 붙어있으므로, property node를 지정하기 위해 context를 사용합니다.
+       */
       context?.apply {
         disableDefaultConstraintViolation()
         buildConstraintViolationWithTemplate(defaultConstraintMessageTemplate)

--- a/src/main/kotlin/pmeet/pmeetserver/project/validation/TotalSumMaxValidator.kt
+++ b/src/main/kotlin/pmeet/pmeetserver/project/validation/TotalSumMaxValidator.kt
@@ -1,0 +1,31 @@
+package pmeet.pmeetserver.project.validation
+
+import jakarta.validation.ConstraintValidator
+import jakarta.validation.ConstraintValidatorContext
+import pmeet.pmeetserver.project.validation.annotation.TotalSumMax
+import kotlin.reflect.full.memberProperties
+
+class TotalSumMaxValidator : ConstraintValidator<TotalSumMax, Collection<*>> {
+  private var max: Int = 0
+  private lateinit var element: String
+
+  override fun initialize(constraintAnnotation: TotalSumMax) {
+    this.max = constraintAnnotation.value
+    this.element = constraintAnnotation.element
+  }
+
+  override fun isValid(value: Collection<*>?, context: ConstraintValidatorContext): Boolean {
+    if (value == null) return true
+
+    val total = value.sumOf {
+      it?.let { item ->
+        item::class.memberProperties
+          .find { prop -> prop.name == element }
+          ?.getter
+          ?.call(item) as? Int ?: 0
+      } ?: 0
+    }
+
+    return total <= max
+  }
+}

--- a/src/main/kotlin/pmeet/pmeetserver/project/validation/TotalSumMaxValidator.kt
+++ b/src/main/kotlin/pmeet/pmeetserver/project/validation/TotalSumMaxValidator.kt
@@ -10,7 +10,7 @@ class TotalSumMaxValidator : ConstraintValidator<TotalSumMax, Collection<*>> {
   private lateinit var element: String
 
   override fun initialize(constraintAnnotation: TotalSumMax) {
-    this.max = constraintAnnotation.value
+    this.max = constraintAnnotation.sum
     this.element = constraintAnnotation.element
   }
 

--- a/src/main/kotlin/pmeet/pmeetserver/project/validation/annotation/TotalSumMax.kt
+++ b/src/main/kotlin/pmeet/pmeetserver/project/validation/annotation/TotalSumMax.kt
@@ -5,12 +5,24 @@ import jakarta.validation.Payload
 import pmeet.pmeetserver.project.validation.TotalSumMaxValidator
 import kotlin.reflect.KClass
 
-@Target(AnnotationTarget.FIELD, AnnotationTarget.PROPERTY_GETTER, AnnotationTarget.PROPERTY_SETTER)
+/**
+ * Collection 타입의 요소들의 특정 필드의 합이 주어진 값보다 작거나 같아야 하는지 검증하는 애노테이션
+ */
+@Target(AnnotationTarget.FIELD)
 @Retention(AnnotationRetention.RUNTIME)
 @Constraint(validatedBy = [TotalSumMaxValidator::class])
 annotation class TotalSumMax(
-  val message: String = "모집 인원의 합이 {value}을 초과할 수 없습니다.",
-  val value: Int,
+  /**
+   * 검증 실패 시 출력할 메시지
+   */
+  val message: String,
+  /**
+   * 합의 최대값
+   */
+  val sum: Int,
+  /**
+   * 검증할 요소의 필드명
+   */
   val element: String = "",
   val groups: Array<KClass<*>> = [],
   val payload: Array<KClass<out Payload>> = []

--- a/src/main/kotlin/pmeet/pmeetserver/project/validation/annotation/TotalSumMax.kt
+++ b/src/main/kotlin/pmeet/pmeetserver/project/validation/annotation/TotalSumMax.kt
@@ -1,0 +1,17 @@
+package pmeet.pmeetserver.project.validation.annotation
+
+import jakarta.validation.Constraint
+import jakarta.validation.Payload
+import pmeet.pmeetserver.project.validation.TotalSumMaxValidator
+import kotlin.reflect.KClass
+
+@Target(AnnotationTarget.FIELD, AnnotationTarget.PROPERTY_GETTER, AnnotationTarget.PROPERTY_SETTER)
+@Retention(AnnotationRetention.RUNTIME)
+@Constraint(validatedBy = [TotalSumMaxValidator::class])
+annotation class TotalSumMax(
+  val message: String = "모집 인원의 합이 {value}을 초과할 수 없습니다.",
+  val value: Int,
+  val element: String = "",
+  val groups: Array<KClass<*>> = [],
+  val payload: Array<KClass<out Payload>> = []
+)

--- a/src/main/kotlin/pmeet/pmeetserver/project/validation/annotation/ValidDateRange.kt
+++ b/src/main/kotlin/pmeet/pmeetserver/project/validation/annotation/ValidDateRange.kt
@@ -1,0 +1,15 @@
+package pmeet.pmeetserver.project.validation.annotation
+
+import jakarta.validation.Constraint
+import jakarta.validation.Payload
+import pmeet.pmeetserver.project.validation.DateRangeValidator
+import kotlin.reflect.KClass
+
+@Target(AnnotationTarget.CLASS)
+@Retention(AnnotationRetention.RUNTIME)
+@Constraint(validatedBy = [DateRangeValidator::class])
+annotation class ValidDateRange(
+  val message: String = "종료일은 시작일보다 이후여야 합니다.",
+  val groups: Array<KClass<*>> = [],
+  val payload: Array<KClass<out Payload>> = []
+)

--- a/src/main/kotlin/pmeet/pmeetserver/project/validation/annotation/ValidDateRange.kt
+++ b/src/main/kotlin/pmeet/pmeetserver/project/validation/annotation/ValidDateRange.kt
@@ -5,10 +5,19 @@ import jakarta.validation.Payload
 import pmeet.pmeetserver.project.validation.DateRangeValidator
 import kotlin.reflect.KClass
 
+/**
+ * 종료일이 시작일보다 이후인지 검증합니다.
+ *
+ * 종료일 또는 시작일이 null이면 유효한 것으로 판단합니다.
+ *
+ */
 @Target(AnnotationTarget.CLASS)
 @Retention(AnnotationRetention.RUNTIME)
 @Constraint(validatedBy = [DateRangeValidator::class])
 annotation class ValidDateRange(
+  /**
+   * 검증 실패 시 출력할 메시지
+   */
   val message: String = "종료일은 시작일보다 이후여야 합니다.",
   val groups: Array<KClass<*>> = [],
   val payload: Array<KClass<out Payload>> = []

--- a/src/main/kotlin/pmeet/pmeetserver/user/controller/JobController.kt
+++ b/src/main/kotlin/pmeet/pmeetserver/user/controller/JobController.kt
@@ -1,5 +1,6 @@
 package pmeet.pmeetserver.user.controller
 
+import jakarta.validation.Valid
 import org.springframework.data.domain.PageRequest
 import org.springframework.data.domain.Slice
 import org.springframework.http.HttpStatus
@@ -23,7 +24,7 @@ class JobController(
   @PostMapping
   @ResponseStatus(HttpStatus.CREATED)
   suspend fun createJob(
-    @RequestBody requestDto: CreateJobRequestDto
+    @RequestBody @Valid requestDto: CreateJobRequestDto
   ): JobResponseDto {
     return jobFacadeService.createJob(requestDto)
   }

--- a/src/test/kotlin/pmeet/pmeetserver/project/ProjectIntegrationTest.kt
+++ b/src/test/kotlin/pmeet/pmeetserver/project/ProjectIntegrationTest.kt
@@ -1,0 +1,159 @@
+package pmeet.pmeetserver.project
+
+import io.kotest.core.spec.IsolationMode
+import io.kotest.core.spec.Spec
+import io.kotest.core.spec.style.DescribeSpec
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.withContext
+import org.junit.jupiter.api.extension.ExtendWith
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.autoconfigure.web.reactive.AutoConfigureWebTestClient
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.http.MediaType
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken
+import org.springframework.security.test.web.reactive.server.SecurityMockServerConfigurers.mockAuthentication
+import org.springframework.test.context.ActiveProfiles
+import org.springframework.test.context.junit.jupiter.SpringExtension
+import org.springframework.test.web.reactive.server.WebTestClient
+import org.springframework.test.web.reactive.server.expectBody
+import org.testcontainers.containers.MongoDBContainer
+import org.testcontainers.junit.jupiter.Container
+import pmeet.pmeetserver.project.domain.Project
+import pmeet.pmeetserver.project.domain.Recruitment
+import pmeet.pmeetserver.project.dto.request.CreateProjectRequestDto
+import pmeet.pmeetserver.project.dto.request.RecruitmentRequestDto
+import pmeet.pmeetserver.project.dto.response.ProjectResponseDto
+import pmeet.pmeetserver.project.repository.ProjectRepository
+import java.time.LocalDateTime
+
+@ExtendWith(SpringExtension::class)
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+@AutoConfigureWebTestClient
+@ExperimentalCoroutinesApi
+@ActiveProfiles("test")
+internal class ProjectIntegrationTest : DescribeSpec() {
+
+  override fun isolationMode(): IsolationMode? {
+    return IsolationMode.InstancePerLeaf
+  }
+
+  @Autowired
+  lateinit var webTestClient: WebTestClient
+
+  @Autowired
+  lateinit var projectRepository: ProjectRepository
+
+  lateinit var project: Project
+  lateinit var userId: String
+  lateinit var recruitments: List<Recruitment>
+
+  override suspend fun beforeSpec(spec: Spec) {
+    userId = "testUserId"
+    recruitments = listOf(
+      Recruitment(
+        jobName = "testJobName",
+        numberOfRecruitment = 1
+      ),
+      Recruitment(
+        jobName = "testJobName2",
+        numberOfRecruitment = 2
+      )
+    )
+
+    project = Project(
+      userId = userId,
+      title = "testTitle",
+      startDate = LocalDateTime.of(2021, 1, 1, 0, 0, 0),
+      endDate = LocalDateTime.of(2021, 12, 31, 23, 59, 59),
+      thumbNailUrl = "testThumbNailUrl",
+      techStacks = listOf("testTechStack1", "testTechStack2"),
+      recruitments = recruitments,
+      description = "testDescription"
+    )
+    withContext(Dispatchers.IO) {
+      projectRepository.save(project).block()
+    }
+  }
+
+  override suspend fun afterSpec(spec: Spec) {
+    withContext(Dispatchers.IO) {
+      projectRepository.deleteAll().block()
+    }
+  }
+
+  init {
+    describe("POST api/v1/projects") {
+      context("인증된 유저의 프로젝트 생성 요청이 들어오면") {
+        val mockAuthentication = UsernamePasswordAuthenticationToken(userId, null, null)
+        val requestDto = CreateProjectRequestDto(
+          title = "TestProject",
+          startDate = LocalDateTime.of(2021, 1, 1, 0, 0, 0),
+          endDate = LocalDateTime.of(2021, 12, 31, 23, 59, 59),
+          thumbNailUrl = "testThumbNailUrl",
+          techStacks = listOf("testTechStack1", "testTechStack2"),
+          recruitments = listOf(
+            RecruitmentRequestDto(
+              jobName = "testJobName",
+              numberOfRecruitment = 1
+            ),
+            RecruitmentRequestDto(
+              jobName = "testJobName2",
+              numberOfRecruitment = 2
+            )
+          ),
+          description = "testDescription"
+        )
+        val performRequest = webTestClient
+          .mutateWith(mockAuthentication(mockAuthentication))
+          .post()
+          .uri("/api/v1/projects")
+          .accept(MediaType.APPLICATION_JSON)
+          .bodyValue(requestDto)
+          .exchange()
+
+        it("요청은 성공한다") {
+          performRequest.expectStatus().isCreated
+        }
+
+        it("생성된 프로젝트 정보를 반환한다") {
+          performRequest.expectBody<ProjectResponseDto>().consumeWith { response ->
+            response.responseBody?.title shouldBe requestDto.title
+            response.responseBody?.startDate shouldBe requestDto.startDate
+            response.responseBody?.endDate shouldBe requestDto.endDate
+            response.responseBody?.thumbNailUrl shouldBe requestDto.thumbNailUrl
+            response.responseBody?.techStacks shouldBe requestDto.techStacks
+            response.responseBody?.recruitments!!.size shouldBe requestDto.recruitments.size
+            response.responseBody?.recruitments!!.forEachIndexed { index, recruitmentResponseDto ->
+              recruitmentResponseDto.jobName shouldBe requestDto.recruitments[index].jobName
+              recruitmentResponseDto.numberOfRecruitment shouldBe requestDto.recruitments[index].numberOfRecruitment
+            }
+            response.responseBody?.description shouldBe requestDto.description
+            response.responseBody?.userId shouldBe userId
+            response.responseBody?.bookMarkers shouldBe mutableListOf()
+            response.responseBody?.isCompleted shouldBe false
+            response.responseBody?.createdAt shouldNotBe null
+            response.responseBody?.id shouldNotBe null
+          }
+        }
+      }
+    }
+  }
+
+  companion object {
+    @Container
+    val mongoDBContainer = MongoDBContainer("mongo:latest").apply {
+      withExposedPorts(27017)
+      start()
+    }
+
+    init {
+      System.setProperty(
+        "spring.data.mongodb.uri",
+        "mongodb://localhost:${mongoDBContainer.getMappedPort(27017)}/test"
+      )
+    }
+  }
+}

--- a/src/test/kotlin/pmeet/pmeetserver/project/controller/ProjectControllerUnitTest.kt
+++ b/src/test/kotlin/pmeet/pmeetserver/project/controller/ProjectControllerUnitTest.kt
@@ -1,0 +1,151 @@
+package pmeet.pmeetserver.project.controller
+
+import com.ninjasquad.springmockk.MockkBean
+import io.kotest.core.spec.style.DescribeSpec
+import io.kotest.matchers.shouldBe
+import io.mockk.coEvery
+import io.mockk.coVerify
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.autoconfigure.web.reactive.WebFluxTest
+import org.springframework.context.annotation.Import
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken
+import org.springframework.security.test.web.reactive.server.SecurityMockServerConfigurers.mockAuthentication
+import org.springframework.test.web.reactive.server.WebTestClient
+import org.springframework.test.web.reactive.server.expectBody
+import pmeet.pmeetserver.config.TestSecurityConfig
+import pmeet.pmeetserver.project.dto.request.CreateProjectRequestDto
+import pmeet.pmeetserver.project.dto.request.RecruitmentRequestDto
+import pmeet.pmeetserver.project.dto.response.ProjectResponseDto
+import pmeet.pmeetserver.project.dto.response.RecruitmentResponseDto
+import pmeet.pmeetserver.project.service.ProjectFacadeService
+import java.time.LocalDateTime
+
+@WebFluxTest(ProjectController::class)
+@Import(TestSecurityConfig::class)
+internal class ProjectControllerUnitTest : DescribeSpec() {
+
+  @Autowired
+  private lateinit var webTestClient: WebTestClient
+
+  @MockkBean
+  lateinit var projectFacadeService: ProjectFacadeService
+
+  init {
+    describe("POST api/v1/projects") {
+      context("인증된 유저의 프로젝트 생성 요청이 들어오면") {
+        val userId = "1234"
+        val requestDto = CreateProjectRequestDto(
+          title = "TestProject",
+          startDate = LocalDateTime.of(2021, 1, 1, 0, 0, 0),
+          endDate = LocalDateTime.of(2021, 12, 31, 23, 59, 59),
+          thumbNailUrl = "testThumbNailUrl",
+          techStacks = listOf("testTechStack1", "testTechStack2"),
+          recruitments = listOf(
+            RecruitmentRequestDto(
+              jobName = "testJobName",
+              numberOfRecruitment = 1
+            ),
+            RecruitmentRequestDto(
+              jobName = "testJobName2",
+              numberOfRecruitment = 2
+            )
+          ),
+          description = "testDescription"
+        )
+        val responseDto = ProjectResponseDto(
+          id = "1234",
+          title = "TestProject",
+          startDate = LocalDateTime.of(2021, 1, 1, 0, 0, 0),
+          endDate = LocalDateTime.of(2021, 12, 31, 23, 59, 59),
+          thumbNailUrl = "testThumbNailUrl",
+          techStacks = listOf("testTechStack1", "testTechStack2"),
+          recruitments = listOf(
+            RecruitmentResponseDto(
+              jobName = "testJobName",
+              numberOfRecruitment = 1
+            ),
+            RecruitmentResponseDto(
+              jobName = "testJobName2",
+              numberOfRecruitment = 2
+            )
+          ),
+          description = "testDescription",
+          userId = userId,
+          bookMarkers = mutableListOf(),
+          isCompleted = false,
+          createdAt = LocalDateTime.of(2021, 5, 1, 0, 0, 0)
+        )
+
+        coEvery { projectFacadeService.createProject(userId, requestDto) } answers { responseDto }
+        val mockAuthentication = UsernamePasswordAuthenticationToken(userId, null, null)
+        val performRequest =
+          webTestClient
+            .mutateWith(mockAuthentication(mockAuthentication))
+            .post()
+            .uri("/api/v1/projects")
+            .bodyValue(requestDto)
+            .exchange()
+
+        it("서비스를 통해 데이터를 생성한다") {
+          coVerify(exactly = 1) { projectFacadeService.createProject(userId, requestDto) }
+        }
+
+        it("요청은 성공한다") {
+          performRequest.expectStatus().isCreated
+        }
+
+        it("생성된 프로젝트 정보를 반환한다") {
+          performRequest.expectBody<ProjectResponseDto>().consumeWith { response ->
+            response.responseBody?.id shouldBe responseDto.id
+            response.responseBody?.title shouldBe responseDto.title
+            response.responseBody?.startDate shouldBe responseDto.startDate
+            response.responseBody?.endDate shouldBe responseDto.endDate
+            response.responseBody?.thumbNailUrl shouldBe responseDto.thumbNailUrl
+            response.responseBody?.techStacks shouldBe responseDto.techStacks
+            response.responseBody?.recruitments!!.size shouldBe responseDto.recruitments.size
+            response.responseBody?.recruitments!!.forEachIndexed { index, recruitmentResponseDto ->
+              recruitmentResponseDto.jobName shouldBe responseDto.recruitments[index].jobName
+              recruitmentResponseDto.numberOfRecruitment shouldBe responseDto.recruitments[index].numberOfRecruitment
+            }
+            response.responseBody?.description shouldBe responseDto.description
+            response.responseBody?.userId shouldBe responseDto.userId
+            response.responseBody?.bookMarkers shouldBe responseDto.bookMarkers
+            response.responseBody?.isCompleted shouldBe responseDto.isCompleted
+            response.responseBody?.createdAt shouldBe responseDto.createdAt
+          }
+        }
+      }
+
+      context("인증되지 않은 유저의 프로젝트 생성 요청이 들어오면") {
+        val requestDto = CreateProjectRequestDto(
+          title = "TestProject",
+          startDate = LocalDateTime.of(2021, 1, 1, 0, 0, 0),
+          endDate = LocalDateTime.of(2021, 12, 31, 23, 59, 59),
+          thumbNailUrl = "testThumbNailUrl",
+          techStacks = listOf("testTechStack1", "testTechStack2"),
+          recruitments = listOf(
+            RecruitmentRequestDto(
+              jobName = "testJobName",
+              numberOfRecruitment = 1
+            ),
+            RecruitmentRequestDto(
+              jobName = "testJobName2",
+              numberOfRecruitment = 2
+            )
+          ),
+          description = "testDescription"
+        )
+        val performRequest =
+          webTestClient
+            .post()
+            .uri("/api/v1/projects")
+            .bodyValue(requestDto)
+            .exchange()
+
+        it("요청은 실패한다") {
+          performRequest.expectStatus().isUnauthorized
+        }
+      }
+    }
+  }
+}

--- a/src/test/kotlin/pmeet/pmeetserver/project/service/ProjectFacadeServiceUnitTest.kt
+++ b/src/test/kotlin/pmeet/pmeetserver/project/service/ProjectFacadeServiceUnitTest.kt
@@ -1,0 +1,109 @@
+package pmeet.pmeetserver.project.service
+
+import io.kotest.core.spec.style.DescribeSpec
+import io.kotest.matchers.shouldBe
+import io.mockk.coEvery
+import io.mockk.mockk
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.setMain
+import org.springframework.test.util.ReflectionTestUtils
+import pmeet.pmeetserver.project.domain.Project
+import pmeet.pmeetserver.project.domain.Recruitment
+import pmeet.pmeetserver.project.dto.request.CreateProjectRequestDto
+import pmeet.pmeetserver.project.dto.request.RecruitmentRequestDto
+import java.time.LocalDateTime
+
+@ExperimentalCoroutinesApi
+internal class ProjectFacadeServiceUnitTest : DescribeSpec({
+
+//  isolationMode = IsolationMode.InstancePerLeaf
+
+  val testDispatcher = StandardTestDispatcher()
+
+  val projectService = mockk<ProjectService>(relaxed = true)
+
+  lateinit var projectFacadeService: ProjectFacadeService
+
+  lateinit var project: Project
+  lateinit var userId: String
+  lateinit var recruitments: List<Recruitment>
+
+  beforeSpec {
+    Dispatchers.setMain(testDispatcher)
+    projectFacadeService = ProjectFacadeService(projectService)
+
+    userId = "testUserId"
+    recruitments = listOf(
+      Recruitment(
+        jobName = "testJobName",
+        numberOfRecruitment = 1
+      ),
+      Recruitment(
+        jobName = "testJobName2",
+        numberOfRecruitment = 2
+      )
+    )
+
+    project = Project(
+      userId = userId,
+      title = "testTitle",
+      startDate = LocalDateTime.of(2021, 1, 1, 0, 0, 0),
+      endDate = LocalDateTime.of(2021, 12, 31, 23, 59, 59),
+      thumbNailUrl = "testThumbNailUrl",
+      techStacks = listOf("testTechStack1", "testTechStack2"),
+      recruitments = recruitments,
+      description = "testDescription"
+    )
+    ReflectionTestUtils.setField(project, "id", "testId")
+    ReflectionTestUtils.setField(project, "createdAt", LocalDateTime.of(2021, 5, 1, 0, 0, 0))
+  }
+
+  afterSpec {
+    Dispatchers.resetMain()
+  }
+
+  describe("createProject") {
+    context("createProjectRequestDto가 주어지면") {
+      val requestDto = CreateProjectRequestDto(
+        title = project.title,
+        startDate = project.startDate,
+        endDate = project.endDate,
+        thumbNailUrl = project.thumbNailUrl,
+        techStacks = project.techStacks,
+        recruitments = project.recruitments.map { recruitment ->
+          RecruitmentRequestDto(
+            jobName = recruitment.jobName,
+            numberOfRecruitment = recruitment.numberOfRecruitment
+          )
+        }.toList(),
+        description = project.description
+      )
+      it("ProjectResponseDto를 반환한다") {
+        runTest {
+          coEvery { projectService.save(any()) } answers { project }
+          val result = projectFacadeService.createProject(userId, requestDto)
+
+          result.id shouldBe project.id
+          result.title shouldBe requestDto.title
+          result.startDate shouldBe requestDto.startDate
+          result.endDate shouldBe requestDto.endDate
+          result.thumbNailUrl shouldBe requestDto.thumbNailUrl
+          result.techStacks shouldBe requestDto.techStacks
+          result.recruitments.size shouldBe project.recruitments.size
+          result.recruitments.forEachIndexed { index, recruitmentResponseDto ->
+            recruitmentResponseDto.jobName shouldBe project.recruitments[index].jobName
+            recruitmentResponseDto.numberOfRecruitment shouldBe project.recruitments[index].numberOfRecruitment
+          }
+          result.description shouldBe requestDto.description
+          result.isCompleted shouldBe project.isCompleted
+          result.bookMarkers shouldBe project.bookMarkers
+          result.createdAt shouldBe project.createdAt
+        }
+      }
+    }
+  }
+})

--- a/src/test/kotlin/pmeet/pmeetserver/project/service/ProjectServiceUnitTest.kt
+++ b/src/test/kotlin/pmeet/pmeetserver/project/service/ProjectServiceUnitTest.kt
@@ -1,0 +1,87 @@
+package pmeet.pmeetserver.project.service
+
+import io.kotest.core.spec.style.DescribeSpec
+import io.kotest.matchers.shouldBe
+import io.mockk.every
+import io.mockk.mockk
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.setMain
+import pmeet.pmeetserver.project.domain.Project
+import pmeet.pmeetserver.project.domain.Recruitment
+import pmeet.pmeetserver.project.repository.ProjectRepository
+import reactor.core.publisher.Mono
+import java.time.LocalDateTime
+
+@ExperimentalCoroutinesApi
+internal class ProjectServiceUnitTest : DescribeSpec({
+
+//  isolationMode = IsolationMode.InstancePerLeaf
+
+  val testDispatcher = StandardTestDispatcher()
+
+  val projectRepository = mockk<ProjectRepository>(relaxed = true)
+
+  lateinit var projectService: ProjectService
+  lateinit var project: Project
+  lateinit var userId: String
+  lateinit var recruitments: List<Recruitment>
+
+  beforeSpec {
+    Dispatchers.setMain(testDispatcher)
+    projectService = ProjectService(projectRepository)
+
+    userId = "testUserId"
+    recruitments = listOf(
+      Recruitment(
+        jobName = "testJobName",
+        numberOfRecruitment = 1
+      ),
+      Recruitment(
+        jobName = "testJobName2",
+        numberOfRecruitment = 2
+      )
+    )
+
+    project = Project(
+      userId = userId,
+      title = "testTitle",
+      startDate = LocalDateTime.of(2021, 1, 1, 0, 0, 0),
+      endDate = LocalDateTime.of(2021, 12, 31, 23, 59, 59),
+      thumbNailUrl = "testThumbNailUrl",
+      techStacks = listOf("testTechStack1", "testTechStack2"),
+      recruitments = recruitments,
+      description = "testDescription"
+    )
+  }
+
+  afterSpec {
+    Dispatchers.resetMain()
+  }
+
+  describe("save") {
+    context("프로젝트 정보가 주어지면") {
+      it("저장 후 프로젝트를 반환한다") {
+        runTest {
+          every { projectRepository.save(any()) } answers { Mono.just(project) }
+
+          val result = projectService.save(project)
+
+          result.userId shouldBe userId
+          result.title shouldBe project.title
+          result.startDate shouldBe project.startDate
+          result.endDate shouldBe project.endDate
+          result.thumbNailUrl shouldBe project.thumbNailUrl
+          result.techStacks shouldBe project.techStacks
+          result.recruitments shouldBe project.recruitments
+          result.description shouldBe project.description
+          result.isCompleted shouldBe project.isCompleted
+          result.bookMarkers shouldBe project.bookMarkers
+        }
+      }
+    }
+  }
+})

--- a/src/test/kotlin/pmeet/pmeetserver/user/job/controller/JobControllerUnitTest.kt
+++ b/src/test/kotlin/pmeet/pmeetserver/user/job/controller/JobControllerUnitTest.kt
@@ -135,14 +135,22 @@ internal class JobControllerUnitTest : DescribeSpec() {
         }
       }
 
-      context("인증되지 않은 유저의 직무 생성 요청이 들어오면") {
-        val requestDto = CreateJobRequestDto("TestJob")
+      context("인증되지 않은 유저가 직무 이름으로 직무 검색 요청이 들어오면") {
+        val jobName = "TestJob"
+        val pageNumber = 0
+        val pageSize = 10
         val performRequest =
           webTestClient
-            .post()
-            .uri("/api/v1/jobs")
-            .bodyValue(requestDto)
+            .get()
+            .uri {
+              it.path("/api/v1/jobs/search")
+                .queryParam("name", jobName)
+                .queryParam("page", pageNumber)
+                .queryParam("size", pageSize)
+                .build()
+            }
             .exchange()
+
         it("요청은 실패한다") {
           performRequest.expectStatus().isUnauthorized
         }


### PR DESCRIPTION
## Related issue
resolves #96 

## Description
- DTO에 검증이 필요한 커스텀 검증 어노테이션 생성 (종료일 시작일 검증, 하위 DTO List의 Number Sum 검증)
- Project 도메인에 북마크 기능을 위한 참조 타입 UserId를 List로 가지게 하였음
## Changes detail
- 직무 컨트롤러에 누락된 `@Valid` 어노테이션 추가
- 직무 컨트롤러 유닛 테스트에서 search의 인증 권한이 없는 경우에 대한 테스트 수정
### Checklist
- [x] Test case
- [x] End of work
