### PR TITLE
feat: 프밋 모집 게시글 필터 슬라이스 조회

### DIFF
--- a/src/main/kotlin/pmeet/pmeetserver/project/controller/ProjectController.kt
+++ b/src/main/kotlin/pmeet/pmeetserver/project/controller/ProjectController.kt
@@ -2,6 +2,8 @@ package pmeet.pmeetserver.project.controller
 
 import jakarta.validation.Valid
 import kotlinx.coroutines.reactor.awaitSingle
+import org.springframework.data.domain.Slice
+import org.springframework.data.domain.Sort.Direction
 import org.springframework.http.HttpStatus
 import org.springframework.security.core.annotation.AuthenticationPrincipal
 import org.springframework.web.bind.annotation.DeleteMapping
@@ -11,12 +13,17 @@ import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.PutMapping
 import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RequestParam
 import org.springframework.web.bind.annotation.ResponseStatus
 import org.springframework.web.bind.annotation.RestController
 import pmeet.pmeetserver.project.dto.request.CreateProjectRequestDto
+import pmeet.pmeetserver.project.dto.request.SearchProjectRequestDto
 import pmeet.pmeetserver.project.dto.request.UpdateProjectRequestDto
 import pmeet.pmeetserver.project.dto.request.comment.ProjectCommentWithChildResponseDto
 import pmeet.pmeetserver.project.dto.response.ProjectResponseDto
+import pmeet.pmeetserver.project.dto.response.SearchProjectResponseDto
+import pmeet.pmeetserver.project.enums.ProjectFilterType
+import pmeet.pmeetserver.project.enums.ProjectSortProperty
 import pmeet.pmeetserver.project.service.ProjectFacadeService
 import reactor.core.publisher.Mono
 
@@ -59,5 +66,21 @@ class ProjectController(
     @PathVariable projectId: String
   ): List<ProjectCommentWithChildResponseDto> {
     return projectFacadeService.getProjectCommentList(projectId)
+  }
+
+  @GetMapping("/search-slice")
+  @ResponseStatus(HttpStatus.OK)
+  suspend fun searchProjectSlice(
+    @AuthenticationPrincipal userId: Mono<String>,
+    @RequestParam(defaultValue = "false") isCompleted: Boolean,
+    @RequestParam(required = false) filterType: ProjectFilterType?,
+    @RequestParam(required = false) filterValue: String?,
+    @RequestParam(defaultValue = "0") page: Int,
+    @RequestParam(defaultValue = "8") size: Int,
+    @RequestParam(defaultValue = "BOOK_MARKERS") sortBy: ProjectSortProperty,
+    @RequestParam(defaultValue = "DESC") direction: Direction
+  ): Slice<SearchProjectResponseDto> {
+    val requestDto = SearchProjectRequestDto.of(isCompleted, filterType, filterValue, page, size, sortBy, direction)
+    return projectFacadeService.searchProjectSlice(userId.awaitSingle(), requestDto)
   }
 }

--- a/src/main/kotlin/pmeet/pmeetserver/project/domain/Project.kt
+++ b/src/main/kotlin/pmeet/pmeetserver/project/domain/Project.kt
@@ -10,6 +10,11 @@ data class Recruitment(
   var numberOfRecruitment: Int,
 )
 
+data class ProjectBookMark(
+  val userId: String,
+  val addedAt: LocalDateTime
+)
+
 @Document
 class Project(
 
@@ -24,7 +29,7 @@ class Project(
   var recruitments: List<Recruitment>,
   var description: String,
   var isCompleted: Boolean = false,
-  var bookMarkers: MutableList<String> = mutableListOf(), // 북마크를 한 유저 ID 리스트
+  var bookMarkers: MutableList<ProjectBookMark> = mutableListOf(), // 북마크를 한 유저 ID 리스트
   val createdAt: LocalDateTime = LocalDateTime.now(),
   var updatedAt: LocalDateTime = LocalDateTime.now() // 조회 시 정렬을 위해 now()로 초기화
 ) {

--- a/src/main/kotlin/pmeet/pmeetserver/project/domain/Project.kt
+++ b/src/main/kotlin/pmeet/pmeetserver/project/domain/Project.kt
@@ -20,11 +20,11 @@ class Project(
   var startDate: LocalDateTime,
   var endDate: LocalDateTime,
   var thumbNailUrl: String? = null,
-  var techStacks: List<String>? = mutableListOf(),
+  var techStacks: List<String>? = listOf(),
   var recruitments: List<Recruitment>,
   var description: String,
   var isCompleted: Boolean = false,
-  var bookMarkers: List<String> = mutableListOf(), // 북마크를 한 유저 ID 리스트
+  var bookMarkers: MutableList<String> = mutableListOf(), // 북마크를 한 유저 ID 리스트
   val createdAt: LocalDateTime = LocalDateTime.now(),
   var updatedAt: LocalDateTime = LocalDateTime.now() // 조회 시 정렬을 위해 now()로 초기화
 ) {

--- a/src/main/kotlin/pmeet/pmeetserver/project/dto/request/SearchProjectRequestDto.kt
+++ b/src/main/kotlin/pmeet/pmeetserver/project/dto/request/SearchProjectRequestDto.kt
@@ -1,0 +1,34 @@
+package pmeet.pmeetserver.project.dto.request
+
+import org.springframework.data.domain.PageRequest
+import org.springframework.data.domain.Pageable
+import org.springframework.data.domain.Sort
+import org.springframework.data.domain.Sort.Direction
+import pmeet.pmeetserver.project.enums.ProjectFilterType
+import pmeet.pmeetserver.project.enums.ProjectSortProperty
+
+data class SearchProjectRequestDto(
+  val isCompleted: Boolean,
+  val filterType: ProjectFilterType? = null,
+  val filterValue: String? = null,
+  val pageable: Pageable
+) {
+  companion object {
+    fun of(
+      isCompleted: Boolean,
+      filterType: ProjectFilterType?,
+      filterValue: String?,
+      page: Int,
+      size: Int,
+      sortBy: ProjectSortProperty,
+      direction: Direction
+    ): SearchProjectRequestDto {
+      return SearchProjectRequestDto(
+        isCompleted = isCompleted,
+        filterType = filterType,
+        filterValue = filterValue,
+        pageable = PageRequest.of(page, size, Sort.by(direction, sortBy.property))
+      )
+    }
+  }
+}

--- a/src/main/kotlin/pmeet/pmeetserver/project/dto/response/ProjectResponseDto.kt
+++ b/src/main/kotlin/pmeet/pmeetserver/project/dto/response/ProjectResponseDto.kt
@@ -20,11 +20,12 @@ data class ProjectResponseDto(
   val recruitments: List<RecruitmentResponseDto>,
   val description: String,
   val isCompleted: Boolean,
-  val bookMarkers: List<String>,
-  val createdAt: LocalDateTime
+  val bookMarked: Boolean,
+  val createdAt: LocalDateTime,
+  val updatedAt: LocalDateTime
 ) {
   companion object {
-    fun from(project: Project): ProjectResponseDto {
+    fun from(project: Project, userId: String): ProjectResponseDto {
       return ProjectResponseDto(
         id = project.id!!,
         userId = project.userId,
@@ -36,8 +37,9 @@ data class ProjectResponseDto(
         recruitments = project.recruitments.map { RecruitmentResponseDto(it.jobName, it.numberOfRecruitment) },
         description = project.description,
         isCompleted = project.isCompleted,
-        bookMarkers = project.bookMarkers,
-        createdAt = project.createdAt
+        bookMarked = project.bookMarkers.any { it.userId == userId },
+        createdAt = project.createdAt,
+        updatedAt = project.updatedAt
       )
     }
   }

--- a/src/main/kotlin/pmeet/pmeetserver/project/dto/response/SearchProjectResponseDto.kt
+++ b/src/main/kotlin/pmeet/pmeetserver/project/dto/response/SearchProjectResponseDto.kt
@@ -1,0 +1,40 @@
+package pmeet.pmeetserver.project.dto.response
+
+import pmeet.pmeetserver.project.domain.Project
+import java.time.LocalDateTime
+
+data class SearchProjectResponseDto(
+  val id: String,
+  val userId: String,
+  val title: String,
+  val startDate: LocalDateTime,
+  val endDate: LocalDateTime,
+  val thumbNailUrl: String?,
+  val techStacks: List<String>,
+  val jobNames: List<String>,
+  val description: String,
+  val isCompleted: Boolean,
+  val bookMarked: Boolean,
+  val createdAt: LocalDateTime,
+  val updatedAt: LocalDateTime
+) {
+  companion object {
+    fun of(project: Project, userId: String): SearchProjectResponseDto {
+      return SearchProjectResponseDto(
+        id = project.id!!,
+        userId = project.userId,
+        title = project.title,
+        startDate = project.startDate,
+        endDate = project.endDate,
+        thumbNailUrl = project.thumbNailUrl,
+        techStacks = project.techStacks!!,
+        jobNames = project.recruitments.map { it.jobName },
+        description = project.description,
+        isCompleted = project.isCompleted,
+        bookMarked = project.bookMarkers.contains(userId),
+        createdAt = project.createdAt,
+        updatedAt = project.updatedAt
+      )
+    }
+  }
+}

--- a/src/main/kotlin/pmeet/pmeetserver/project/dto/response/SearchProjectResponseDto.kt
+++ b/src/main/kotlin/pmeet/pmeetserver/project/dto/response/SearchProjectResponseDto.kt
@@ -31,7 +31,7 @@ data class SearchProjectResponseDto(
         jobNames = project.recruitments.map { it.jobName },
         description = project.description,
         isCompleted = project.isCompleted,
-        bookMarked = project.bookMarkers.contains(userId),
+        bookMarked = project.bookMarkers.any { it.userId == userId },
         createdAt = project.createdAt,
         updatedAt = project.updatedAt
       )

--- a/src/main/kotlin/pmeet/pmeetserver/project/enums/ProjectFilterType.kt
+++ b/src/main/kotlin/pmeet/pmeetserver/project/enums/ProjectFilterType.kt
@@ -1,0 +1,7 @@
+package pmeet.pmeetserver.project.enums
+
+enum class ProjectFilterType(val filterBy: String) {
+  ALL("all"),
+  TITLE("title"),
+  JOB_NAME("jobName");
+}

--- a/src/main/kotlin/pmeet/pmeetserver/project/enums/ProjectSortProperty.kt
+++ b/src/main/kotlin/pmeet/pmeetserver/project/enums/ProjectSortProperty.kt
@@ -1,0 +1,7 @@
+package pmeet.pmeetserver.project.enums
+
+enum class ProjectSortProperty(val property: String) {
+  BOOK_MARKERS("bookMarkers"),
+  CREATED_AT("createdAt"),
+  UPDATED_AT("updatedAt");
+}

--- a/src/main/kotlin/pmeet/pmeetserver/project/repository/CustomProjectRepository.kt
+++ b/src/main/kotlin/pmeet/pmeetserver/project/repository/CustomProjectRepository.kt
@@ -7,6 +7,14 @@ import reactor.core.publisher.Flux
 
 interface CustomProjectRepository {
 
+  /**
+   * 프로젝트 필터링을 통한 프로젝트 목록 조회
+   *
+   * @param isCompleted 완료 여부
+   * @param filterType ? 필터 타입(ALL, TITLE, JOB_NAME)
+   * @param filterValue ? 필터 값
+   * @param pageable 페이징 정보
+   */
   fun findAllByFilter(
     isCompleted: Boolean,
     filterType: ProjectFilterType?,

--- a/src/main/kotlin/pmeet/pmeetserver/project/repository/CustomProjectRepository.kt
+++ b/src/main/kotlin/pmeet/pmeetserver/project/repository/CustomProjectRepository.kt
@@ -1,0 +1,16 @@
+package pmeet.pmeetserver.project.repository
+
+import org.springframework.data.domain.Pageable
+import pmeet.pmeetserver.project.domain.Project
+import pmeet.pmeetserver.project.enums.ProjectFilterType
+import reactor.core.publisher.Flux
+
+interface CustomProjectRepository {
+
+  fun findAllByFilter(
+    isCompleted: Boolean,
+    filterType: ProjectFilterType?,
+    filterValue: String?,
+    pageable: Pageable
+  ): Flux<Project>
+}

--- a/src/main/kotlin/pmeet/pmeetserver/project/repository/CustomProjectRepositoryImpl.kt
+++ b/src/main/kotlin/pmeet/pmeetserver/project/repository/CustomProjectRepositoryImpl.kt
@@ -1,0 +1,80 @@
+package pmeet.pmeetserver.project.repository
+
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.data.domain.Pageable
+import org.springframework.data.domain.Sort
+import org.springframework.data.mongodb.core.ReactiveMongoTemplate
+import org.springframework.data.mongodb.core.aggregation.Aggregation
+import org.springframework.data.mongodb.core.aggregation.ArrayOperators
+import org.springframework.data.mongodb.core.query.Criteria
+import pmeet.pmeetserver.project.domain.Project
+import pmeet.pmeetserver.project.enums.ProjectFilterType
+import reactor.core.publisher.Flux
+
+class CustomProjectRepositoryImpl(
+  @Autowired private val mongoTemplate: ReactiveMongoTemplate
+) : CustomProjectRepository {
+
+  companion object {
+    private const val DOCUMENT_NAME = "project"
+    private const val PROPERTY_NAME_BOOK_MARKERS = "bookMarkers"
+    private const val PROPERTY_NAME_JOB_NAME = "recruitments.jobName"
+    private const val PROPERTY_NAME_TITLE = "title"
+    private const val PROPERTY_NAME_IS_COMPLETED = "isCompleted"
+    private const val PROPERTY_NAME_BOOK_MARKERS_SIZE = "bookMarkersSize"
+  }
+
+  override fun findAllByFilter(
+    isCompleted: Boolean,
+    filterType: ProjectFilterType?,
+    filterValue: String?,
+    pageable: Pageable
+  ): Flux<Project> {
+    val criteria = createCriteria(filterType, filterValue)
+    return aggregateProjects(isCompleted, criteria, pageable)
+  }
+
+  private fun createCriteria(filterType: ProjectFilterType?, filterValue: String?): Criteria {
+    return if (filterType == null || filterValue == null) {
+      Criteria()
+    } else {
+      when (filterType) {
+        ProjectFilterType.ALL -> Criteria().orOperator(
+          Criteria.where(PROPERTY_NAME_TITLE).regex(".*${filterValue}.*"),
+          Criteria.where(PROPERTY_NAME_JOB_NAME).regex(".*${filterValue}.*")
+        )
+
+        ProjectFilterType.TITLE -> Criteria.where(PROPERTY_NAME_TITLE).regex(".*${filterValue}.*")
+        ProjectFilterType.JOB_NAME -> Criteria.where(PROPERTY_NAME_JOB_NAME).regex(".*${filterValue}.*")
+      }
+    }
+  }
+
+  private fun aggregateProjects(isCompleted: Boolean, criteria: Criteria, pageable: Pageable): Flux<Project> {
+    val aggregation = generateSearchAggregation(isCompleted, criteria, pageable)
+    return mongoTemplate.aggregate(aggregation, DOCUMENT_NAME, Project::class.java)
+  }
+
+  private fun generateSearchAggregation(isCompleted: Boolean, criteria: Criteria, pageable: Pageable): Aggregation {
+    val newCriteria = Criteria.where(PROPERTY_NAME_IS_COMPLETED).`is`(isCompleted).andOperator(criteria)
+
+    val match = Aggregation.match(newCriteria)
+
+    val addFields = Aggregation.addFields()
+      .addField(PROPERTY_NAME_BOOK_MARKERS_SIZE)
+      .withValue(ArrayOperators.Size.lengthOfArray(PROPERTY_NAME_BOOK_MARKERS))
+      .build()
+
+    val sort = if (pageable.sort.getOrderFor(PROPERTY_NAME_BOOK_MARKERS) != null) {
+      val direction = pageable.sort.getOrderFor(PROPERTY_NAME_BOOK_MARKERS)!!.direction
+      Aggregation.sort(Sort.by(direction, PROPERTY_NAME_BOOK_MARKERS_SIZE))
+    } else {
+      Aggregation.sort(pageable.sort)
+    }
+
+    val limit = Aggregation.limit(pageable.pageSize.toLong() + 1)
+    val skip = Aggregation.skip((pageable.pageNumber * pageable.pageSize).toLong())
+
+    return Aggregation.newAggregation(match, addFields, sort, skip, limit)
+  }
+}

--- a/src/main/kotlin/pmeet/pmeetserver/project/repository/CustomProjectRepositoryImpl.kt
+++ b/src/main/kotlin/pmeet/pmeetserver/project/repository/CustomProjectRepositoryImpl.kt
@@ -34,8 +34,14 @@ class CustomProjectRepositoryImpl(
     return aggregateProjects(isCompleted, criteria, pageable)
   }
 
+  /**
+   * 프로젝트 필터 조건인 Criteria 생성
+   *
+   * @param filterType ? 필터 타입(ALL, TITLE, JOB_NAME)
+   * @param filterValue ? 필터 값
+   */
   private fun createCriteria(filterType: ProjectFilterType?, filterValue: String?): Criteria {
-    return if (filterType == null || filterValue == null) {
+    return if (filterType == null || filterValue == null) { // 필터가 없거나 값이 없는 경우 전체 조회
       Criteria()
     } else {
       when (filterType) {
@@ -50,11 +56,25 @@ class CustomProjectRepositoryImpl(
     }
   }
 
+  /**
+   * 프로젝트 목록을 조회하기 위한 Aggregation을 수행
+   *
+   * @param isCompleted 완료 여부
+   * @param criteria 검색 조건
+   * @param pageable 페이징 정보
+   */
   private fun aggregateProjects(isCompleted: Boolean, criteria: Criteria, pageable: Pageable): Flux<Project> {
     val aggregation = generateSearchAggregation(isCompleted, criteria, pageable)
     return mongoTemplate.aggregate(aggregation, DOCUMENT_NAME, Project::class.java)
   }
 
+  /**
+   * 프로젝트 검색을 위한 Aggregation 생성
+   *
+   * @param isCompleted 완료 여부
+   * @param criteria 검색 조건
+   * @param pageable 페이징 정보
+   */
   private fun generateSearchAggregation(isCompleted: Boolean, criteria: Criteria, pageable: Pageable): Aggregation {
     val newCriteria = Criteria.where(PROPERTY_NAME_IS_COMPLETED).`is`(isCompleted).andOperator(criteria)
 

--- a/src/main/kotlin/pmeet/pmeetserver/project/repository/ProjectRepository.kt
+++ b/src/main/kotlin/pmeet/pmeetserver/project/repository/ProjectRepository.kt
@@ -4,6 +4,6 @@ import org.springframework.data.mongodb.repository.ReactiveMongoRepository
 import pmeet.pmeetserver.project.domain.Project
 import reactor.core.publisher.Flux
 
-interface ProjectRepository : ReactiveMongoRepository<Project, String> {
+interface ProjectRepository : ReactiveMongoRepository<Project, String>, CustomProjectRepository {
   fun findByUserId(userId: String): Flux<Project>
 }

--- a/src/main/kotlin/pmeet/pmeetserver/project/service/ProjectFacadeService.kt
+++ b/src/main/kotlin/pmeet/pmeetserver/project/service/ProjectFacadeService.kt
@@ -1,6 +1,6 @@
 package pmeet.pmeetserver.project.service
 
-import java.time.LocalDateTime
+import org.springframework.data.domain.Slice
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 import pmeet.pmeetserver.common.ErrorCode
@@ -11,6 +11,7 @@ import pmeet.pmeetserver.project.domain.ProjectTryout
 import pmeet.pmeetserver.project.domain.Recruitment
 import pmeet.pmeetserver.project.domain.enum.ProjectTryoutStatus
 import pmeet.pmeetserver.project.dto.request.CreateProjectRequestDto
+import pmeet.pmeetserver.project.dto.request.SearchProjectRequestDto
 import pmeet.pmeetserver.project.dto.request.UpdateProjectRequestDto
 import pmeet.pmeetserver.project.dto.request.comment.CreateProjectCommentRequestDto
 import pmeet.pmeetserver.project.dto.request.comment.ProjectCommentResponseDto
@@ -18,7 +19,9 @@ import pmeet.pmeetserver.project.dto.request.comment.ProjectCommentWithChildResp
 import pmeet.pmeetserver.project.dto.request.tryout.CreateProjectTryoutRequestDto
 import pmeet.pmeetserver.project.dto.request.tryout.ProjectTryoutResponseDto
 import pmeet.pmeetserver.project.dto.response.ProjectResponseDto
+import pmeet.pmeetserver.project.dto.response.SearchProjectResponseDto
 import pmeet.pmeetserver.user.service.resume.ResumeService
+import java.time.LocalDateTime
 
 @Service
 class ProjectFacadeService(
@@ -140,5 +143,15 @@ class ProjectFacadeService(
   @Transactional(readOnly = true)
   suspend fun getProjectCommentList(projectId: String): List<ProjectCommentWithChildResponseDto> {
     return projectCommentService.getProjectCommentWithChildByProjectId(projectId)
+  }
+
+  @Transactional(readOnly = true)
+  suspend fun searchProjectSlice(userId: String, requestDto: SearchProjectRequestDto): Slice<SearchProjectResponseDto> {
+    return projectService.searchSliceByFilter(
+      requestDto.isCompleted,
+      requestDto.filterType,
+      requestDto.filterValue,
+      requestDto.pageable
+    ).map { SearchProjectResponseDto.of(it, userId) }
   }
 }

--- a/src/main/kotlin/pmeet/pmeetserver/project/service/ProjectFacadeService.kt
+++ b/src/main/kotlin/pmeet/pmeetserver/project/service/ProjectFacadeService.kt
@@ -50,7 +50,7 @@ class ProjectFacadeService(
       description = requestDto.description
     )
 
-    return ProjectResponseDto.from(projectService.save(project))
+    return ProjectResponseDto.from(projectService.save(project), userId)
   }
 
   @Transactional
@@ -71,7 +71,7 @@ class ProjectFacadeService(
       description = requestDto.description
     )
 
-    return ProjectResponseDto.from(projectService.update(originalProject))
+    return ProjectResponseDto.from(projectService.update(originalProject), userId)
   }
 
   @Transactional

--- a/src/main/kotlin/pmeet/pmeetserver/project/service/ProjectService.kt
+++ b/src/main/kotlin/pmeet/pmeetserver/project/service/ProjectService.kt
@@ -2,11 +2,15 @@ package pmeet.pmeetserver.project.service
 
 import kotlinx.coroutines.reactor.awaitSingle
 import kotlinx.coroutines.reactor.awaitSingleOrNull
+import org.springframework.data.domain.Pageable
+import org.springframework.data.domain.Slice
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 import pmeet.pmeetserver.common.ErrorCode
 import pmeet.pmeetserver.common.exception.EntityNotFoundException
+import pmeet.pmeetserver.common.utils.page.SliceResponse
 import pmeet.pmeetserver.project.domain.Project
+import pmeet.pmeetserver.project.enums.ProjectFilterType
 import pmeet.pmeetserver.project.repository.ProjectRepository
 
 @Service
@@ -33,5 +37,23 @@ class ProjectService(
   @Transactional
   suspend fun delete(project: Project) {
     projectRepository.delete(project).awaitSingleOrNull()
+  }
+
+  @Transactional(readOnly = true)
+  suspend fun searchSliceByFilter(
+    isCompleted: Boolean,
+    filterType: ProjectFilterType?,
+    filterValue: String?,
+    pageable: Pageable
+  ): Slice<Project> {
+    return SliceResponse.of(
+      projectRepository.findAllByFilter(
+        isCompleted,
+        filterType,
+        filterValue,
+        pageable
+      ).collectList().awaitSingle(),
+      pageable
+    )
   }
 }

--- a/src/test/kotlin/pmeet/pmeetserver/project/ProjectIntegrationTest.kt
+++ b/src/test/kotlin/pmeet/pmeetserver/project/ProjectIntegrationTest.kt
@@ -24,6 +24,7 @@ import org.springframework.test.web.reactive.server.expectBody
 import org.testcontainers.containers.MongoDBContainer
 import org.testcontainers.junit.jupiter.Container
 import pmeet.pmeetserver.project.domain.Project
+import pmeet.pmeetserver.project.domain.ProjectBookMark
 import pmeet.pmeetserver.project.domain.ProjectComment
 import pmeet.pmeetserver.project.domain.Recruitment
 import pmeet.pmeetserver.project.dto.request.CreateProjectRequestDto
@@ -167,9 +168,10 @@ internal class ProjectIntegrationTest : DescribeSpec() {
             }
             response.responseBody?.description shouldBe requestDto.description
             response.responseBody?.userId shouldBe project.userId
-            response.responseBody?.bookMarkers shouldBe project.bookMarkers
+            response.responseBody?.bookMarked shouldBe false
             response.responseBody?.isCompleted shouldBe project.isCompleted
             response.responseBody?.createdAt shouldNotBe null
+            response.responseBody?.updatedAt shouldNotBe null
           }
         }
       }
@@ -224,9 +226,10 @@ internal class ProjectIntegrationTest : DescribeSpec() {
             }
             response.responseBody?.description shouldBe requestDto.description
             response.responseBody?.userId shouldBe project.userId
-            response.responseBody?.bookMarkers shouldBe project.bookMarkers
+            response.responseBody?.bookMarked shouldBe false
             response.responseBody?.isCompleted shouldBe project.isCompleted
             response.responseBody?.createdAt shouldNotBe null
+            response.responseBody?.updatedAt shouldNotBe null
           }
         }
       }
@@ -631,10 +634,10 @@ internal class ProjectIntegrationTest : DescribeSpec() {
             description = "testDescription"
           )
           if (i == 20) {
-            newProject.bookMarkers.add(userId)
+            newProject.bookMarkers.add(ProjectBookMark(userId, LocalDateTime.now()))
           }
           for (j in 1..i) {
-            newProject.bookMarkers.add("testUserId$j")
+            newProject.bookMarkers.add(ProjectBookMark("testUserId$j", LocalDateTime.now()))
           }
           withContext(Dispatchers.IO) {
             projectRepository.save(newProject).block()

--- a/src/test/kotlin/pmeet/pmeetserver/project/controller/ProjectControllerUnitTest.kt
+++ b/src/test/kotlin/pmeet/pmeetserver/project/controller/ProjectControllerUnitTest.kt
@@ -73,9 +73,10 @@ internal class ProjectControllerUnitTest : DescribeSpec() {
           recruitments = requestDto.recruitments.map { RecruitmentResponseDto(it.jobName, it.numberOfRecruitment) },
           description = requestDto.description,
           userId = userId,
-          bookMarkers = mutableListOf(),
+          bookMarked = false,
           isCompleted = false,
-          createdAt = LocalDateTime.of(2021, 5, 1, 0, 0, 0)
+          createdAt = LocalDateTime.of(2021, 5, 1, 0, 0, 0),
+          updatedAt = LocalDateTime.of(2021, 6, 1, 0, 0, 0)
         )
 
         coEvery { projectFacadeService.createProject(userId, requestDto) } answers { responseDto }
@@ -111,9 +112,10 @@ internal class ProjectControllerUnitTest : DescribeSpec() {
             }
             response.responseBody?.description shouldBe responseDto.description
             response.responseBody?.userId shouldBe responseDto.userId
-            response.responseBody?.bookMarkers shouldBe responseDto.bookMarkers
+            response.responseBody?.bookMarked shouldBe responseDto.bookMarked
             response.responseBody?.isCompleted shouldBe responseDto.isCompleted
             response.responseBody?.createdAt shouldBe responseDto.createdAt
+            response.responseBody?.updatedAt shouldBe responseDto.updatedAt
           }
         }
       }
@@ -164,9 +166,10 @@ internal class ProjectControllerUnitTest : DescribeSpec() {
           recruitments = requestDto.recruitments.map { RecruitmentResponseDto(it.jobName, it.numberOfRecruitment) },
           description = requestDto.description,
           userId = userId,
-          bookMarkers = mutableListOf(),
+          bookMarked = false,
           isCompleted = false,
-          createdAt = LocalDateTime.of(2021, 5, 1, 0, 0, 0)
+          createdAt = LocalDateTime.of(2021, 5, 1, 0, 0, 0),
+          updatedAt = LocalDateTime.of(2021, 6, 1, 0, 0, 0)
         )
 
         coEvery { projectFacadeService.updateProject(userId, requestDto) } answers { responseDto }
@@ -202,9 +205,10 @@ internal class ProjectControllerUnitTest : DescribeSpec() {
             }
             response.responseBody?.description shouldBe responseDto.description
             response.responseBody?.userId shouldBe responseDto.userId
-            response.responseBody?.bookMarkers shouldBe responseDto.bookMarkers
+            response.responseBody?.bookMarked shouldBe responseDto.bookMarked
             response.responseBody?.isCompleted shouldBe responseDto.isCompleted
             response.responseBody?.createdAt shouldBe responseDto.createdAt
+            response.responseBody?.updatedAt shouldBe responseDto.updatedAt
           }
         }
       }

--- a/src/test/kotlin/pmeet/pmeetserver/project/repository/ProjectRepositoryUnitTest.kt
+++ b/src/test/kotlin/pmeet/pmeetserver/project/repository/ProjectRepositoryUnitTest.kt
@@ -1,0 +1,425 @@
+package pmeet.pmeetserver.project.repository
+
+import io.kotest.core.spec.IsolationMode
+import io.kotest.core.spec.style.DescribeSpec
+import io.kotest.matchers.shouldBe
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.setMain
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.autoconfigure.data.mongo.DataMongoTest
+import org.springframework.data.domain.PageRequest
+import org.springframework.data.domain.Sort
+import org.springframework.data.mongodb.core.ReactiveMongoTemplate
+import org.springframework.data.mongodb.repository.support.ReactiveMongoRepositoryFactory
+import org.springframework.test.util.ReflectionTestUtils
+import org.testcontainers.containers.MongoDBContainer
+import org.testcontainers.junit.jupiter.Container
+import pmeet.pmeetserver.project.domain.Project
+import pmeet.pmeetserver.project.domain.Recruitment
+import pmeet.pmeetserver.project.enums.ProjectFilterType
+import pmeet.pmeetserver.project.enums.ProjectSortProperty
+import java.time.LocalDateTime
+
+@ExperimentalCoroutinesApi
+@DataMongoTest
+internal class ProjectRepositoryUnitTest(
+  @Autowired private val template: ReactiveMongoTemplate
+) : DescribeSpec({
+
+  isolationMode = IsolationMode.InstancePerLeaf
+
+  val testDispatcher = StandardTestDispatcher()
+
+  val factory = ReactiveMongoRepositoryFactory(template)
+  val customRepository = CustomProjectRepositoryImpl(template)
+  val projectRepository = factory.getRepository(ProjectRepository::class.java, customRepository)
+
+  lateinit var userId: String
+
+  beforeSpec {
+    Dispatchers.setMain(testDispatcher)
+    userId = "testUserId"
+  }
+
+  afterSpec {
+    projectRepository.deleteAll().block()
+    Dispatchers.resetMain()
+  }
+
+  describe("findAllByFilter") {
+    context("완료 여부가 False이고, 필터가 주어지지 않으면") {
+      it("완료되지 않은 Project를 대상으로 PageSize + 1만큼 잘라서 반환한다") {
+        for (i in 1..20) {
+          val project = Project(
+            userId = userId,
+            title = "testTitle$i",
+            startDate = LocalDateTime.of(2024, 7, 21, 0, 0, 0),
+            endDate = LocalDateTime.of(2024, 7, 21, 0, 0, 0),
+            recruitments = listOf(
+              Recruitment(
+                jobName = "testJobName$i",
+                numberOfRecruitment = 1
+              )
+            ),
+            description = "testDescription$i"
+          )
+          projectRepository.save(project).block()
+        }
+        val result = projectRepository.findAllByFilter(
+          false,
+          null,
+          null,
+          PageRequest.of(0, 10, Sort.by(Sort.Direction.DESC, ProjectSortProperty.BOOK_MARKERS.name))
+        ).collectList().block()
+
+        result?.size shouldBe 11
+      }
+    }
+    context("완료 여부가 True이고, 필터가 주어지지 않으면") {
+      it("완료된 Project를 대상으로 PageSize + 1만큼 잘라서 반환한다") {
+        for (i in 1..20) {
+          val project = Project(
+            userId = userId,
+            title = "testTitle$i",
+            startDate = LocalDateTime.of(2024, 7, 21, 0, 0, 0),
+            endDate = LocalDateTime.of(2024, 7, 21, 0, 0, 0),
+            recruitments = listOf(
+              Recruitment(
+                jobName = "testJobName$i",
+                numberOfRecruitment = 1
+              )
+            ),
+            description = "testDescription$i",
+            isCompleted = true
+          )
+          projectRepository.save(project).block()
+        }
+        val result = projectRepository.findAllByFilter(
+          true,
+          null,
+          null,
+          PageRequest.of(0, 10, Sort.by(Sort.Direction.DESC, ProjectSortProperty.BOOK_MARKERS.name))
+        ).collectList().block()
+
+        result?.size shouldBe 11
+      }
+    }
+    context("ALL 타입 필터가 주어지면") {
+      val filterType = ProjectFilterType.ALL
+      val filterValue = "2"
+      it("Title 또는 JobName에 filterValue가 포함된 Project를 반환한다") {
+        for (i in 1..20) {
+          val project = Project(
+            userId = userId,
+            title = "testTitle$i",
+            startDate = LocalDateTime.of(2024, 7, 21, 0, 0, 0),
+            endDate = LocalDateTime.of(2024, 7, 21, 0, 0, 0),
+            recruitments = listOf(
+              Recruitment(
+                jobName = "testJobName$i",
+                numberOfRecruitment = 1
+              )
+            ),
+            description = "testDescription$i"
+          )
+          projectRepository.save(project).block()
+        }
+        val result = projectRepository.findAllByFilter(
+          false,
+          filterType,
+          filterValue,
+          PageRequest.of(0, 10, Sort.by(Sort.Direction.DESC, ProjectSortProperty.BOOK_MARKERS.name))
+        ).collectList().block()
+
+        result?.size shouldBe 3
+      }
+    }
+    context("TITLE 타입 필터가 주어지면") {
+      val filterType = ProjectFilterType.TITLE
+      val filterValue = "Title10"
+      it("Title에 filterValue가 포함된 Project를 반환한다") {
+        for (i in 1..20) {
+          val project = Project(
+            userId = userId,
+            title = "testTitle$i",
+            startDate = LocalDateTime.of(2024, 7, 21, 0, 0, 0),
+            endDate = LocalDateTime.of(2024, 7, 21, 0, 0, 0),
+            recruitments = listOf(
+              Recruitment(
+                jobName = "testJobName$i",
+                numberOfRecruitment = 1
+              )
+            ),
+            description = "testDescription$i"
+          )
+          projectRepository.save(project).block()
+        }
+        val result = projectRepository.findAllByFilter(
+          false,
+          filterType,
+          filterValue,
+          PageRequest.of(0, 10, Sort.by(Sort.Direction.DESC, ProjectSortProperty.BOOK_MARKERS.name))
+        ).collectList().block()
+
+        result?.size shouldBe 1
+        result?.first()?.title shouldBe "testTitle10"
+      }
+    }
+    context("JOB_NAME 타입 필터가 주어지면") {
+      val filterType = ProjectFilterType.JOB_NAME
+      val filterValue = "JobName10"
+      it("JobName에 filterValue가 포함된 Project를 반환한다") {
+        for (i in 1..20) {
+          val project = Project(
+            userId = userId,
+            title = "testTitle$i",
+            startDate = LocalDateTime.of(2024, 7, 21, 0, 0, 0),
+            endDate = LocalDateTime.of(2024, 7, 21, 0, 0, 0),
+            recruitments = listOf(
+              Recruitment(
+                jobName = "testJobName$i",
+                numberOfRecruitment = 1
+              )
+            ),
+            description = "testDescription$i"
+          )
+          projectRepository.save(project).block()
+        }
+        val result = projectRepository.findAllByFilter(
+          false,
+          filterType,
+          filterValue,
+          PageRequest.of(0, 10, Sort.by(Sort.Direction.DESC, ProjectSortProperty.BOOK_MARKERS.name))
+        ).collectList().block()
+
+        result?.size shouldBe 1
+        result?.first()?.title shouldBe "testTitle10"
+      }
+    }
+    context("북마크수 내림차순 정렬이 주어지면") {
+      it("북마크수 내림차순으로 Project를 반환한다") {
+        for (i in 1..20) {
+          val project = Project(
+            userId = userId,
+            title = "testTitle$i",
+            startDate = LocalDateTime.of(2024, 7, 21, 0, 0, 0),
+            endDate = LocalDateTime.of(2024, 7, 21, 0, 0, 0),
+            recruitments = listOf(
+              Recruitment(
+                jobName = "testJobName$i",
+                numberOfRecruitment = 1
+              )
+            ),
+            description = "testDescription$i"
+          )
+          for (j in 1..i) {
+            project.bookMarkers.add("testUserId$j")
+          }
+          projectRepository.save(project).block()
+        }
+        val result = projectRepository.findAllByFilter(
+          false,
+          null,
+          null,
+          PageRequest.of(0, 10, Sort.by(Sort.Direction.DESC, ProjectSortProperty.BOOK_MARKERS.property))
+        ).collectList().block()
+
+        result?.size shouldBe 11
+        result?.first()?.title shouldBe "testTitle20"
+        result?.last()?.title shouldBe "testTitle10"
+      }
+    }
+    context("북마크수 오름차순 정렬이 주어지면") {
+      it("북마크수 오름차순으로 Project를 반환한다") {
+        for (i in 1..20) {
+          val project = Project(
+            userId = userId,
+            title = "testTitle$i",
+            startDate = LocalDateTime.of(2024, 7, 21, 0, 0, 0),
+            endDate = LocalDateTime.of(2024, 7, 21, 0, 0, 0),
+            recruitments = listOf(
+              Recruitment(
+                jobName = "testJobName$i",
+                numberOfRecruitment = 1
+              )
+            ),
+            description = "testDescription$i"
+          )
+          for (j in 1..i) {
+            project.bookMarkers.add("testUserId$j")
+          }
+          projectRepository.save(project).block()
+        }
+        val result = projectRepository.findAllByFilter(
+          false,
+          null,
+          null,
+          PageRequest.of(0, 10, Sort.by(Sort.Direction.ASC, ProjectSortProperty.BOOK_MARKERS.property))
+        ).collectList().block()
+
+        result?.size shouldBe 11
+        result?.first()?.title shouldBe "testTitle1"
+        result?.last()?.title shouldBe "testTitle11"
+      }
+    }
+    context("생성일 오름차순 정렬이 주어지면") {
+      it("생성일 오름차순으로 Project를 반환한다") {
+        for (i in 1..20) {
+          val project = Project(
+            userId = userId,
+            title = "testTitle$i",
+            startDate = LocalDateTime.of(2024, 7, 21, 0, 0, 0),
+            endDate = LocalDateTime.of(2024, 7, 22, 0, 0, 0),
+            recruitments = listOf(
+              Recruitment(
+                jobName = "testJobName$i",
+                numberOfRecruitment = 1
+              )
+            ),
+            description = "testDescription$i"
+          )
+          ReflectionTestUtils.setField(
+            project,
+            "createdAt",
+            LocalDateTime.of(2024, 7, 21, 0, 0, 0).plusDays(i.toLong())
+          )
+          projectRepository.save(project).block()
+        }
+        val result = projectRepository.findAllByFilter(
+          false,
+          null,
+          null,
+          PageRequest.of(0, 10, Sort.by(Sort.Direction.ASC, ProjectSortProperty.CREATED_AT.property))
+        ).collectList().block()
+
+        result?.size shouldBe 11
+        result?.first()?.title shouldBe "testTitle1"
+        result?.last()?.title shouldBe "testTitle11"
+      }
+    }
+    context("생성일 내림차순 정렬이 주어지면") {
+      it("생성일 내림차순으로 Project를 반환한다") {
+        for (i in 1..20) {
+          val project = Project(
+            userId = userId,
+            title = "testTitle$i",
+            startDate = LocalDateTime.of(2024, 7, 21, 0, 0, 0),
+            endDate = LocalDateTime.of(2024, 7, 22, 0, 0, 0),
+            recruitments = listOf(
+              Recruitment(
+                jobName = "testJobName$i",
+                numberOfRecruitment = 1
+              )
+            ),
+            description = "testDescription$i"
+          )
+          ReflectionTestUtils.setField(
+            project,
+            "createdAt",
+            LocalDateTime.of(2024, 7, 21, 0, 0, 0).plusDays(i.toLong())
+          )
+          projectRepository.save(project).block()
+        }
+        val result = projectRepository.findAllByFilter(
+          false,
+          null,
+          null,
+          PageRequest.of(0, 10, Sort.by(Sort.Direction.DESC, ProjectSortProperty.CREATED_AT.property))
+        ).collectList().block()
+
+        result?.size shouldBe 11
+        result?.first()?.title shouldBe "testTitle20"
+        result?.last()?.title shouldBe "testTitle10"
+      }
+    }
+    context("수정일 오름차순 정렬이 주어지면") {
+      it("수정일 오름차순으로 Project를 반환한다") {
+        for (i in 1..20) {
+          val project = Project(
+            userId = userId,
+            title = "testTitle$i",
+            startDate = LocalDateTime.of(2024, 7, 21, 0, 0, 0),
+            endDate = LocalDateTime.of(2024, 7, 22, 0, 0, 0),
+            recruitments = listOf(
+              Recruitment(
+                jobName = "testJobName$i",
+                numberOfRecruitment = 1
+              )
+            ),
+            description = "testDescription$i"
+          )
+          ReflectionTestUtils.setField(
+            project,
+            "updatedAt",
+            LocalDateTime.of(2024, 7, 21, 0, 0, 0).plusDays(i.toLong())
+          )
+          projectRepository.save(project).block()
+        }
+        val result = projectRepository.findAllByFilter(
+          false,
+          null,
+          null,
+          PageRequest.of(0, 10, Sort.by(Sort.Direction.ASC, ProjectSortProperty.UPDATED_AT.property))
+        ).collectList().block()
+
+        result?.size shouldBe 11
+        result?.first()?.title shouldBe "testTitle1"
+        result?.last()?.title shouldBe "testTitle11"
+      }
+    }
+    context("수정일 내림차순 정렬이 주어지면") {
+      it("수정일 내림차순으로 Project를 반환한다") {
+        for (i in 1..20) {
+          val project = Project(
+            userId = userId,
+            title = "testTitle$i",
+            startDate = LocalDateTime.of(2024, 7, 21, 0, 0, 0),
+            endDate = LocalDateTime.of(2024, 7, 22, 0, 0, 0),
+            recruitments = listOf(
+              Recruitment(
+                jobName = "testJobName$i",
+                numberOfRecruitment = 1
+              )
+            ),
+            description = "testDescription$i"
+          )
+          ReflectionTestUtils.setField(
+            project,
+            "updatedAt",
+            LocalDateTime.of(2024, 7, 21, 0, 0, 0).plusDays(i.toLong())
+          )
+          projectRepository.save(project).block()
+        }
+        val result = projectRepository.findAllByFilter(
+          false,
+          null,
+          null,
+          PageRequest.of(0, 10, Sort.by(Sort.Direction.DESC, ProjectSortProperty.UPDATED_AT.property))
+        ).collectList().block()
+
+        result?.size shouldBe 11
+        result?.first()?.title shouldBe "testTitle20"
+        result?.last()?.title shouldBe "testTitle10"
+      }
+    }
+  }
+
+}) {
+  companion object {
+    @Container
+    val mongoDBContainer = MongoDBContainer("mongo:latest").apply {
+      withExposedPorts(27017)
+      start()
+    }
+
+    init {
+      System.setProperty(
+        "spring.data.mongodb.uri",
+        "mongodb://localhost:${mongoDBContainer.getMappedPort(27017)}/test"
+      )
+    }
+  }
+}

--- a/src/test/kotlin/pmeet/pmeetserver/project/repository/ProjectRepositoryUnitTest.kt
+++ b/src/test/kotlin/pmeet/pmeetserver/project/repository/ProjectRepositoryUnitTest.kt
@@ -18,6 +18,7 @@ import org.springframework.test.util.ReflectionTestUtils
 import org.testcontainers.containers.MongoDBContainer
 import org.testcontainers.junit.jupiter.Container
 import pmeet.pmeetserver.project.domain.Project
+import pmeet.pmeetserver.project.domain.ProjectBookMark
 import pmeet.pmeetserver.project.domain.Recruitment
 import pmeet.pmeetserver.project.enums.ProjectFilterType
 import pmeet.pmeetserver.project.enums.ProjectSortProperty
@@ -216,7 +217,7 @@ internal class ProjectRepositoryUnitTest(
             description = "testDescription$i"
           )
           for (j in 1..i) {
-            project.bookMarkers.add("testUserId$j")
+            project.bookMarkers.add(ProjectBookMark("testUserId$j", LocalDateTime.now()))
           }
           projectRepository.save(project).block()
         }
@@ -249,7 +250,7 @@ internal class ProjectRepositoryUnitTest(
             description = "testDescription$i"
           )
           for (j in 1..i) {
-            project.bookMarkers.add("testUserId$j")
+            project.bookMarkers.add(ProjectBookMark("testUserId$j", LocalDateTime.now()))
           }
           projectRepository.save(project).block()
         }

--- a/src/test/kotlin/pmeet/pmeetserver/project/service/ProjectFacadeServiceUnitTest.kt
+++ b/src/test/kotlin/pmeet/pmeetserver/project/service/ProjectFacadeServiceUnitTest.kt
@@ -19,6 +19,7 @@ import org.springframework.test.util.ReflectionTestUtils
 import pmeet.pmeetserver.common.ErrorCode
 import pmeet.pmeetserver.common.exception.ForbiddenRequestException
 import pmeet.pmeetserver.project.domain.Project
+import pmeet.pmeetserver.project.domain.ProjectBookMark
 import pmeet.pmeetserver.project.domain.ProjectComment
 import pmeet.pmeetserver.project.domain.ProjectTryout
 import pmeet.pmeetserver.project.domain.Recruitment
@@ -94,7 +95,7 @@ internal class ProjectFacadeServiceUnitTest : DescribeSpec({
     )
     ReflectionTestUtils.setField(project, "id", "testId")
     ReflectionTestUtils.setField(project, "createdAt", LocalDateTime.of(2021, 5, 1, 0, 0, 0))
-
+    ReflectionTestUtils.setField(project, "updatedAt", LocalDateTime.of(2021, 6, 1, 0, 0, 0))
     projectComment = ProjectComment(
       projectId = project.id!!,
       userId = userId,
@@ -156,8 +157,9 @@ internal class ProjectFacadeServiceUnitTest : DescribeSpec({
           }
           result.description shouldBe requestDto.description
           result.isCompleted shouldBe project.isCompleted
-          result.bookMarkers shouldBe project.bookMarkers
+          result.bookMarked shouldBe false
           result.createdAt shouldBe project.createdAt
+          result.updatedAt shouldBe project.updatedAt
         }
       }
     }
@@ -204,8 +206,9 @@ internal class ProjectFacadeServiceUnitTest : DescribeSpec({
           }
           result.description shouldBe requestDto.description
           result.isCompleted shouldBe project.isCompleted
-          result.bookMarkers shouldBe project.bookMarkers
+          result.bookMarked shouldBe false
           result.createdAt shouldBe project.createdAt
+          result.updatedAt shouldBe project.updatedAt
         }
       }
     }
@@ -423,10 +426,10 @@ internal class ProjectFacadeServiceUnitTest : DescribeSpec({
             description = "testDescription"
           )
           if (i == 1) {
-            newProject.bookMarkers.add(requesterUserId)
+            newProject.bookMarkers.add(ProjectBookMark(requesterUserId, LocalDateTime.now()))
           }
           for (j in 1..i) {
-            newProject.bookMarkers.add("$userId$i")
+            newProject.bookMarkers.add(ProjectBookMark("$userId$i", LocalDateTime.now()))
           }
           projects.add(newProject)
         }


### PR DESCRIPTION
## Related issue
resolves #95
resolves #94

## Description
![image](https://github.com/user-attachments/assets/a7525600-4b57-49c3-aad1-9d10836b45de)

- 직무`or`타이틀(ALL), 타이틀, 직무이름을 필터타입으로 사용
- 완료된 게시글도 조회하는 경우를 대비하여 `isCompleted`도 필터 추가
- 정렬 규칙은 인기순, 최신등록순, 수정순이 있음
## Changes detail
- 북마크한 유저ID는 read-only가 아니므로 `MutableList`로 변경 
### Checklist
- [x] Test case
- [x] End of work
