### PR TITLE
feat: 프밋 모집 게시글 수정, 프밋 모집 게시글 UpdatedAt 추가

### DIFF
--- a/src/main/kotlin/pmeet/pmeetserver/common/ErrorCode.kt
+++ b/src/main/kotlin/pmeet/pmeetserver/common/ErrorCode.kt
@@ -34,8 +34,10 @@ enum class ErrorCode(private val code: String, private val message: String) {
   RESUME_ACTIVE_CHANGE_FORBIDDEN("RESUME-40304", "해당하는 이력서의 프미팅 상태를 변경할 권한이 없습니다."),
   RESUME_NOT_FOUND("RESUME-40400", "해당하는 ID의 이력서를 찾을 수 없습니다."),
 
-  // Porject
-  PROJECT_NOT_FOUND("PROJECT-40400", "해당하는 ID의 프로젝트를 찾을 수 없습니다.")
+  // Project
+  PROJECT_NOT_FOUND("PROJECT-40400", "해당하는 ID의 프로젝트를 찾을 수 없습니다."),
+
+  PROJECT_UPDATE_FORBIDDEN("PROJECT-40300", "해당하는 프로젝트를 수정할 권한이 없습니다.")
 
   ;
 

--- a/src/main/kotlin/pmeet/pmeetserver/project/controller/ProjectController.kt
+++ b/src/main/kotlin/pmeet/pmeetserver/project/controller/ProjectController.kt
@@ -5,11 +5,13 @@ import kotlinx.coroutines.reactor.awaitSingle
 import org.springframework.http.HttpStatus
 import org.springframework.security.core.annotation.AuthenticationPrincipal
 import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.PutMapping
 import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.ResponseStatus
 import org.springframework.web.bind.annotation.RestController
 import pmeet.pmeetserver.project.dto.request.CreateProjectRequestDto
+import pmeet.pmeetserver.project.dto.request.UpdateProjectRequestDto
 import pmeet.pmeetserver.project.dto.response.ProjectResponseDto
 import pmeet.pmeetserver.project.service.ProjectFacadeService
 import reactor.core.publisher.Mono
@@ -27,5 +29,14 @@ class ProjectController(
     @RequestBody @Valid requestDto: CreateProjectRequestDto
   ): ProjectResponseDto {
     return projectFacadeService.createProject(userId.awaitSingle(), requestDto)
+  }
+
+  @PutMapping
+  @ResponseStatus(HttpStatus.OK)
+  suspend fun updateProject(
+    @AuthenticationPrincipal userId: Mono<String>,
+    @RequestBody @Valid requestDto: UpdateProjectRequestDto
+  ): ProjectResponseDto {
+    return projectFacadeService.updateProject(userId.awaitSingle(), requestDto)
   }
 }

--- a/src/main/kotlin/pmeet/pmeetserver/project/domain/Project.kt
+++ b/src/main/kotlin/pmeet/pmeetserver/project/domain/Project.kt
@@ -27,4 +27,23 @@ class Project(
   var bookMarkers: List<String> = mutableListOf(), // 북마크를 한 유저 ID 리스트
   val createdAt: LocalDateTime = LocalDateTime.now()
 ) {
+
+  fun update(
+    title: String? = null,
+    startDate: LocalDateTime? = null,
+    endDate: LocalDateTime? = null,
+    thumbNailUrl: String? = null,
+    techStacks: List<String>? = null,
+    recruitments: List<Recruitment>? = null,
+    description: String? = null
+  ) = apply {
+    title?.let { this.title = it }
+    startDate?.let { this.startDate = it }
+    endDate?.let { this.endDate = it }
+    thumbNailUrl?.let { this.thumbNailUrl = it }
+    techStacks?.let { this.techStacks = it }
+    recruitments?.let { this.recruitments = it }
+    description?.let { this.description = it }
+  }
+
 }

--- a/src/main/kotlin/pmeet/pmeetserver/project/domain/Project.kt
+++ b/src/main/kotlin/pmeet/pmeetserver/project/domain/Project.kt
@@ -25,7 +25,8 @@ class Project(
   var description: String,
   var isCompleted: Boolean = false,
   var bookMarkers: List<String> = mutableListOf(), // 북마크를 한 유저 ID 리스트
-  val createdAt: LocalDateTime = LocalDateTime.now()
+  val createdAt: LocalDateTime = LocalDateTime.now(),
+  var updatedAt: LocalDateTime = LocalDateTime.now() // 조회 시 정렬을 위해 now()로 초기화
 ) {
 
   fun update(
@@ -44,6 +45,7 @@ class Project(
     techStacks?.let { this.techStacks = it }
     recruitments?.let { this.recruitments = it }
     description?.let { this.description = it }
+    this.updatedAt = LocalDateTime.now()
   }
 
 }

--- a/src/main/kotlin/pmeet/pmeetserver/project/dto/request/UpdateProjectRequestDto.kt
+++ b/src/main/kotlin/pmeet/pmeetserver/project/dto/request/UpdateProjectRequestDto.kt
@@ -1,0 +1,41 @@
+package pmeet.pmeetserver.project.dto.request
+
+import jakarta.validation.Valid
+import jakarta.validation.constraints.NotBlank
+import jakarta.validation.constraints.NotEmpty
+import jakarta.validation.constraints.NotNull
+import jakarta.validation.constraints.Pattern
+import jakarta.validation.constraints.Size
+import org.hibernate.validator.constraints.UniqueElements
+import pmeet.pmeetserver.project.validation.annotation.TotalSumMax
+import pmeet.pmeetserver.project.validation.annotation.ValidDateRange
+import java.time.LocalDateTime
+
+@ValidDateRange
+data class UpdateProjectRequestDto(
+  @field:NotBlank(message = "프로젝트 ID는 필수입니다.")
+  val id: String,
+  @field:NotBlank(message = "프로젝트 제목은 필수입니다.")
+  @field:Size(min = 1, max = 30, message = "프로젝트 제목은 1자에서 30자 사이여야 합니다.")
+  @field:Pattern(
+    regexp = "^[가-힣a-zA-Z0-9\\p{Punct}\\s]*$",
+    message = "프로젝트 제목은 한글, 영어, 숫자, 문장부호만 입력 가능합니다."
+  )
+  val title: String,
+  @field:NotNull(message = "프로젝트 시작일은 필수입니다.")
+  val startDate: LocalDateTime,
+  @field:NotNull(message = "프로젝트 종료일은 필수입니다.")
+  val endDate: LocalDateTime,
+  val thumbNailUrl: String? = null,
+  @field:Size(max = 5, message = "기술 스택은 5개까지만 입력 가능합니다.")
+  @field:UniqueElements(message = "기술 스택은 중복되지 않아야 합니다.")
+  val techStacks: List<String>? = mutableListOf(),
+  @field:NotEmpty(message = "프로젝트 모집 정보는 필수입니다.")
+  @field:Valid
+  @field:TotalSumMax(sum = 30, element = "numberOfRecruitment", message = "모집 인원의 합은 30명을 초과할 수 없습니다.")
+  val recruitments: List<RecruitmentRequestDto>,
+  @field:NotBlank(message = "프로젝트 설명은 필수입니다.")
+  @field:Size(min = 1, max = 2000, message = "프로젝트 설명은 1자에서 2000자 사이여야 합니다.")
+  val description: String,
+) {
+}

--- a/src/main/kotlin/pmeet/pmeetserver/project/service/ProjectService.kt
+++ b/src/main/kotlin/pmeet/pmeetserver/project/service/ProjectService.kt
@@ -24,4 +24,9 @@ class ProjectService(
     return projectRepository.findById(projectId).awaitSingleOrNull()
       ?: throw EntityNotFoundException(ErrorCode.PROJECT_NOT_FOUND)
   }
+
+  @Transactional
+  suspend fun update(project: Project): Project {
+    return projectRepository.save(project).awaitSingle()
+  }
 }

--- a/src/test/kotlin/pmeet/pmeetserver/project/controller/ProjectControllerUnitTest.kt
+++ b/src/test/kotlin/pmeet/pmeetserver/project/controller/ProjectControllerUnitTest.kt
@@ -15,6 +15,7 @@ import org.springframework.test.web.reactive.server.expectBody
 import pmeet.pmeetserver.config.TestSecurityConfig
 import pmeet.pmeetserver.project.dto.request.CreateProjectRequestDto
 import pmeet.pmeetserver.project.dto.request.RecruitmentRequestDto
+import pmeet.pmeetserver.project.dto.request.UpdateProjectRequestDto
 import pmeet.pmeetserver.project.dto.response.ProjectResponseDto
 import pmeet.pmeetserver.project.dto.response.RecruitmentResponseDto
 import pmeet.pmeetserver.project.service.ProjectFacadeService
@@ -32,44 +33,35 @@ internal class ProjectControllerUnitTest : DescribeSpec() {
 
   init {
     describe("POST api/v1/projects") {
-      context("인증된 유저의 프로젝트 생성 요청이 들어오면") {
+      val requestDto = CreateProjectRequestDto(
+        title = "TestTitlet",
+        startDate = LocalDateTime.of(2021, 1, 1, 0, 0, 0),
+        endDate = LocalDateTime.of(2021, 12, 31, 23, 59, 59),
+        thumbNailUrl = "testThumbNailUrl",
+        techStacks = listOf("testTechStack1", "testTechStack2"),
+        recruitments = listOf(
+          RecruitmentRequestDto(
+            jobName = "testJobName1",
+            numberOfRecruitment = 1
+          ),
+          RecruitmentRequestDto(
+            jobName = "testJobName2",
+            numberOfRecruitment = 2
+          )
+        ),
+        description = "testDescription"
+      )
+      context("인증된 유저의 Project 생성 요청이 들어오면") {
         val userId = "1234"
-        val requestDto = CreateProjectRequestDto(
-          title = "TestProject",
-          startDate = LocalDateTime.of(2021, 1, 1, 0, 0, 0),
-          endDate = LocalDateTime.of(2021, 12, 31, 23, 59, 59),
-          thumbNailUrl = "testThumbNailUrl",
-          techStacks = listOf("testTechStack1", "testTechStack2"),
-          recruitments = listOf(
-            RecruitmentRequestDto(
-              jobName = "testJobName",
-              numberOfRecruitment = 1
-            ),
-            RecruitmentRequestDto(
-              jobName = "testJobName2",
-              numberOfRecruitment = 2
-            )
-          ),
-          description = "testDescription"
-        )
         val responseDto = ProjectResponseDto(
-          id = "1234",
-          title = "TestProject",
-          startDate = LocalDateTime.of(2021, 1, 1, 0, 0, 0),
-          endDate = LocalDateTime.of(2021, 12, 31, 23, 59, 59),
-          thumbNailUrl = "testThumbNailUrl",
-          techStacks = listOf("testTechStack1", "testTechStack2"),
-          recruitments = listOf(
-            RecruitmentResponseDto(
-              jobName = "testJobName",
-              numberOfRecruitment = 1
-            ),
-            RecruitmentResponseDto(
-              jobName = "testJobName2",
-              numberOfRecruitment = 2
-            )
-          ),
-          description = "testDescription",
+          id = "testId",
+          title = requestDto.title,
+          startDate = requestDto.startDate,
+          endDate = requestDto.endDate,
+          thumbNailUrl = requestDto.thumbNailUrl,
+          techStacks = requestDto.techStacks!!,
+          recruitments = requestDto.recruitments.map { RecruitmentResponseDto(it.jobName, it.numberOfRecruitment) },
+          description = requestDto.description,
           userId = userId,
           bookMarkers = mutableListOf(),
           isCompleted = false,
@@ -94,7 +86,7 @@ internal class ProjectControllerUnitTest : DescribeSpec() {
           performRequest.expectStatus().isCreated
         }
 
-        it("생성된 프로젝트 정보를 반환한다") {
+        it("생성된 Project 정보를 반환한다") {
           performRequest.expectBody<ProjectResponseDto>().consumeWith { response ->
             response.responseBody?.id shouldBe responseDto.id
             response.responseBody?.title shouldBe responseDto.title
@@ -116,28 +108,100 @@ internal class ProjectControllerUnitTest : DescribeSpec() {
         }
       }
 
-      context("인증되지 않은 유저의 프로젝트 생성 요청이 들어오면") {
-        val requestDto = CreateProjectRequestDto(
-          title = "TestProject",
-          startDate = LocalDateTime.of(2021, 1, 1, 0, 0, 0),
-          endDate = LocalDateTime.of(2021, 12, 31, 23, 59, 59),
-          thumbNailUrl = "testThumbNailUrl",
-          techStacks = listOf("testTechStack1", "testTechStack2"),
-          recruitments = listOf(
-            RecruitmentRequestDto(
-              jobName = "testJobName",
-              numberOfRecruitment = 1
-            ),
-            RecruitmentRequestDto(
-              jobName = "testJobName2",
-              numberOfRecruitment = 2
-            )
-          ),
-          description = "testDescription"
-        )
+      context("인증되지 않은 유저의 Project 생성 요청이 들어오면") {
         val performRequest =
           webTestClient
             .post()
+            .uri("/api/v1/projects")
+            .bodyValue(requestDto)
+            .exchange()
+
+        it("요청은 실패한다") {
+          performRequest.expectStatus().isUnauthorized
+        }
+      }
+    }
+
+    describe("PUT api/v1/projects") {
+      val requestDto = UpdateProjectRequestDto(
+        id = "testId",
+        title = "updateProject",
+        startDate = LocalDateTime.of(2024, 7, 20, 0, 0, 0),
+        endDate = LocalDateTime.of(2024, 7, 22, 0, 0, 0),
+        thumbNailUrl = "updateThumbNailUrl",
+        techStacks = listOf("updateTechStack1", "updateTechStack2"),
+        recruitments = listOf(
+          RecruitmentRequestDto(
+            jobName = "updateJobName1",
+            numberOfRecruitment = 3
+          ),
+          RecruitmentRequestDto(
+            jobName = "updateJobName2",
+            numberOfRecruitment = 4
+          )
+        ),
+        description = "updateDescription"
+      )
+      context("인증된 유저의 Project 수정 요청이 들어오면") {
+        val userId = "1234"
+        val responseDto = ProjectResponseDto(
+          id = requestDto.id,
+          title = requestDto.title,
+          startDate = requestDto.startDate,
+          endDate = requestDto.endDate,
+          thumbNailUrl = requestDto.thumbNailUrl,
+          techStacks = requestDto.techStacks!!,
+          recruitments = requestDto.recruitments.map { RecruitmentResponseDto(it.jobName, it.numberOfRecruitment) },
+          description = requestDto.description,
+          userId = userId,
+          bookMarkers = mutableListOf(),
+          isCompleted = false,
+          createdAt = LocalDateTime.of(2021, 5, 1, 0, 0, 0)
+        )
+
+        coEvery { projectFacadeService.updateProject(userId, requestDto) } answers { responseDto }
+        val mockAuthentication = UsernamePasswordAuthenticationToken(userId, null, null)
+        val performRequest =
+          webTestClient
+            .mutateWith(mockAuthentication(mockAuthentication))
+            .put()
+            .uri("/api/v1/projects")
+            .bodyValue(requestDto)
+            .exchange()
+
+        it("서비스를 통해 데이터를 수정한다") {
+          coVerify(exactly = 1) { projectFacadeService.updateProject(userId, requestDto) }
+        }
+
+        it("요청은 성공한다") {
+          performRequest.expectStatus().isOk
+        }
+
+        it("수정된 Project 정보를 반환한다") {
+          performRequest.expectBody<ProjectResponseDto>().consumeWith { response ->
+            response.responseBody?.id shouldBe responseDto.id
+            response.responseBody?.title shouldBe responseDto.title
+            response.responseBody?.startDate shouldBe responseDto.startDate
+            response.responseBody?.endDate shouldBe responseDto.endDate
+            response.responseBody?.thumbNailUrl shouldBe responseDto.thumbNailUrl
+            response.responseBody?.techStacks shouldBe responseDto.techStacks
+            response.responseBody?.recruitments!!.size shouldBe responseDto.recruitments.size
+            response.responseBody?.recruitments!!.forEachIndexed { index, recruitmentResponseDto ->
+              recruitmentResponseDto.jobName shouldBe responseDto.recruitments[index].jobName
+              recruitmentResponseDto.numberOfRecruitment shouldBe responseDto.recruitments[index].numberOfRecruitment
+            }
+            response.responseBody?.description shouldBe responseDto.description
+            response.responseBody?.userId shouldBe responseDto.userId
+            response.responseBody?.bookMarkers shouldBe responseDto.bookMarkers
+            response.responseBody?.isCompleted shouldBe responseDto.isCompleted
+            response.responseBody?.createdAt shouldBe responseDto.createdAt
+          }
+        }
+      }
+      context("인증되지 않은 유저의 Project 수정 요청이 들어오면") {
+        val performRequest =
+          webTestClient
+            .put()
             .uri("/api/v1/projects")
             .bodyValue(requestDto)
             .exchange()

--- a/src/test/kotlin/pmeet/pmeetserver/project/service/ProjectServiceUnitTest.kt
+++ b/src/test/kotlin/pmeet/pmeetserver/project/service/ProjectServiceUnitTest.kt
@@ -86,6 +86,8 @@ internal class ProjectServiceUnitTest : DescribeSpec({
           result.description shouldBe project.description
           result.isCompleted shouldBe project.isCompleted
           result.bookMarkers shouldBe project.bookMarkers
+          result.createdAt shouldBe project.createdAt
+          result.updatedAt shouldBe project.updatedAt
         }
       }
     }
@@ -110,6 +112,8 @@ internal class ProjectServiceUnitTest : DescribeSpec({
           result.description shouldBe project.description
           result.isCompleted shouldBe project.isCompleted
           result.bookMarkers shouldBe project.bookMarkers
+          result.createdAt shouldBe project.createdAt
+          result.updatedAt shouldBe project.updatedAt
         }
       }
     }
@@ -166,6 +170,8 @@ internal class ProjectServiceUnitTest : DescribeSpec({
           result.description shouldBe updatedProject.description
           result.isCompleted shouldBe updatedProject.isCompleted
           result.bookMarkers shouldBe updatedProject.bookMarkers
+          result.updatedAt shouldBe updatedProject.updatedAt
+          result.createdAt shouldBe updatedProject.createdAt
         }
       }
     }

--- a/src/test/kotlin/pmeet/pmeetserver/project/service/ProjectServiceUnitTest.kt
+++ b/src/test/kotlin/pmeet/pmeetserver/project/service/ProjectServiceUnitTest.kt
@@ -1,5 +1,6 @@
 package pmeet.pmeetserver.project.service
 
+import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.core.spec.style.DescribeSpec
 import io.kotest.matchers.shouldBe
 import io.mockk.every
@@ -10,6 +11,9 @@ import kotlinx.coroutines.test.StandardTestDispatcher
 import kotlinx.coroutines.test.resetMain
 import kotlinx.coroutines.test.runTest
 import kotlinx.coroutines.test.setMain
+import org.springframework.test.util.ReflectionTestUtils
+import pmeet.pmeetserver.common.ErrorCode
+import pmeet.pmeetserver.common.exception.EntityNotFoundException
 import pmeet.pmeetserver.project.domain.Project
 import pmeet.pmeetserver.project.domain.Recruitment
 import pmeet.pmeetserver.project.repository.ProjectRepository
@@ -56,6 +60,7 @@ internal class ProjectServiceUnitTest : DescribeSpec({
       recruitments = recruitments,
       description = "testDescription"
     )
+    ReflectionTestUtils.setField(project, "id", "testProjectId")
   }
 
   afterSpec {
@@ -63,14 +68,15 @@ internal class ProjectServiceUnitTest : DescribeSpec({
   }
 
   describe("save") {
-    context("프로젝트 정보가 주어지면") {
+    context("프로젝트 객체가 주어지면") {
       it("저장 후 프로젝트를 반환한다") {
         runTest {
           every { projectRepository.save(any()) } answers { Mono.just(project) }
 
           val result = projectService.save(project)
 
-          result.userId shouldBe userId
+          result.id shouldBe project.id
+          result.userId shouldBe project.userId
           result.title shouldBe project.title
           result.startDate shouldBe project.startDate
           result.endDate shouldBe project.endDate
@@ -80,6 +86,86 @@ internal class ProjectServiceUnitTest : DescribeSpec({
           result.description shouldBe project.description
           result.isCompleted shouldBe project.isCompleted
           result.bookMarkers shouldBe project.bookMarkers
+        }
+      }
+    }
+  }
+
+  describe("getProjectById") {
+    context("존재하는 Project Id가 주어지면") {
+      it("Project를 반환한다") {
+        runTest {
+          every { projectRepository.findById(project.id!!) } answers { Mono.just(project) }
+
+          val result = projectService.getProjectById(project.id!!)
+
+          result.id shouldBe project.id
+          result.userId shouldBe project.userId
+          result.title shouldBe project.title
+          result.startDate shouldBe project.startDate
+          result.endDate shouldBe project.endDate
+          result.thumbNailUrl shouldBe project.thumbNailUrl
+          result.techStacks shouldBe project.techStacks
+          result.recruitments shouldBe project.recruitments
+          result.description shouldBe project.description
+          result.isCompleted shouldBe project.isCompleted
+          result.bookMarkers shouldBe project.bookMarkers
+        }
+      }
+    }
+    context("존재하지 않는 Project Id가 주어지면") {
+      it("NotFoundException을 던진다") {
+        runTest {
+          every { projectRepository.findById("nonExistProjectId") } answers { Mono.empty() }
+
+          val exception = shouldThrow<EntityNotFoundException> {
+            projectService.getProjectById("nonExistProjectId")
+          }
+
+          exception.errorCode shouldBe ErrorCode.PROJECT_NOT_FOUND
+        }
+      }
+    }
+  }
+
+  describe("update") {
+    context("업데이트 된 Project 객체가 주어지면") {
+      val updatedProject = project.update(
+        title = "updatedTitle",
+        startDate = LocalDateTime.of(2022, 1, 1, 0, 0, 0),
+        endDate = LocalDateTime.of(2022, 12, 31, 23, 59, 59),
+        thumbNailUrl = "updatedThumbNailUrl",
+        techStacks = listOf("updatedTechStack1", "updatedTechStack2"),
+        recruitments = listOf(
+          Recruitment(
+            jobName = "updatedJobName",
+            numberOfRecruitment = 3
+          ),
+          Recruitment(
+            jobName = "updatedJobName2",
+            numberOfRecruitment = 4
+          )
+        ),
+        description = "updatedDescription"
+      )
+      it("저장 후 Project를 반환한다") {
+        runTest {
+
+          every { projectRepository.save(updatedProject) } answers { Mono.just(updatedProject) }
+
+          val result = projectService.update(updatedProject)
+
+          result.id shouldBe updatedProject.id
+          result.userId shouldBe updatedProject.userId
+          result.title shouldBe updatedProject.title
+          result.startDate shouldBe updatedProject.startDate
+          result.endDate shouldBe updatedProject.endDate
+          result.thumbNailUrl shouldBe updatedProject.thumbNailUrl
+          result.techStacks shouldBe updatedProject.techStacks
+          result.recruitments shouldBe updatedProject.recruitments
+          result.description shouldBe updatedProject.description
+          result.isCompleted shouldBe updatedProject.isCompleted
+          result.bookMarkers shouldBe updatedProject.bookMarkers
         }
       }
     }

--- a/src/test/kotlin/pmeet/pmeetserver/user/resume/service/ResumeServiceUnitTest.kt
+++ b/src/test/kotlin/pmeet/pmeetserver/user/resume/service/ResumeServiceUnitTest.kt
@@ -145,7 +145,6 @@ internal class ResumeServiceUnitTest : DescribeSpec({
       it("저장 후 이력서를 반환한다") {
         runTest {
           val resumeUpdateRequestDto = createMockUpdateResumeRequestDto();
-          every { resumeRepository.findByIdAndUserId("resume-id", "John-id") } answers { Mono.just(resume) }
           every { resumeRepository.save(any()) } answers { Mono.just(generateUpdatedResume()) }
 
           val result = resumeService.update(generateUpdatedResume())


### PR DESCRIPTION
## Related issue
resolves #99 
resolves #97 

## Description
 - `Project` 객체의 필드를 수정하는 `update` 메서드
 -  북마크, 완료여부는 분리된 API로 수정될 예정으로 도메인 `update` 메서드에서 제외
## Changes detail
- `getProjectById` 테스트가 없어서 추가 
- `ResumeServiceUnitTest`에 불 필요한 모킹 제거
-  통합 테스트에서 `Project` 생성자에 id 추가
![image](https://github.com/user-attachments/assets/9f640728-7bff-403e-93ed-511b751a2e92)

- UpdatedAt 추가 
### Checklist
- [x] Test case
- [x] End of work
