### PR TITLE
fix: 북마크 리스트 사이즈 Null 핸들링

### DIFF
--- a/src/main/kotlin/pmeet/pmeetserver/project/repository/CustomProjectRepositoryImpl.kt
+++ b/src/main/kotlin/pmeet/pmeetserver/project/repository/CustomProjectRepositoryImpl.kt
@@ -6,8 +6,10 @@ import org.springframework.data.domain.Sort
 import org.springframework.data.mongodb.core.ReactiveMongoTemplate
 import org.springframework.data.mongodb.core.aggregation.Aggregation
 import org.springframework.data.mongodb.core.aggregation.ArrayOperators
+import org.springframework.data.mongodb.core.aggregation.ConditionalOperators
 import org.springframework.data.mongodb.core.query.Criteria
 import pmeet.pmeetserver.project.domain.Project
+import pmeet.pmeetserver.project.domain.ProjectBookmark
 import pmeet.pmeetserver.project.enums.ProjectFilterType
 import reactor.core.publisher.Flux
 
@@ -82,7 +84,11 @@ class CustomProjectRepositoryImpl(
 
     val addFields = Aggregation.addFields()
       .addField(PROPERTY_NAME_BOOK_MARKERS_SIZE)
-      .withValue(ArrayOperators.Size.lengthOfArray(PROPERTY_NAME_BOOK_MARKERS))
+      .withValue(
+        ArrayOperators.Size.lengthOfArray(
+          ConditionalOperators.IfNull.ifNull(PROPERTY_NAME_BOOK_MARKERS).then(emptyList<ProjectBookmark>())
+        )
+      )
       .build()
 
     val sort = if (pageable.sort.getOrderFor(PROPERTY_NAME_BOOK_MARKERS) != null) {


### PR DESCRIPTION
## Related issue

## Description
`{ "aggregate" : "__collection__", "pipeline" : [{ "$match" : { "isCompleted" : false, "$and" : [{}]}}, { "$addFields" : { "bookmarkersSize" : { "$size" : "$bookmarkers"}}}, { "$sort" : { "updatedAt" : -1}}, { "$skip" : 0}, { "$limit" : 9}]}`

**The argument to $size must be an array, but was of type: missing'**
에러 발생하여 Null 인 케이스 로직 추가
## Changes detail
- 
-
### Checklist
- [x] Test case
- [x] End of work
