### PR TITLE
feat: 프밋 모집 게시글 영구 삭제

### DIFF
--- a/src/main/kotlin/pmeet/pmeetserver/common/ErrorCode.kt
+++ b/src/main/kotlin/pmeet/pmeetserver/common/ErrorCode.kt
@@ -37,6 +37,7 @@ enum class ErrorCode(private val code: String, private val message: String) {
   // Project
   PROJECT_NOT_FOUND("PROJECT-40400", "해당하는 ID의 프로젝트를 찾을 수 없습니다."),
   PROJECT_UPDATE_FORBIDDEN("PROJECT-40300", "해당하는 프로젝트를 수정할 권한이 없습니다."),
+  PROJECT_DELETE_FORBIDDEN("PROJECT-40301", "해당하는 프로젝트를 삭제할 권한이 없습니다."),
 
   // Project Comment
   PROJECT_COMMENT_NOT_FOUND("PROJECT-COMMENT-40400", "해당하는 ID의 댓글을 찾을 수 없습니다."),

--- a/src/main/kotlin/pmeet/pmeetserver/project/controller/ProjectController.kt
+++ b/src/main/kotlin/pmeet/pmeetserver/project/controller/ProjectController.kt
@@ -4,6 +4,8 @@ import jakarta.validation.Valid
 import kotlinx.coroutines.reactor.awaitSingle
 import org.springframework.http.HttpStatus
 import org.springframework.security.core.annotation.AuthenticationPrincipal
+import org.springframework.web.bind.annotation.DeleteMapping
+import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.PutMapping
 import org.springframework.web.bind.annotation.RequestBody
@@ -38,5 +40,14 @@ class ProjectController(
     @RequestBody @Valid requestDto: UpdateProjectRequestDto
   ): ProjectResponseDto {
     return projectFacadeService.updateProject(userId.awaitSingle(), requestDto)
+  }
+
+  @DeleteMapping("/{projectId}")
+  @ResponseStatus(HttpStatus.NO_CONTENT)
+  suspend fun deleteProject(
+    @AuthenticationPrincipal userId: Mono<String>,
+    @PathVariable projectId: String
+  ) {
+    projectFacadeService.deleteProject(userId.awaitSingle(), projectId)
   }
 }

--- a/src/main/kotlin/pmeet/pmeetserver/project/repository/ProjectCommentRepository.kt
+++ b/src/main/kotlin/pmeet/pmeetserver/project/repository/ProjectCommentRepository.kt
@@ -3,8 +3,11 @@ package pmeet.pmeetserver.project.repository
 import org.springframework.data.mongodb.repository.ReactiveMongoRepository
 import pmeet.pmeetserver.project.domain.ProjectComment
 import reactor.core.publisher.Flux
+import reactor.core.publisher.Mono
 
 interface ProjectCommentRepository : ReactiveMongoRepository<ProjectComment, String> {
   fun findByProjectId(projectId: String): Flux<ProjectComment>
-}
 
+  fun deleteByProjectId(projectId: String): Mono<Void> // 프로젝트 ID로 삭제
+
+}

--- a/src/main/kotlin/pmeet/pmeetserver/project/service/ProjectCommentService.kt
+++ b/src/main/kotlin/pmeet/pmeetserver/project/service/ProjectCommentService.kt
@@ -24,4 +24,9 @@ class ProjectCommentService(
     return projectCommentRepository.findById(projectCommentId).awaitSingleOrNull()
       ?: throw EntityNotFoundException(ErrorCode.PROJECT_COMMENT_NOT_FOUND)
   }
+  
+  @Transactional
+  suspend fun deleteAllByProjectId(projectId: String) {
+    projectCommentRepository.deleteByProjectId(projectId).awaitSingleOrNull()
+  }
 }

--- a/src/main/kotlin/pmeet/pmeetserver/project/service/ProjectFacadeService.kt
+++ b/src/main/kotlin/pmeet/pmeetserver/project/service/ProjectFacadeService.kt
@@ -91,4 +91,16 @@ class ProjectFacadeService(
 
     return ProjectCommentResponseDto.from(projectCommentService.save(comment))
   }
+
+  @Transactional
+  suspend fun deleteProject(usedId: String, projectId: String) {
+    val project = projectService.getProjectById(projectId)
+
+    if (project.userId != usedId) {
+      throw ForbiddenRequestException(ErrorCode.PROJECT_DELETE_FORBIDDEN)
+    }
+
+    projectCommentService.deleteAllByProjectId(projectId)
+    projectService.delete(project)
+  }
 }

--- a/src/main/kotlin/pmeet/pmeetserver/project/service/ProjectService.kt
+++ b/src/main/kotlin/pmeet/pmeetserver/project/service/ProjectService.kt
@@ -29,4 +29,9 @@ class ProjectService(
   suspend fun update(project: Project): Project {
     return projectRepository.save(project).awaitSingle()
   }
+
+  @Transactional
+  suspend fun delete(project: Project) {
+    projectRepository.delete(project).awaitSingleOrNull()
+  }
 }

--- a/src/test/kotlin/pmeet/pmeetserver/project/controller/ProjectControllerUnitTest.kt
+++ b/src/test/kotlin/pmeet/pmeetserver/project/controller/ProjectControllerUnitTest.kt
@@ -211,5 +211,48 @@ internal class ProjectControllerUnitTest : DescribeSpec() {
         }
       }
     }
+
+    describe("DELETE api/v1/projects/{projectId}") {
+      val projectId = "testProjectId"
+      context("인증된 유저의 Project 삭제 요청이 들어오면") {
+        val userId = "1234"
+        coEvery { projectFacadeService.deleteProject(userId, projectId) } answers { Unit }
+        val mockAuthentication = UsernamePasswordAuthenticationToken(userId, null, null)
+        val performRequest =
+          webTestClient
+            .mutateWith(mockAuthentication(mockAuthentication))
+            .delete()
+            .uri {
+              it.path("/api/v1/projects")
+                .path("/$projectId")
+                .build()
+            }
+            .exchange()
+
+        it("서비스를 통해 데이터를 삭제한다") {
+          coVerify(exactly = 1) { projectFacadeService.deleteProject(userId, projectId) }
+        }
+
+        it("요청은 성공한다") {
+          performRequest.expectStatus().isNoContent
+        }
+      }
+
+      context("인증되지 않은 유저의 Project 삭제 요청이 들어오면") {
+        val performRequest =
+          webTestClient
+            .delete()
+            .uri {
+              it.path("/api/v1/projects")
+                .path("/$projectId")
+                .build()
+            }
+            .exchange()
+
+        it("요청은 실패한다") {
+          performRequest.expectStatus().isUnauthorized
+        }
+      }
+    }
   }
 }

--- a/src/test/kotlin/pmeet/pmeetserver/project/repository/ProjectCommentRepositoryUnitTest.kt
+++ b/src/test/kotlin/pmeet/pmeetserver/project/repository/ProjectCommentRepositoryUnitTest.kt
@@ -14,7 +14,6 @@ import org.springframework.data.mongodb.repository.support.ReactiveMongoReposito
 import org.testcontainers.containers.MongoDBContainer
 import org.testcontainers.junit.jupiter.Container
 import pmeet.pmeetserver.project.domain.ProjectComment
-import pmeet.pmeetserver.user.repository.job.JobRepository
 
 @ExperimentalCoroutinesApi
 @DataMongoTest
@@ -60,12 +59,6 @@ internal class ProjectCommentRepositoryUnitTest(
 
   }
 }) {
-  @Autowired
-  private lateinit var projectCommentRepository: ProjectCommentRepository
-
-  @Autowired
-  private lateinit var jobRepository: JobRepository
-
   companion object {
     @Container
     val mongoDBContainer = MongoDBContainer("mongo:latest").apply {

--- a/src/test/kotlin/pmeet/pmeetserver/project/repository/ProjectCommentRepositoryUnitTest.kt
+++ b/src/test/kotlin/pmeet/pmeetserver/project/repository/ProjectCommentRepositoryUnitTest.kt
@@ -1,0 +1,83 @@
+package pmeet.pmeetserver.project.repository
+
+import io.kotest.core.spec.style.DescribeSpec
+import io.kotest.matchers.shouldBe
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.setMain
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.autoconfigure.data.mongo.DataMongoTest
+import org.springframework.data.mongodb.core.ReactiveMongoTemplate
+import org.springframework.data.mongodb.repository.support.ReactiveMongoRepositoryFactory
+import org.testcontainers.containers.MongoDBContainer
+import org.testcontainers.junit.jupiter.Container
+import pmeet.pmeetserver.project.domain.ProjectComment
+import pmeet.pmeetserver.user.repository.job.JobRepository
+
+@ExperimentalCoroutinesApi
+@DataMongoTest
+internal class ProjectCommentRepositoryUnitTest(
+  @Autowired private val template: ReactiveMongoTemplate
+) : DescribeSpec({
+
+//  isolationMode = IsolationMode.InstancePerLeaf
+
+  val testDispatcher = StandardTestDispatcher()
+
+  val factory = ReactiveMongoRepositoryFactory(template)
+  val projectCommentRepository = factory.getRepository(ProjectCommentRepository::class.java)
+
+  lateinit var projectComment: ProjectComment
+
+  beforeSpec {
+    Dispatchers.setMain(testDispatcher)
+    projectComment = ProjectComment(
+      id = "testId",
+      projectId = "testProjectId",
+      userId = "testUserId",
+      content = "testContent"
+    )
+    projectCommentRepository.save(projectComment).block()
+  }
+
+  afterSpec {
+    Dispatchers.resetMain()
+    projectCommentRepository.deleteAll().block()
+  }
+
+  describe("deleteByProjectId") {
+    context("프로젝트 ID가 주어지면") {
+      it("해당하는 프로젝트 ID의 댓글을 삭제한다") {
+        projectCommentRepository.deleteByProjectId(projectComment.projectId).block()
+
+        // 삭제됐는지 확인
+        val deletedComment = projectCommentRepository.findById(projectComment.id!!).block()
+        deletedComment shouldBe null
+      }
+    }
+
+  }
+}) {
+  @Autowired
+  private lateinit var projectCommentRepository: ProjectCommentRepository
+
+  @Autowired
+  private lateinit var jobRepository: JobRepository
+
+  companion object {
+    @Container
+    val mongoDBContainer = MongoDBContainer("mongo:latest").apply {
+      withExposedPorts(27017)
+      start()
+    }
+
+    init {
+      System.setProperty(
+        "spring.data.mongodb.uri",
+        "mongodb://localhost:${mongoDBContainer.getMappedPort(27017)}/test"
+      )
+    }
+  }
+}

--- a/src/test/kotlin/pmeet/pmeetserver/project/service/ProjectCommentServiceUnitTest.kt
+++ b/src/test/kotlin/pmeet/pmeetserver/project/service/ProjectCommentServiceUnitTest.kt
@@ -5,6 +5,7 @@ import io.kotest.core.spec.style.DescribeSpec
 import io.kotest.matchers.shouldBe
 import io.mockk.every
 import io.mockk.mockk
+import io.mockk.verify
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.StandardTestDispatcher
@@ -92,6 +93,20 @@ internal class ProjectCommentServiceUnitTest : DescribeSpec({
           shouldThrow<EntityNotFoundException> {
             projectCommentService.getProjectCommentById(commentId)
           }.errorCode shouldBe ErrorCode.PROJECT_COMMENT_NOT_FOUND
+        }
+      }
+    }
+  }
+
+  describe("deleteAllByProjectId") {
+    context("프로젝트 ID가 주어지면") {
+      it("해당 프로젝트 ID에 해당하는 댓글을 삭제한다") {
+        runTest {
+          every { projectCommentRepository.deleteByProjectId(any()) } answers { Mono.empty() }
+
+          projectCommentService.deleteAllByProjectId(projectComment.projectId)
+
+          verify(exactly = 1) { projectCommentRepository.deleteByProjectId(projectComment.projectId) }
         }
       }
     }

--- a/src/test/kotlin/pmeet/pmeetserver/project/service/ProjectServiceUnitTest.kt
+++ b/src/test/kotlin/pmeet/pmeetserver/project/service/ProjectServiceUnitTest.kt
@@ -5,6 +5,7 @@ import io.kotest.core.spec.style.DescribeSpec
 import io.kotest.matchers.shouldBe
 import io.mockk.every
 import io.mockk.mockk
+import io.mockk.verify
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.StandardTestDispatcher
@@ -172,6 +173,20 @@ internal class ProjectServiceUnitTest : DescribeSpec({
           result.bookMarkers shouldBe updatedProject.bookMarkers
           result.updatedAt shouldBe updatedProject.updatedAt
           result.createdAt shouldBe updatedProject.createdAt
+        }
+      }
+    }
+  }
+
+  describe("delete") {
+    context("삭제하고자 하는 Project Id가 주어지면") {
+      it("삭제한다") {
+        runTest {
+          every { projectRepository.delete(project) } answers { Mono.empty() }
+
+          projectService.delete(project)
+
+          verify(exactly = 1) { projectRepository.delete(project) }
         }
       }
     }


### PR DESCRIPTION
## Related issue
resolves #98 

## Description
![image](https://github.com/user-attachments/assets/df05ed5d-62ff-42c2-94a1-8988b86feed1)
- 영구삭제 기능으로 개발
- 게시글에 달린 댓글도 함께 삭제
## Changes detail
- 
-
### Checklist
- [x] Test case
- [x] End of work
