### PR TITLE
refac: ForbiddenRequestException 추가 및 ErrorCode 디테일 분류

### DIFF
--- a/src/main/kotlin/pmeet/pmeetserver/common/ErrorCode.kt
+++ b/src/main/kotlin/pmeet/pmeetserver/common/ErrorCode.kt
@@ -12,23 +12,26 @@ enum class ErrorCode(private val code: String, private val message: String) {
   // User
   USER_DUPLICATE_BY_EMAIL("USER-40000", "중복된 이메일입니다."),
   USER_DUPLICATE_BY_NICKNAME("USER-40001", "중복된 닉네임입니다."),
-  USER_NOT_FOUND_BY_EMAIL("USER-40002", "해당하는 이메일의 유저를 찾을 수 없습니다."),
   INVALID_PASSWORD("USER-40003", "비밀번호를 다시 입력해 주세요."),
-  USER_NOT_FOUND_BY_NICKNAME("USER-40006", "해당하는 닉네임의 유저를 찾을 수 없습니다."),
-  USER_NOT_FOUND_BY_ID("USER-40007", "해당하는 ID의 유저를 찾을 수 없습니다."),
-  IS_DELETED_USER("USER-40008", "탈퇴한 유저입니다."),
+  IS_DELETED_USER("USER-40004", "탈퇴한 유저입니다."),
+
+  USER_NOT_FOUND_BY_EMAIL("USER-40400", "해당하는 이메일의 유저를 찾을 수 없습니다."),
+  USER_NOT_FOUND_BY_NICKNAME("USER-40401", "해당하는 닉네임의 유저를 찾을 수 없습니다."),
+  USER_NOT_FOUND_BY_ID("USER-40402", "해당하는 ID의 유저를 찾을 수 없습니다."),
 
   // Job
   JOB_DUPLICATE_BY_NAME("JOB-40000", "중복된 직무명입니다."),
 
   // TechStack
-  TECHSTACK_DUPLICATE_BY_NAME("TECHSTACH-40000", "중복된 기술스택입니다."),
+  TECHSTACK_DUPLICATE_BY_NAME("TECHSTACK-40000", "중복된 기술스택입니다."),
 
   // Resume
   RESUME_NUMBER_EXCEEDED("RESUME-40000", "이력서는 5개까지만 생성 가능합니다."),
-  RESUME_NOT_FOUND("RESUME-40001", "해당하는 ID 의 이력서를 찾을 수 없습니다."),
-  RESUME_UPDATE_UNAUTHORIZED("RESUME-40002", "해당하는 이력서를 수정할 권한이 없습니다."),
-  RESUME_DELETE_UNAUTHORIZED("RESUME-40003", "해당하는 이력서를 삭제할 권한이 없습니다.")
+
+  RESUME_UPDATE_FORBIDDEN("RESUME-40301", "해당하는 이력서를 수정할 권한이 없습니다."),
+  RESUME_DELETE_FORBIDDEN("RESUME-40302", "해당하는 이력서를 삭제할 권한이 없습니다."),
+
+  RESUME_NOT_FOUND("RESUME-40400", "해당하는 ID의 이력서를 찾을 수 없습니다.")
   ;
 
   fun getCode(): String {

--- a/src/main/kotlin/pmeet/pmeetserver/common/exception/ExceptionDto.kt
+++ b/src/main/kotlin/pmeet/pmeetserver/common/exception/ExceptionDto.kt
@@ -1,6 +1,4 @@
 package pmeet.pmeetserver.common.exception
 
-import pmeet.pmeetserver.common.ErrorCode
-
-data class ExceptionDto(val errorCode: ErrorCode, val message: String)
+data class ExceptionDto(val errorCode: String, val message: String)
 

--- a/src/main/kotlin/pmeet/pmeetserver/common/exception/ForbiddenRequestException.kt
+++ b/src/main/kotlin/pmeet/pmeetserver/common/exception/ForbiddenRequestException.kt
@@ -1,0 +1,5 @@
+package pmeet.pmeetserver.common.exception
+
+import pmeet.pmeetserver.common.ErrorCode
+
+class ForbiddenRequestException(val errorCode: ErrorCode) : RuntimeException(errorCode.getMessage()) {}

--- a/src/main/kotlin/pmeet/pmeetserver/common/exception/GlobalExceptionHandler.kt
+++ b/src/main/kotlin/pmeet/pmeetserver/common/exception/GlobalExceptionHandler.kt
@@ -25,20 +25,27 @@ class GlobalExceptionHandler {
   @ResponseStatus(HttpStatus.BAD_REQUEST)
   suspend fun handleEntityDuplicateException(exception: EntityDuplicateException): ExceptionDto {
     logger.error(exception) { "error: ${exception.message}" }
-    return ExceptionDto(exception.errorCode, exception.message!!)
+    return ExceptionDto(exception.errorCode.getCode(), exception.message!!)
   }
 
   @ExceptionHandler(value = [EntityNotFoundException::class])
   @ResponseStatus(HttpStatus.NOT_FOUND)
   suspend fun handleEntityNotFoundException(exception: EntityNotFoundException): ExceptionDto {
     logger.error(exception) { "error: ${exception.message}" }
-    return ExceptionDto(exception.errorCode, exception.message!!)
+    return ExceptionDto(exception.errorCode.getCode(), exception.message!!)
   }
 
   @ExceptionHandler(value = [UnauthorizedException::class])
   @ResponseStatus(HttpStatus.UNAUTHORIZED)
   suspend fun handleUnauthorizedExceptionException(exception: UnauthorizedException): ExceptionDto {
     logger.error(exception) { "error: ${exception.message}" }
-    return ExceptionDto(exception.errorCode, exception.message!!)
+    return ExceptionDto(exception.errorCode.getCode(), exception.message!!)
+  }
+
+  @ExceptionHandler(value = [ForbiddenRequestException::class])
+  @ResponseStatus(HttpStatus.FORBIDDEN)
+  suspend fun handleForbiddenRequestException(exception: ForbiddenRequestException): ExceptionDto {
+    logger.error(exception) { "error: ${exception.message}" }
+    return ExceptionDto(exception.errorCode.getCode(), exception.message!!)
   }
 }

--- a/src/main/kotlin/pmeet/pmeetserver/user/service/resume/ResumeFacadeService.kt
+++ b/src/main/kotlin/pmeet/pmeetserver/user/service/resume/ResumeFacadeService.kt
@@ -3,7 +3,7 @@ package pmeet.pmeetserver.user.service.resume
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 import pmeet.pmeetserver.common.ErrorCode
-import pmeet.pmeetserver.common.exception.UnauthorizedException
+import pmeet.pmeetserver.common.exception.ForbiddenRequestException
 import pmeet.pmeetserver.user.dto.resume.request.CreateResumeRequestDto
 import pmeet.pmeetserver.user.dto.resume.request.DeleteResumeRequestDto
 import pmeet.pmeetserver.user.dto.resume.request.UpdateResumeRequestDto
@@ -29,7 +29,7 @@ class ResumeFacadeService(
   suspend fun updateResume(userId: String, requestDto: UpdateResumeRequestDto): ResumeResponseDto {
     val originalResume = resumeService.getByResumeId(requestDto.id);
     if (!originalResume.userId.equals(userId)) {
-      throw UnauthorizedException(ErrorCode.RESUME_UPDATE_UNAUTHORIZED)
+      throw ForbiddenRequestException(ErrorCode.RESUME_UPDATE_FORBIDDEN)
     }
     val updateResume = originalResume.update(
       title = requestDto.title,
@@ -40,7 +40,8 @@ class ResumeFacadeService(
       projectExperiences = requestDto.projectExperiences.map { it.toEntity() },
       portfolioFileUrl = requestDto.portfolioFileUrl,
       portfolioUrl = requestDto.portfolioUrl,
-      selfDescription = requestDto.selfDescription)
+      selfDescription = requestDto.selfDescription
+    )
     return ResumeResponseDto.from(resumeService.update(updateResume))
   }
 
@@ -48,7 +49,7 @@ class ResumeFacadeService(
   suspend fun deleteResume(requestDto: DeleteResumeRequestDto) {
     val originalResume = resumeService.getByResumeId(requestDto.id);
     if (!originalResume.userId.equals(requestDto.userId)) {
-      throw UnauthorizedException(ErrorCode.RESUME_DELETE_UNAUTHORIZED)
+      throw ForbiddenRequestException(ErrorCode.RESUME_DELETE_FORBIDDEN)
     }
     resumeService.delete(originalResume)
   }

--- a/src/test/kotlin/pmeet/pmeetserver/user/resume/service/ResumeFacadeServiceUnitTest.kt
+++ b/src/test/kotlin/pmeet/pmeetserver/user/resume/service/ResumeFacadeServiceUnitTest.kt
@@ -15,7 +15,7 @@ import kotlinx.coroutines.test.runTest
 import kotlinx.coroutines.test.setMain
 import pmeet.pmeetserver.common.ErrorCode
 import pmeet.pmeetserver.common.exception.EntityNotFoundException
-import pmeet.pmeetserver.common.exception.UnauthorizedException
+import pmeet.pmeetserver.common.exception.ForbiddenRequestException
 import pmeet.pmeetserver.user.domain.resume.Resume
 import pmeet.pmeetserver.user.dto.resume.request.DeleteResumeRequestDto
 import pmeet.pmeetserver.user.resume.ResumeGenerator.createMockCreateResumeRequestDto
@@ -111,16 +111,16 @@ class ResumeFacadeServiceUnitTest : DescribeSpec({
           exception.errorCode shouldBe ErrorCode.RESUME_NOT_FOUND
         }
       }
-      it("권한이 없는 userId 로 업데이트 시도 시 UnauthorizedException 발생시킨다") {
+      it("권한이 없는 userId 로 업데이트 시도 시 ForbiddenRequestException 발생시킨다") {
         runTest {
           coEvery { resumeService.getByResumeId(any()) } answers { resume }
 
           val updateRequest = createMockUpdateResumeRequestDto()
 
-          val exception = shouldThrow<UnauthorizedException> {
+          val exception = shouldThrow<ForbiddenRequestException> {
             resumeFacadeService.updateResume("no-auth-user", updateRequest)
           }
-          exception.errorCode shouldBe ErrorCode.RESUME_UPDATE_UNAUTHORIZED
+          exception.errorCode shouldBe ErrorCode.RESUME_UPDATE_FORBIDDEN
         }
       }
     }
@@ -151,7 +151,7 @@ class ResumeFacadeServiceUnitTest : DescribeSpec({
         }
       }
 
-      it("권한이 없는 userId 로 삭제 시도 시 UnauthorizedException 발생시킨다") {
+      it("권한이 없는 userId 로 삭제 시도 시 ForbiddenRequestException 발생시킨다") {
         runTest {
           coEvery { resumeService.getByResumeId(any()) } answers { resume }
 
@@ -160,10 +160,10 @@ class ResumeFacadeServiceUnitTest : DescribeSpec({
             userId = "John-id-wrong",
           )
 
-          val exception = shouldThrow<UnauthorizedException> {
+          val exception = shouldThrow<ForbiddenRequestException> {
             resumeFacadeService.deleteResume(deleteRequest)
           }
-          exception.errorCode shouldBe ErrorCode.RESUME_DELETE_UNAUTHORIZED
+          exception.errorCode shouldBe ErrorCode.RESUME_DELETE_FORBIDDEN
         }
       }
     }


### PR DESCRIPTION
## Related issue

## Description
- 권한 없음(403) 을 나타내는 `ForbiddenRequestException` 추가
## Changes detail
- `ForbiddenRequestException` Handler 추가
- ErrorCode의 Code가 400인 것들을 세분화
- ErrorCode의 Enum 이름 대신 Code 필드를 반환하게 수정(이미지 확인)

- Before ![image](https://github.com/user-attachments/assets/5c596a41-d910-4f20-8cdd-c980d01fcfe9)
- After ![image](https://github.com/user-attachments/assets/30aaa2d1-2a63-47f5-a384-681a44dfddbc)


### Checklist
- [x] Test case
- [x] End of work
