### PR TITLE
feat: Download PresignedURL을 사전 생성 하여 응답

### DIFF
--- a/src/main/kotlin/pmeet/pmeetserver/file/controller/FileController.kt
+++ b/src/main/kotlin/pmeet/pmeetserver/file/controller/FileController.kt
@@ -7,12 +7,12 @@ import org.springframework.web.bind.annotation.RequestParam
 import org.springframework.web.bind.annotation.ResponseStatus
 import org.springframework.web.bind.annotation.RestController
 import pmeet.pmeetserver.file.dto.response.FileUrlResponseDto
-import pmeet.pmeetserver.file.service.FileService
+import pmeet.pmeetserver.file.service.FileFacadeService
 
 @RestController
 @RequestMapping("/api/v1/file")
 class FileController(
-  private val fileService: FileService
+  private val fileFacadeService: FileFacadeService
 ) {
 
   @GetMapping("/presigned-url/upload")
@@ -21,13 +21,13 @@ class FileController(
     @RequestParam("filename") fileName: String,
     @RequestParam("filedomain") fileDomain: String
   ): FileUrlResponseDto {
-    return fileService.generatePreSignedUrlToUpload(fileName, fileDomain)
+    return fileFacadeService.getPreSignedUrlToUpload(fileName, fileDomain)
   }
 
 
   @GetMapping("/presigned-url/download")
   @ResponseStatus(HttpStatus.OK)
   suspend fun getPreSignedUrlToDownload(@RequestParam("objectname") objectName: String): FileUrlResponseDto {
-    return fileService.generatePreSignedUrlToDownload(objectName)
+    return fileFacadeService.getPreSignedUrlToDownload(objectName)
   }
 }

--- a/src/main/kotlin/pmeet/pmeetserver/file/service/FileFacadeService.kt
+++ b/src/main/kotlin/pmeet/pmeetserver/file/service/FileFacadeService.kt
@@ -1,0 +1,18 @@
+package pmeet.pmeetserver.file.service
+
+import org.springframework.stereotype.Service
+import pmeet.pmeetserver.file.dto.response.FileUrlResponseDto
+
+@Service
+class FileFacadeService(
+  private val fileService: FileService
+) {
+
+  suspend fun getPreSignedUrlToUpload(fileName: String, fileDomain: String): FileUrlResponseDto {
+    return fileService.generatePreSignedUrlToUpload(fileName, fileDomain)
+  }
+
+  suspend fun getPreSignedUrlToDownload(objectName: String): FileUrlResponseDto {
+    return FileUrlResponseDto.of(fileService.generatePreSignedUrlToDownload(objectName), objectName)
+  }
+}

--- a/src/main/kotlin/pmeet/pmeetserver/file/service/FileService.kt
+++ b/src/main/kotlin/pmeet/pmeetserver/file/service/FileService.kt
@@ -47,7 +47,7 @@ class FileService(
       }
   }
 
-  suspend fun generatePreSignedUrlToDownload(objectName: String): FileUrlResponseDto {
+  suspend fun generatePreSignedUrlToDownload(objectName: String): String {
     S3Presigner.builder()
       .credentialsProvider(awsCredentialsProvider)
       .region(Region.of(region))
@@ -61,7 +61,7 @@ class FileService(
               .build()
           )
           .build().run {
-            return FileUrlResponseDto.of(presigner.presignGetObject(this).url().toExternalForm(), objectName)
+            return presigner.presignGetObject(this).url().toExternalForm()
           }
       }
   }

--- a/src/main/kotlin/pmeet/pmeetserver/project/controller/ProjectCommentController.kt
+++ b/src/main/kotlin/pmeet/pmeetserver/project/controller/ProjectCommentController.kt
@@ -11,8 +11,8 @@ import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.ResponseStatus
 import org.springframework.web.bind.annotation.RestController
-import pmeet.pmeetserver.project.dto.request.comment.CreateProjectCommentRequestDto
-import pmeet.pmeetserver.project.dto.request.comment.ProjectCommentResponseDto
+import pmeet.pmeetserver.project.dto.comment.request.CreateProjectCommentRequestDto
+import pmeet.pmeetserver.project.dto.comment.response.ProjectCommentResponseDto
 import pmeet.pmeetserver.project.service.ProjectFacadeService
 import reactor.core.publisher.Mono
 

--- a/src/main/kotlin/pmeet/pmeetserver/project/controller/ProjectController.kt
+++ b/src/main/kotlin/pmeet/pmeetserver/project/controller/ProjectController.kt
@@ -16,10 +16,10 @@ import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RequestParam
 import org.springframework.web.bind.annotation.ResponseStatus
 import org.springframework.web.bind.annotation.RestController
+import pmeet.pmeetserver.project.dto.comment.response.ProjectCommentWithChildResponseDto
 import pmeet.pmeetserver.project.dto.request.CreateProjectRequestDto
 import pmeet.pmeetserver.project.dto.request.SearchProjectRequestDto
 import pmeet.pmeetserver.project.dto.request.UpdateProjectRequestDto
-import pmeet.pmeetserver.project.dto.request.comment.ProjectCommentWithChildResponseDto
 import pmeet.pmeetserver.project.dto.response.ProjectResponseDto
 import pmeet.pmeetserver.project.dto.response.ProjectWithUserResponseDto
 import pmeet.pmeetserver.project.dto.response.SearchProjectResponseDto

--- a/src/main/kotlin/pmeet/pmeetserver/project/controller/ProjectTryoutController.kt
+++ b/src/main/kotlin/pmeet/pmeetserver/project/controller/ProjectTryoutController.kt
@@ -11,33 +11,33 @@ import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.ResponseStatus
 import org.springframework.web.bind.annotation.RestController
-import pmeet.pmeetserver.project.dto.request.tryout.CreateProjectTryoutRequestDto
-import pmeet.pmeetserver.project.dto.request.tryout.ProjectTryoutResponseDto
+import pmeet.pmeetserver.project.dto.tryout.request.CreateProjectTryoutRequestDto
+import pmeet.pmeetserver.project.dto.tryout.response.ProjectTryoutResponseDto
 import pmeet.pmeetserver.project.service.ProjectFacadeService
 import reactor.core.publisher.Mono
 
 @RestController
 @RequestMapping("/api/v1/project-tryouts")
 class ProjectTryoutController(
-    private val projectFacadeService: ProjectFacadeService
+  private val projectFacadeService: ProjectFacadeService
 ) {
 
-    @PostMapping
-    @ResponseStatus(HttpStatus.CREATED)
-    suspend fun createProjectTryout(
-        @AuthenticationPrincipal userId: Mono<String>,
-        @RequestBody @Valid requestDto: CreateProjectTryoutRequestDto
-    ): ProjectTryoutResponseDto {
-        return projectFacadeService.createProjectTryout(userId.awaitSingle(), requestDto)
-    }
+  @PostMapping
+  @ResponseStatus(HttpStatus.CREATED)
+  suspend fun createProjectTryout(
+    @AuthenticationPrincipal userId: Mono<String>,
+    @RequestBody @Valid requestDto: CreateProjectTryoutRequestDto
+  ): ProjectTryoutResponseDto {
+    return projectFacadeService.createProjectTryout(userId.awaitSingle(), requestDto)
+  }
 
-    @GetMapping("/{projectId}")
-    @ResponseStatus(HttpStatus.OK)
-    suspend fun getProjectTryoutList(
-        @AuthenticationPrincipal userId: Mono<String>,
-        @PathVariable projectId: String
-    ): List<ProjectTryoutResponseDto> {
-        return projectFacadeService.getProjectTryoutListByProjectId(userId.awaitSingle(), projectId)
-    }
+  @GetMapping("/{projectId}")
+  @ResponseStatus(HttpStatus.OK)
+  suspend fun getProjectTryoutList(
+    @AuthenticationPrincipal userId: Mono<String>,
+    @PathVariable projectId: String
+  ): List<ProjectTryoutResponseDto> {
+    return projectFacadeService.getProjectTryoutListByProjectId(userId.awaitSingle(), projectId)
+  }
 
 }

--- a/src/main/kotlin/pmeet/pmeetserver/project/dto/comment/request/CreateProjectCommentRequestDto.kt
+++ b/src/main/kotlin/pmeet/pmeetserver/project/dto/comment/request/CreateProjectCommentRequestDto.kt
@@ -1,4 +1,4 @@
-package pmeet.pmeetserver.project.dto.request.comment
+package pmeet.pmeetserver.project.dto.comment.request
 
 import jakarta.validation.constraints.NotBlank
 import jakarta.validation.constraints.Size

--- a/src/main/kotlin/pmeet/pmeetserver/project/dto/comment/response/ProjectCommentResponseDto.kt
+++ b/src/main/kotlin/pmeet/pmeetserver/project/dto/comment/response/ProjectCommentResponseDto.kt
@@ -1,9 +1,9 @@
-package pmeet.pmeetserver.project.dto.request.comment
+package pmeet.pmeetserver.project.dto.comment.response
 
-import java.time.LocalDateTime
 import pmeet.pmeetserver.project.domain.ProjectComment
+import java.time.LocalDateTime
 
-data class ProjectCommentWithChildResponseDto(
+data class ProjectCommentResponseDto(
   val id: String,
   val parentCommentId: String?,
   val projectId: String,
@@ -11,12 +11,11 @@ data class ProjectCommentWithChildResponseDto(
   val content: String,
   val likerIdList: List<String>,
   val createdAt: LocalDateTime,
-  val isDeleted: Boolean,
-  val childComments: List<ProjectCommentResponseDto>
+  val isDeleted: Boolean
 ) {
   companion object {
-    fun from(comment: ProjectComment, childComments: List<ProjectComment>): ProjectCommentWithChildResponseDto {
-      return ProjectCommentWithChildResponseDto(
+    fun from(comment: ProjectComment): ProjectCommentResponseDto {
+      return ProjectCommentResponseDto(
         id = comment.id!!,
         parentCommentId = comment.parentCommentId,
         projectId = comment.projectId,
@@ -24,8 +23,7 @@ data class ProjectCommentWithChildResponseDto(
         content = comment.content,
         likerIdList = comment.likerIdList,
         createdAt = comment.createdAt,
-        isDeleted = comment.isDeleted,
-        childComments = childComments.map { ProjectCommentResponseDto.from(it) }
+        isDeleted = comment.isDeleted
       )
     }
   }

--- a/src/main/kotlin/pmeet/pmeetserver/project/dto/comment/response/ProjectCommentWithChildResponseDto.kt
+++ b/src/main/kotlin/pmeet/pmeetserver/project/dto/comment/response/ProjectCommentWithChildResponseDto.kt
@@ -1,9 +1,9 @@
-package pmeet.pmeetserver.project.dto.request.comment
+package pmeet.pmeetserver.project.dto.comment.response
 
-import java.time.LocalDateTime
 import pmeet.pmeetserver.project.domain.ProjectComment
+import java.time.LocalDateTime
 
-data class ProjectCommentResponseDto(
+data class ProjectCommentWithChildResponseDto(
   val id: String,
   val parentCommentId: String?,
   val projectId: String,
@@ -11,11 +11,12 @@ data class ProjectCommentResponseDto(
   val content: String,
   val likerIdList: List<String>,
   val createdAt: LocalDateTime,
-  val isDeleted: Boolean
+  val isDeleted: Boolean,
+  val childComments: List<ProjectCommentResponseDto>
 ) {
   companion object {
-    fun from(comment: ProjectComment): ProjectCommentResponseDto {
-      return ProjectCommentResponseDto(
+    fun from(comment: ProjectComment, childComments: List<ProjectComment>): ProjectCommentWithChildResponseDto {
+      return ProjectCommentWithChildResponseDto(
         id = comment.id!!,
         parentCommentId = comment.parentCommentId,
         projectId = comment.projectId,
@@ -23,7 +24,8 @@ data class ProjectCommentResponseDto(
         content = comment.content,
         likerIdList = comment.likerIdList,
         createdAt = comment.createdAt,
-        isDeleted = comment.isDeleted
+        isDeleted = comment.isDeleted,
+        childComments = childComments.map { ProjectCommentResponseDto.from(it) }
       )
     }
   }

--- a/src/main/kotlin/pmeet/pmeetserver/project/dto/response/ProjectResponseDto.kt
+++ b/src/main/kotlin/pmeet/pmeetserver/project/dto/response/ProjectResponseDto.kt
@@ -25,14 +25,14 @@ data class ProjectResponseDto(
   val updatedAt: LocalDateTime
 ) {
   companion object {
-    fun from(project: Project, userId: String): ProjectResponseDto {
+    fun of(project: Project, userId: String, thumbNailDownloadUrl: String?): ProjectResponseDto {
       return ProjectResponseDto(
         id = project.id!!,
         userId = project.userId,
         title = project.title,
         startDate = project.startDate,
         endDate = project.endDate,
-        thumbNailUrl = project.thumbNailUrl,
+        thumbNailUrl = thumbNailDownloadUrl,
         techStacks = project.techStacks!!,
         recruitments = project.recruitments.map { RecruitmentResponseDto(it.jobName, it.numberOfRecruitment) },
         description = project.description,

--- a/src/main/kotlin/pmeet/pmeetserver/project/dto/response/ProjectWithUserResponseDto.kt
+++ b/src/main/kotlin/pmeet/pmeetserver/project/dto/response/ProjectWithUserResponseDto.kt
@@ -24,14 +24,20 @@ data class ProjectWithUserResponseDto(
   val createdAt: LocalDateTime
 ) {
   companion object {
-    fun from(project: Project, user: User, requestedUserId: String): ProjectWithUserResponseDto {
+    fun from(
+      project: Project,
+      user: User,
+      requestedUserId: String,
+      thumbNailDownloadUrl: String?,
+      userProfileImageDownloadUrl: String?
+    ): ProjectWithUserResponseDto {
       return ProjectWithUserResponseDto(
         id = project.id!!,
         userId = project.userId,
         title = project.title,
         startDate = project.startDate,
         endDate = project.endDate,
-        thumbNailUrl = project.thumbNailUrl,
+        thumbNailUrl = thumbNailDownloadUrl,
         techStacks = project.techStacks!!,
         recruitments = project.recruitments.map {
           RecruitmentResponseDto(
@@ -43,7 +49,7 @@ data class ProjectWithUserResponseDto(
         isCompleted = project.isCompleted,
         bookmarks = project.bookmarkers,
         isMyBookmark = project.bookmarkers.any { it.userId == requestedUserId },
-        userInfo = UserResponseDtoInProject.from(user),
+        userInfo = UserResponseDtoInProject.of(user, userProfileImageDownloadUrl),
         createdAt = project.createdAt
       )
     }

--- a/src/main/kotlin/pmeet/pmeetserver/project/dto/response/SearchProjectResponseDto.kt
+++ b/src/main/kotlin/pmeet/pmeetserver/project/dto/response/SearchProjectResponseDto.kt
@@ -19,14 +19,14 @@ data class SearchProjectResponseDto(
   val updatedAt: LocalDateTime
 ) {
   companion object {
-    fun of(project: Project, userId: String): SearchProjectResponseDto {
+    fun of(project: Project, userId: String, thumbNailDownloadUrl: String?): SearchProjectResponseDto {
       return SearchProjectResponseDto(
         id = project.id!!,
         userId = project.userId,
         title = project.title,
         startDate = project.startDate,
         endDate = project.endDate,
-        thumbNailUrl = project.thumbNailUrl,
+        thumbNailUrl = thumbNailDownloadUrl,
         techStacks = project.techStacks!!,
         jobNames = project.recruitments.map { it.jobName },
         description = project.description,

--- a/src/main/kotlin/pmeet/pmeetserver/project/dto/tryout/request/CreateProjectTryoutRequestDto.kt
+++ b/src/main/kotlin/pmeet/pmeetserver/project/dto/tryout/request/CreateProjectTryoutRequestDto.kt
@@ -1,4 +1,4 @@
-package pmeet.pmeetserver.project.dto.request.tryout
+package pmeet.pmeetserver.project.dto.tryout.request
 
 import jakarta.validation.constraints.NotBlank
 

--- a/src/main/kotlin/pmeet/pmeetserver/project/dto/tryout/response/ProjectTryoutResponseDto.kt
+++ b/src/main/kotlin/pmeet/pmeetserver/project/dto/tryout/response/ProjectTryoutResponseDto.kt
@@ -1,4 +1,4 @@
-package pmeet.pmeetserver.project.dto.request.tryout
+package pmeet.pmeetserver.project.dto.tryout.response
 
 import pmeet.pmeetserver.project.domain.ProjectTryout
 import pmeet.pmeetserver.project.domain.enum.ProjectTryoutStatus

--- a/src/main/kotlin/pmeet/pmeetserver/project/repository/ProjectCommentRepositoryCustom.kt
+++ b/src/main/kotlin/pmeet/pmeetserver/project/repository/ProjectCommentRepositoryCustom.kt
@@ -1,6 +1,6 @@
 package pmeet.pmeetserver.project.repository
 
-import pmeet.pmeetserver.project.dto.request.comment.ProjectCommentWithChildResponseDto
+import pmeet.pmeetserver.project.dto.comment.response.ProjectCommentWithChildResponseDto
 import reactor.core.publisher.Flux
 
 interface ProjectCommentRepositoryCustom {

--- a/src/main/kotlin/pmeet/pmeetserver/project/repository/ProjectCommentRepositoryCustomImpl.kt
+++ b/src/main/kotlin/pmeet/pmeetserver/project/repository/ProjectCommentRepositoryCustomImpl.kt
@@ -13,8 +13,8 @@ import org.springframework.data.mongodb.core.aggregation.Aggregation.sort
 import org.springframework.data.mongodb.core.aggregation.AggregationOperation
 import org.springframework.data.mongodb.core.aggregation.AggregationOperationContext
 import org.springframework.data.mongodb.core.query.Criteria
-import pmeet.pmeetserver.project.dto.request.comment.ProjectCommentResponseDto
-import pmeet.pmeetserver.project.dto.request.comment.ProjectCommentWithChildResponseDto
+import pmeet.pmeetserver.project.dto.comment.response.ProjectCommentResponseDto
+import pmeet.pmeetserver.project.dto.comment.response.ProjectCommentWithChildResponseDto
 import reactor.core.publisher.Flux
 
 class ProjectCommentRepositoryCustomImpl(
@@ -96,7 +96,8 @@ class ProjectCommentRepositoryCustomImpl(
                 userId = childDoc.getString("userId") ?: "",
                 content = childDoc.getString("content") ?: "",
                 likerIdList = childDoc.getList("likerIdList", String::class.java) ?: emptyList(),
-                createdAt = childDoc.getDate("createdAt")?.toInstant()?.atZone(ZoneId.systemDefault())?.toLocalDateTime() ?: LocalDateTime.now(),
+                createdAt = childDoc.getDate("createdAt")?.toInstant()?.atZone(ZoneId.systemDefault())
+                  ?.toLocalDateTime() ?: LocalDateTime.now(),
                 isDeleted = childDoc.getBoolean("isDeleted") ?: false
               )
             }

--- a/src/main/kotlin/pmeet/pmeetserver/project/service/ProjectCommentService.kt
+++ b/src/main/kotlin/pmeet/pmeetserver/project/service/ProjectCommentService.kt
@@ -7,7 +7,7 @@ import org.springframework.transaction.annotation.Transactional
 import pmeet.pmeetserver.common.ErrorCode
 import pmeet.pmeetserver.common.exception.EntityNotFoundException
 import pmeet.pmeetserver.project.domain.ProjectComment
-import pmeet.pmeetserver.project.dto.request.comment.ProjectCommentWithChildResponseDto
+import pmeet.pmeetserver.project.dto.comment.response.ProjectCommentWithChildResponseDto
 import pmeet.pmeetserver.project.repository.ProjectCommentRepository
 
 @Service

--- a/src/main/kotlin/pmeet/pmeetserver/user/dto/response/UserResponseDto.kt
+++ b/src/main/kotlin/pmeet/pmeetserver/user/dto/response/UserResponseDto.kt
@@ -1,8 +1,8 @@
 package pmeet.pmeetserver.user.dto.response
 
-import java.time.LocalDate
 import pmeet.pmeetserver.user.domain.User
 import pmeet.pmeetserver.user.domain.enum.Gender
+import java.time.LocalDate
 
 data class UserResponseDto(
   val id: String,
@@ -18,7 +18,7 @@ data class UserResponseDto(
   val profileImageUrl: String?
 ) {
   companion object {
-    fun from(user: User): UserResponseDto {
+    fun of(user: User, profileImageDownloadUrl: String?): UserResponseDto {
       return UserResponseDto(
         id = user.id!!,
         provider = user.provider,
@@ -30,7 +30,7 @@ data class UserResponseDto(
         introductionComment = user.introductionComment,
         nickname = user.nickname,
         isEmployed = user.isEmployed,
-        profileImageUrl = user.profileImageUrl
+        profileImageUrl = profileImageDownloadUrl
       )
     }
   }

--- a/src/main/kotlin/pmeet/pmeetserver/user/dto/response/UserResponseDtoInProject.kt
+++ b/src/main/kotlin/pmeet/pmeetserver/user/dto/response/UserResponseDtoInProject.kt
@@ -15,7 +15,7 @@ data class UserResponseDtoInProject(
   val profileImageUrl: String?
 ) {
   companion object {
-    fun from(user: User): UserResponseDtoInProject {
+    fun of(user: User, userProfileImageDownloadUrl: String?): UserResponseDtoInProject {
       return UserResponseDtoInProject(
         id = user.id!!,
         email = user.email,
@@ -24,7 +24,7 @@ data class UserResponseDtoInProject(
         gender = user.gender,
         introductionComment = user.introductionComment,
         nickname = user.nickname,
-        profileImageUrl = user.profileImageUrl
+        profileImageUrl = userProfileImageDownloadUrl
       )
     }
   }

--- a/src/main/kotlin/pmeet/pmeetserver/user/dto/response/UserSummaryResponseDto.kt
+++ b/src/main/kotlin/pmeet/pmeetserver/user/dto/response/UserSummaryResponseDto.kt
@@ -11,13 +11,13 @@ data class UserSummaryResponseDto(
   val profileImageUrl: String?
 ) {
   companion object {
-    fun from(user: User): UserSummaryResponseDto {
+    fun of(user: User, profileImageDownloadUrl: String?): UserSummaryResponseDto {
       return UserSummaryResponseDto(
         id = user.id!!,
         email = user.email,
         nickname = user.nickname,
         isEmployed = user.isEmployed,
-        profileImageUrl =  user.profileImageUrl
+        profileImageUrl = profileImageDownloadUrl
       )
     }
   }

--- a/src/main/kotlin/pmeet/pmeetserver/user/dto/resume/response/ResumeResponseDto.kt
+++ b/src/main/kotlin/pmeet/pmeetserver/user/dto/resume/response/ResumeResponseDto.kt
@@ -52,19 +52,19 @@ data class ResumeResponseDto(
   val userBirthDate: LocalDate,
   val userPhoneNumber: String,
   val userEmail: String,
-  val userProfileImageUrl: String,
+  val userProfileImageUrl: String?,
   val desiredJobs: List<JobResponseDto>,
   val techStacks: List<TechStackResponseDto>,
   val jobExperiences: List<ResumeJobExperienceResponseDto>,
   val projectExperiences: List<ResumeProjectExperienceResponseDto>,
-  val portfolioFileUrl: String,
+  val portfolioFileUrl: String?,
   val portfolioUrl: List<String>,
   val selfDescription: String,
   val updatedAt: LocalDateTime,
   val createdAt: LocalDateTime,
 ) {
   companion object {
-    fun from(resume: Resume): ResumeResponseDto {
+    fun of(resume: Resume, profileImageDownloadUrl: String?, portfolioFileDownloadUrl: String?): ResumeResponseDto {
       return ResumeResponseDto(
         id = resume.id!!,
         title = resume.title,
@@ -75,12 +75,12 @@ data class ResumeResponseDto(
         userBirthDate = resume.userBirthDate,
         userPhoneNumber = resume.userPhoneNumber,
         userEmail = resume.userEmail,
-        userProfileImageUrl = resume.userProfileImageUrl ?: "",
+        userProfileImageUrl = profileImageDownloadUrl,
         desiredJobs = resume.desiredJobs.map { JobResponseDto.from(it) },
         techStacks = resume.techStacks.map { TechStackResponseDto.from(it) },
         jobExperiences = resume.jobExperiences.map { ResumeJobExperienceResponseDto.from(it) },
         projectExperiences = resume.projectExperiences.map { ResumeProjectExperienceResponseDto.from(it) },
-        portfolioFileUrl = resume.portfolioFileUrl ?: "",
+        portfolioFileUrl = portfolioFileDownloadUrl,
         portfolioUrl = resume.portfolioUrl,
         selfDescription = resume.selfDescription ?: "",
         updatedAt = resume.updatedAt,

--- a/src/main/kotlin/pmeet/pmeetserver/user/service/UserFacadeService.kt
+++ b/src/main/kotlin/pmeet/pmeetserver/user/service/UserFacadeService.kt
@@ -6,6 +6,7 @@ import org.springframework.transaction.annotation.Transactional
 import pmeet.pmeetserver.common.ErrorCode
 import pmeet.pmeetserver.common.exception.UnauthorizedException
 import pmeet.pmeetserver.common.utils.jwt.JwtUtil
+import pmeet.pmeetserver.file.service.FileService
 import pmeet.pmeetserver.user.domain.User
 import pmeet.pmeetserver.user.dto.request.CheckMailRequestDto
 import pmeet.pmeetserver.user.dto.request.CheckNickNameRequestDto
@@ -26,7 +27,8 @@ class UserFacadeService(
   private val passwordEncoder: PasswordEncoder,
   private val userService: UserService,
   private val emailService: EmailService,
-  private val jwtUtil: JwtUtil
+  private val jwtUtil: JwtUtil,
+  private val fileService: FileService
 ) {
   @Transactional
   suspend fun save(requestDto: SignUpRequestDto): UserSignUpResponseDto {
@@ -98,17 +100,30 @@ class UserFacadeService(
         requestDto.introductionComment
       )
     }
-    return UserResponseDto.from(userService.update(user))
+    return UserResponseDto.of(
+      userService.update(user),
+      user.profileImageUrl?.let { fileService.generatePreSignedUrlToDownload(it) }
+    )
   }
 
   @Transactional(readOnly = true)
   suspend fun getMySummaryInfo(userId: String): UserSummaryResponseDto {
-    return UserSummaryResponseDto.from(userService.getUserById(userId))
+    val user = userService.getUserById(userId)
+
+    return UserSummaryResponseDto.of(
+      user,
+      user.profileImageUrl?.let { fileService.generatePreSignedUrlToDownload(it) }
+    )
   }
 
   @Transactional(readOnly = true)
   suspend fun getMyInfo(userId: String): UserResponseDto {
-    return UserResponseDto.from(userService.getUserById(userId))
+    val user = userService.getUserById(userId)
+
+    return UserResponseDto.of(
+      user,
+      user.profileImageUrl?.let { fileService.generatePreSignedUrlToDownload(it) }
+    )
   }
 
   @Transactional

--- a/src/test/kotlin/pmeet/pmeetserver/project/ProjectCommentIntegrationTest.kt
+++ b/src/test/kotlin/pmeet/pmeetserver/project/ProjectCommentIntegrationTest.kt
@@ -23,8 +23,8 @@ import pmeet.pmeetserver.config.BaseMongoDBTestForIntegration
 import pmeet.pmeetserver.config.TestSecurityConfig
 import pmeet.pmeetserver.project.domain.Project
 import pmeet.pmeetserver.project.domain.ProjectComment
-import pmeet.pmeetserver.project.dto.request.comment.CreateProjectCommentRequestDto
-import pmeet.pmeetserver.project.dto.request.comment.ProjectCommentResponseDto
+import pmeet.pmeetserver.project.dto.comment.request.CreateProjectCommentRequestDto
+import pmeet.pmeetserver.project.dto.comment.response.ProjectCommentResponseDto
 import pmeet.pmeetserver.project.repository.ProjectCommentRepository
 import pmeet.pmeetserver.project.repository.ProjectRepository
 import java.time.LocalDateTime

--- a/src/test/kotlin/pmeet/pmeetserver/project/ProjectIntegrationTest.kt
+++ b/src/test/kotlin/pmeet/pmeetserver/project/ProjectIntegrationTest.kt
@@ -2,7 +2,6 @@ package pmeet.pmeetserver.project
 
 import io.kotest.core.spec.IsolationMode
 import io.kotest.core.spec.Spec
-import io.kotest.core.spec.style.DescribeSpec
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.shouldNotBe
 import kotlinx.coroutines.Dispatchers
@@ -23,12 +22,16 @@ import org.springframework.test.util.ReflectionTestUtils
 import org.springframework.test.web.reactive.server.WebTestClient
 import org.springframework.test.web.reactive.server.expectBody
 import pmeet.pmeetserver.config.BaseMongoDBTestForIntegration
-import pmeet.pmeetserver.project.domain.*
+import pmeet.pmeetserver.project.domain.Project
+import pmeet.pmeetserver.project.domain.ProjectBookmark
+import pmeet.pmeetserver.project.domain.ProjectComment
+import pmeet.pmeetserver.project.domain.ProjectTryout
+import pmeet.pmeetserver.project.domain.Recruitment
 import pmeet.pmeetserver.project.domain.enum.ProjectTryoutStatus
+import pmeet.pmeetserver.project.dto.comment.response.ProjectCommentWithChildResponseDto
 import pmeet.pmeetserver.project.dto.request.CreateProjectRequestDto
 import pmeet.pmeetserver.project.dto.request.RecruitmentRequestDto
 import pmeet.pmeetserver.project.dto.request.UpdateProjectRequestDto
-import pmeet.pmeetserver.project.dto.request.comment.ProjectCommentWithChildResponseDto
 import pmeet.pmeetserver.project.dto.response.ProjectResponseDto
 import pmeet.pmeetserver.project.dto.response.ProjectWithUserResponseDto
 import pmeet.pmeetserver.project.dto.response.SearchProjectResponseDto
@@ -50,935 +53,933 @@ import java.time.LocalDateTime
 @ActiveProfiles("test")
 internal class ProjectIntegrationTest : BaseMongoDBTestForIntegration() {
 
-    override fun isolationMode(): IsolationMode? {
-        return IsolationMode.InstancePerLeaf
+  override fun isolationMode(): IsolationMode? {
+    return IsolationMode.InstancePerLeaf
+  }
+
+  @Autowired
+  lateinit var webTestClient: WebTestClient
+
+  @Autowired
+  lateinit var projectRepository: ProjectRepository
+
+  @Autowired
+  lateinit var projectCommentRepository: ProjectCommentRepository
+
+  @Autowired
+  lateinit var userRepository: UserRepository
+
+  @Autowired
+  lateinit var projectTryoutRepository: ProjectTryoutRepository
+
+  lateinit var project: Project
+  lateinit var projectId: String
+  lateinit var userId: String
+  lateinit var recruitments: List<Recruitment>
+  lateinit var projectComment: ProjectComment
+  lateinit var user: User
+  lateinit var deletedProjectComment: ProjectComment
+  lateinit var childProjectComment: ProjectComment
+  lateinit var projectTryout: ProjectTryout
+
+  override suspend fun beforeSpec(spec: Spec) {
+    userId = "user-id"
+    user = User(
+      id = userId,
+      email = "testEmail@test.com",
+      name = "testName",
+      nickname = "nickname",
+      phoneNumber = "phone",
+      gender = Gender.MALE,
+      profileImageUrl = "image-url"
+    )
+
+    recruitments = listOf(
+      Recruitment(
+        jobName = "testJobName",
+        numberOfRecruitment = 1
+      ),
+      Recruitment(
+        jobName = "testJobName2",
+        numberOfRecruitment = 2
+      )
+    )
+
+    projectId = "project-id"
+    project = Project(
+      id = projectId,
+      userId = userId,
+      title = "testTitle",
+      startDate = LocalDateTime.of(2021, 1, 1, 0, 0, 0),
+      endDate = LocalDateTime.of(2021, 12, 31, 23, 59, 59),
+      thumbNailUrl = "testThumbNailUrl",
+      techStacks = listOf("testTechStack1", "testTechStack2"),
+      recruitments = recruitments,
+      description = "testDescription"
+    )
+
+    project.addBookmark(userId)
+
+    withContext(Dispatchers.IO) {
+      projectRepository.save(project).block()
+
+      projectComment = ProjectComment(
+        projectId = projectId,
+        userId = userId,
+        content = "testContent",
+        isDeleted = false,
+      )
+      projectCommentRepository.save(projectComment).block()
+      userRepository.save(user).block()
+
+      deletedProjectComment = ProjectComment(
+        projectId = projectId,
+        userId = userId,
+        content = "childContent",
+        isDeleted = true,
+      )
+      projectCommentRepository.save(deletedProjectComment).block()
+
+      projectTryout = ProjectTryout(
+        projectId = project.id!!,
+        userId = userId,
+        resumeId = "resumeId",
+        userName = "testUserName",
+        userSelfDescription = "testUserSelfDescription",
+        positionName = "testPosition",
+        tryoutStatus = ProjectTryoutStatus.INREVIEW,
+        createdAt = LocalDateTime.now()
+      )
+      projectTryoutRepository.save(projectTryout).block()
+    }
+  }
+
+  override suspend fun afterSpec(spec: Spec) {
+    withContext(Dispatchers.IO) {
+      projectRepository.deleteAll().block()
+      projectCommentRepository.deleteAll().block()
+      projectTryoutRepository.deleteAll().block()
+      userRepository.deleteAll().block()
+    }
+  }
+
+  init {
+    describe("GET api/v1/projects") {
+      context("유저의 프로젝트 조회 요청이 들어오면") {
+        val mockAuthentication = UsernamePasswordAuthenticationToken(userId, null, null)
+
+        val performRequest =
+          webTestClient
+            .mutateWith(mockAuthentication(mockAuthentication))
+            .get()
+            .uri {
+              it.path("/api/v1/projects/$projectId")
+                .build()
+            }
+            .exchange()
+
+
+        it("요청은 성공한다") {
+          performRequest.expectStatus().isOk
+        }
+
+        it("프로젝트를 반환한다") {
+          performRequest.expectBody<ProjectWithUserResponseDto>().consumeWith { result ->
+            val returnedProject = result.responseBody!!
+
+            returnedProject.id shouldBe projectId
+            returnedProject.userId shouldBe userId
+            returnedProject.title shouldBe project.title
+            returnedProject.startDate shouldBe project.startDate
+            returnedProject.endDate shouldBe project.endDate
+            returnedProject.thumbNailUrl shouldNotBe project.thumbNailUrl
+            returnedProject.description shouldBe project.description
+            returnedProject.isCompleted shouldBe project.isCompleted
+            returnedProject.userInfo.id shouldBe user.id
+            returnedProject.techStacks shouldBe project.techStacks
+            returnedProject.recruitments.size shouldBe project.recruitments.size
+            returnedProject.recruitments.forEachIndexed { index, recruitmentResponseDto ->
+              recruitmentResponseDto.jobName shouldBe project.recruitments[index].jobName
+              recruitmentResponseDto.numberOfRecruitment shouldBe project.recruitments[index].numberOfRecruitment
+            }
+            returnedProject.isMyBookmark shouldBe true
+          }
+        }
+      }
     }
 
-    @Autowired
-    lateinit var webTestClient: WebTestClient
-
-    @Autowired
-    lateinit var projectRepository: ProjectRepository
-
-    @Autowired
-    lateinit var projectCommentRepository: ProjectCommentRepository
-
-    @Autowired
-    lateinit var userRepository: UserRepository
-
-    @Autowired
-    lateinit var projectTryoutRepository: ProjectTryoutRepository
-
-    lateinit var project: Project
-    lateinit var projectId: String
-    lateinit var userId: String
-    lateinit var recruitments: List<Recruitment>
-    lateinit var projectComment: ProjectComment
-    lateinit var user: User
-    lateinit var deletedProjectComment: ProjectComment
-    lateinit var childProjectComment: ProjectComment
-    lateinit var projectTryout: ProjectTryout
-
-    override suspend fun beforeSpec(spec: Spec) {
-        userId = "user-id"
-        user = User(
-            id = userId,
-            email = "testEmail@test.com",
-            name = "testName",
-            nickname = "nickname",
-            phoneNumber = "phone",
-            gender = Gender.MALE,
-            profileImageUrl = "image-url"
-        )
-
-        recruitments = listOf(
-            Recruitment(
-                jobName = "testJobName",
-                numberOfRecruitment = 1
+    describe("POST api/v1/projects") {
+      context("인증된 유저의 Project 생성 요청이 들어오면") {
+        val mockAuthentication = UsernamePasswordAuthenticationToken(userId, null, null)
+        val requestDto = CreateProjectRequestDto(
+          title = "TestProject",
+          startDate = LocalDateTime.of(2021, 1, 1, 0, 0, 0),
+          endDate = LocalDateTime.of(2021, 12, 31, 23, 59, 59),
+          thumbNailUrl = "testThumbNailUrl",
+          techStacks = listOf("testTechStack1", "testTechStack2"),
+          recruitments = listOf(
+            RecruitmentRequestDto(
+              jobName = "testJobName",
+              numberOfRecruitment = 1
             ),
-            Recruitment(
-                jobName = "testJobName2",
-                numberOfRecruitment = 2
+            RecruitmentRequestDto(
+              jobName = "testJobName2",
+              numberOfRecruitment = 2
             )
+          ),
+          description = "testDescription"
         )
+        val performRequest = webTestClient
+          .mutateWith(mockAuthentication(mockAuthentication))
+          .post()
+          .uri("/api/v1/projects")
+          .accept(MediaType.APPLICATION_JSON)
+          .bodyValue(requestDto)
+          .exchange()
 
-        projectId = "project-id"
-        project = Project(
-            id = projectId,
+        it("요청은 성공한다") {
+          performRequest.expectStatus().isCreated
+        }
+
+        it("생성된 Project 정보를 반환한다") {
+          performRequest.expectBody<ProjectResponseDto>().consumeWith { response ->
+            response.responseBody?.id shouldNotBe project.id
+            response.responseBody?.title shouldBe requestDto.title
+            response.responseBody?.startDate shouldBe requestDto.startDate
+            response.responseBody?.endDate shouldBe requestDto.endDate
+            response.responseBody?.thumbNailUrl shouldNotBe requestDto.thumbNailUrl
+            response.responseBody?.techStacks shouldBe requestDto.techStacks
+            response.responseBody?.recruitments?.size shouldBe requestDto.recruitments.size
+            response.responseBody?.recruitments?.forEachIndexed { index, recruitmentResponseDto ->
+              recruitmentResponseDto.jobName shouldBe requestDto.recruitments[index].jobName
+              recruitmentResponseDto.numberOfRecruitment shouldBe requestDto.recruitments[index].numberOfRecruitment
+            }
+            response.responseBody?.description shouldBe requestDto.description
+            response.responseBody?.userId shouldBe project.userId
+            response.responseBody?.bookmarked shouldBe false
+            response.responseBody?.isCompleted shouldBe project.isCompleted
+            response.responseBody?.createdAt shouldNotBe null
+            response.responseBody?.updatedAt shouldNotBe null
+          }
+        }
+      }
+    }
+
+    describe("PUT api/v1/projects") {
+      context("인증된 유저의 Project 수정 요청이 들어오면") {
+        val mockAuthentication = UsernamePasswordAuthenticationToken(userId, null, null)
+        val requestDto = UpdateProjectRequestDto(
+          id = project.id!!,
+          title = "UpdateTitle",
+          startDate = LocalDateTime.of(2024, 7, 20, 0, 0, 0),
+          endDate = LocalDateTime.of(2024, 7, 22, 0, 0, 0),
+          thumbNailUrl = "updateThumbNailUrl",
+          techStacks = listOf("updateTechStack1", "updateTechStack2"),
+          recruitments = listOf(
+            RecruitmentRequestDto(
+              jobName = "updateJobName1",
+              numberOfRecruitment = 3
+            ),
+            RecruitmentRequestDto(
+              jobName = "updateJobName2",
+              numberOfRecruitment = 4
+            )
+          ),
+          description = "updateDescription"
+        )
+        val performRequest = webTestClient
+          .mutateWith(mockAuthentication(mockAuthentication))
+          .put()
+          .uri("/api/v1/projects")
+          .accept(MediaType.APPLICATION_JSON)
+          .bodyValue(requestDto)
+          .exchange()
+
+        it("요청은 성공한다") {
+          performRequest.expectStatus().isOk
+        }
+
+        it("수정된 Project 정보를 반환한다") {
+          performRequest.expectBody<ProjectResponseDto>().consumeWith { response ->
+            response.responseBody?.id shouldBe project.id
+            response.responseBody?.title shouldBe requestDto.title
+            response.responseBody?.startDate shouldBe requestDto.startDate
+            response.responseBody?.endDate shouldBe requestDto.endDate
+            response.responseBody?.thumbNailUrl shouldNotBe requestDto.thumbNailUrl
+            response.responseBody?.techStacks shouldBe requestDto.techStacks
+            response.responseBody?.recruitments?.size shouldBe requestDto.recruitments.size
+            response.responseBody?.recruitments?.forEachIndexed { index, recruitmentResponseDto ->
+              recruitmentResponseDto.jobName shouldBe requestDto.recruitments[index].jobName
+              recruitmentResponseDto.numberOfRecruitment shouldBe requestDto.recruitments[index].numberOfRecruitment
+            }
+            response.responseBody?.description shouldBe requestDto.description
+            response.responseBody?.userId shouldBe project.userId
+            response.responseBody?.bookmarked shouldBe true
+            response.responseBody?.isCompleted shouldBe project.isCompleted
+            response.responseBody?.createdAt shouldNotBe null
+            response.responseBody?.updatedAt shouldNotBe null
+          }
+        }
+      }
+    }
+
+    describe("DELETE api/v1/projects/{projectId}") {
+      context("인증된 유저의 Project 삭제 요청이 들어오면") {
+        val mockAuthentication = UsernamePasswordAuthenticationToken(userId, null, null)
+        val performRequest = webTestClient
+          .mutateWith(mockAuthentication(mockAuthentication))
+          .delete()
+          .uri("/api/v1/projects/${project.id}")
+          .accept(MediaType.APPLICATION_JSON)
+          .exchange()
+
+        it("요청은 성공한다") {
+          performRequest.expectStatus().isNoContent
+        }
+
+        it("Project가 삭제된다") {
+          withContext(Dispatchers.IO) {
+            val deletedProject = projectRepository.findById(project.id!!).block()
+            deletedProject shouldBe null
+          }
+        }
+
+        it("ProjectComment가 삭제된다") {
+          withContext(Dispatchers.IO) {
+            val deletedProjectComment = projectCommentRepository.findById(projectComment.id!!).block()
+            deletedProjectComment shouldBe null
+          }
+        }
+
+        it("ProjectTryout이 삭제된다") {
+          withContext(Dispatchers.IO) {
+            val deletedProjectTryout = projectTryoutRepository.findById(projectTryout.id!!).block()
+            deletedProjectTryout shouldBe null
+          }
+        }
+      }
+    }
+
+    describe("GET api/v1/projects/{projectId}/comments") {
+      context("Project Comment 전체 조회 요청이 들어오면") {
+        val deletedProjectComment1 = ProjectComment(
+          projectId = "testProjectId",
+          userId = "testUserId",
+          content = "deleted1",
+          isDeleted = true
+        )
+        projectCommentRepository.save(deletedProjectComment1).block()
+
+        val deletedProjectComment2 = ProjectComment(
+          projectId = "testProjectId",
+          userId = "testUserId",
+          content = "deleted2",
+          isDeleted = true
+        )
+        projectCommentRepository.save(deletedProjectComment2).block()
+
+        val childProjectComment1 = ProjectComment(
+          parentCommentId = deletedProjectComment1.id!!,
+          projectId = "testProjectId",
+          userId = "testUserId",
+          content = "child",
+          isDeleted = false
+        )
+        projectCommentRepository.save(childProjectComment1).block()
+
+        val deletedChildProjectComment1 = ProjectComment(
+          parentCommentId = deletedProjectComment1.id!!,
+          projectId = "testProjectId",
+          userId = "testUserId",
+          content = "deletedChild",
+          isDeleted = true
+        )
+        projectCommentRepository.save(deletedChildProjectComment1).block()
+
+        val mockAuthentication = UsernamePasswordAuthenticationToken(userId, null, null)
+        val projectId = "testProjectId"
+
+        val performRequest = webTestClient
+          .mutateWith(mockAuthentication(mockAuthentication))
+          .get()
+          .uri("/api/v1/projects/$projectId/comments")
+          .accept(MediaType.APPLICATION_JSON)
+          .exchange()
+
+        it("요청은 성공한다") {
+          performRequest.expectStatus().isOk
+        }
+
+        it("생성된 Project 정보를 반환한다") {
+          performRequest.expectBody<List<ProjectCommentWithChildResponseDto>>().consumeWith { response ->
+            response.responseBody?.get(0)?.id shouldBe deletedProjectComment1.id
+            response.responseBody?.get(0)?.parentCommentId shouldBe deletedProjectComment1.parentCommentId
+            response.responseBody?.get(0)?.projectId shouldBe deletedProjectComment1.projectId
+            response.responseBody?.get(0)?.userId shouldBe deletedProjectComment1.userId
+            response.responseBody?.get(0)?.content shouldBe deletedProjectComment1.content
+            response.responseBody?.get(0)?.isDeleted shouldBe deletedProjectComment1.isDeleted
+
+            response.responseBody?.get(0)?.childComments?.get(0)?.id shouldBe childProjectComment1.id
+            response.responseBody?.get(0)?.childComments?.get(0)?.content shouldBe childProjectComment1.content
+            response.responseBody?.get(0)?.childComments?.get(0)?.userId shouldBe childProjectComment1.userId
+            response.responseBody?.get(0)?.childComments?.get(0)?.parentCommentId shouldBe childProjectComment1.parentCommentId
+            response.responseBody?.get(0)?.childComments?.get(0)?.projectId shouldBe childProjectComment1.projectId
+            response.responseBody?.get(0)?.childComments?.get(0)?.isDeleted shouldBe childProjectComment1.isDeleted
+          }
+        }
+      }
+    }
+
+    describe("GET /api/v1/projects/search-slice") {
+      withContext(Dispatchers.IO) {
+        projectRepository.deleteAll().block()
+      }
+      val userId = "1234"
+      val pageNumber = 0
+      val pageSize = 10
+      val mockAuthentication = UsernamePasswordAuthenticationToken(userId, null, null)
+      context("인증된 유저가 Filter 없이 완료되지 않은 Project Slice 조회를 하면") {
+        for (i in 1..20) {
+          val newProject = Project(
+            id = "testId$i",
             userId = userId,
-            title = "testTitle",
+            title = "testTitle$i",
             startDate = LocalDateTime.of(2021, 1, 1, 0, 0, 0),
             endDate = LocalDateTime.of(2021, 12, 31, 23, 59, 59),
             thumbNailUrl = "testThumbNailUrl",
             techStacks = listOf("testTechStack1", "testTechStack2"),
             recruitments = recruitments,
             description = "testDescription"
-        )
-
-        project.addBookmark(userId)
-
-        withContext(Dispatchers.IO) {
-            projectRepository.save(project).block()
-
-            projectComment = ProjectComment(
-                projectId = projectId,
-                userId = userId,
-                content = "testContent",
-                isDeleted = false,
-            )
-            projectCommentRepository.save(projectComment).block()
-            userRepository.save(user).block()
-
-            deletedProjectComment = ProjectComment(
-                projectId = projectId,
-                userId = userId,
-                content = "childContent",
-                isDeleted = true,
-            )
-            projectCommentRepository.save(deletedProjectComment).block()
-
-            projectTryout = ProjectTryout(
-                projectId = project.id!!,
-                userId = userId,
-                resumeId = "resumeId",
-                userName = "testUserName",
-                userSelfDescription = "testUserSelfDescription",
-                positionName = "testPosition",
-                tryoutStatus = ProjectTryoutStatus.INREVIEW,
-                createdAt = LocalDateTime.now()
-            )
-            projectTryoutRepository.save(projectTryout).block()
+          )
+          ReflectionTestUtils.setField(
+            newProject,
+            "createdAt",
+            LocalDateTime.of(2021, 1, 1, 0, 0, 0).plusDays(i.toLong())
+          )
+          withContext(Dispatchers.IO) {
+            projectRepository.save(newProject).block()
+          }
         }
+        val performRequest = webTestClient
+          .mutateWith(mockAuthentication(mockAuthentication))
+          .get()
+          .uri {
+            it.path("/api/v1/projects/search-slice")
+              .queryParam("page", pageNumber)
+              .queryParam("size", pageSize)
+              .queryParam("sortBy", ProjectSortProperty.CREATED_AT)
+              .queryParam("direction", Direction.DESC)
+              .build()
+          }
+          .accept(MediaType.APPLICATION_JSON)
+          .exchange()
+
+        it("요청은 성공한다") {
+          performRequest.expectStatus().isOk
+        }
+
+        it("완료되지 않은 Project를 대상으로 PageSize만큼 Slice를 반환한다") {
+          performRequest.expectBody<RestSliceImpl<SearchProjectResponseDto>>().consumeWith { response ->
+            response.responseBody?.content?.size shouldBe pageSize
+            response.responseBody?.isFirst shouldBe true
+            response.responseBody?.isLast shouldBe false
+            response.responseBody?.hasNext() shouldBe true
+            response.responseBody?.forEachIndexed { index, searchProjectResponseDto ->
+              searchProjectResponseDto.id shouldBe "testId${20 - index}"
+              searchProjectResponseDto.title shouldBe "testTitle${20 - index}"
+              searchProjectResponseDto.isCompleted shouldBe false
+              searchProjectResponseDto.createdAt shouldBe LocalDateTime.of(2021, 1, 1, 0, 0, 0)
+                .plusDays(20 - index.toLong())
+            }
+          }
+        }
+      }
+      context("인증된 유저가 Filter 없이 완료된 Project Slice 조회를 하면") {
+        for (i in 1..20) {
+          val newProject = Project(
+            id = "testId$i",
+            userId = userId,
+            title = "testTitle$i",
+            startDate = LocalDateTime.of(2021, 1, 1, 0, 0, 0),
+            endDate = LocalDateTime.of(2021, 12, 31, 23, 59, 59),
+            thumbNailUrl = "testThumbNailUrl",
+            techStacks = listOf("testTechStack1", "testTechStack2"),
+            recruitments = recruitments,
+            description = "testDescription",
+            isCompleted = true
+          )
+          ReflectionTestUtils.setField(
+            newProject,
+            "createdAt",
+            LocalDateTime.of(2021, 1, 1, 0, 0, 0).plusDays(i.toLong())
+          )
+          withContext(Dispatchers.IO) {
+            projectRepository.save(newProject).block()
+          }
+        }
+        val performRequest = webTestClient
+          .mutateWith(mockAuthentication(mockAuthentication))
+          .get()
+          .uri {
+            it.path("/api/v1/projects/search-slice")
+              .queryParam("page", pageNumber)
+              .queryParam("size", pageSize)
+              .queryParam("sortBy", ProjectSortProperty.CREATED_AT)
+              .queryParam("direction", Direction.DESC)
+              .queryParam("isCompleted", true)
+              .build()
+          }
+          .accept(MediaType.APPLICATION_JSON)
+          .exchange()
+
+        it("요청은 성공한다") {
+          performRequest.expectStatus().isOk
+        }
+
+        it("완료된 Project를 대상으로 PageSize만큼 Slice를 반환한다") {
+          performRequest.expectBody<RestSliceImpl<SearchProjectResponseDto>>().consumeWith { response ->
+            response.responseBody?.content?.size shouldBe pageSize
+            response.responseBody?.isFirst shouldBe true
+            response.responseBody?.isLast shouldBe false
+            response.responseBody?.hasNext() shouldBe true
+            response.responseBody?.forEachIndexed { index, searchProjectResponseDto ->
+              searchProjectResponseDto.id shouldBe "testId${20 - index}"
+              searchProjectResponseDto.title shouldBe "testTitle${20 - index}"
+              searchProjectResponseDto.createdAt shouldBe LocalDateTime.of(2021, 1, 1, 0, 0, 0)
+                .plusDays(20 - index.toLong())
+              searchProjectResponseDto.isCompleted shouldBe true
+            }
+          }
+        }
+      }
+      context("인증된 유저가 ALL Type 필터로 조회하면") {
+        for (i in 1..20) {
+          val newProject = Project(
+            id = "testId$i",
+            userId = userId,
+            title = "testTitle$i",
+            startDate = LocalDateTime.of(2021, 1, 1, 0, 0, 0),
+            endDate = LocalDateTime.of(2021, 12, 31, 23, 59, 59),
+            thumbNailUrl = "testThumbNailUrl",
+            techStacks = listOf("testTechStack1", "testTechStack2"),
+            recruitments = recruitments,
+            description = "testDescription"
+          )
+          ReflectionTestUtils.setField(
+            newProject,
+            "createdAt",
+            LocalDateTime.of(2021, 1, 1, 0, 0, 0).plusDays(i.toLong())
+          )
+          withContext(Dispatchers.IO) {
+            projectRepository.save(newProject).block()
+          }
+        }
+        val performRequest = webTestClient
+          .mutateWith(mockAuthentication(mockAuthentication))
+          .get()
+          .uri {
+            it.path("/api/v1/projects/search-slice")
+              .queryParam("page", pageNumber)
+              .queryParam("size", pageSize)
+              .queryParam("sortBy", ProjectSortProperty.CREATED_AT)
+              .queryParam("direction", Direction.DESC)
+              .queryParam("filterType", ProjectFilterType.ALL)
+              .queryParam("filterValue", "Title2")
+              .build()
+          }
+          .accept(MediaType.APPLICATION_JSON)
+          .exchange()
+
+        it("요청은 성공한다") {
+          performRequest.expectStatus().isOk
+        }
+
+        it("완료된 Project를 대상으로 PageSize만큼 Slice를 반환한다") {
+          performRequest.expectBody<RestSliceImpl<SearchProjectResponseDto>>().consumeWith { response ->
+            response.responseBody?.content?.size shouldBe 2
+            response.responseBody?.isFirst shouldBe true
+            response.responseBody?.isLast shouldBe true
+            response.responseBody?.hasNext() shouldBe false
+            response.responseBody?.content?.get(0)?.id shouldBe "testId20"
+            response.responseBody?.content?.get(1)?.id shouldBe "testId2"
+          }
+        }
+      }
+      context("인증된 유저가 Title Type 필터로 조회하면") {
+        for (i in 1..20) {
+          val newProject = Project(
+            id = "testId$i",
+            userId = userId,
+            title = "testTitle$i",
+            startDate = LocalDateTime.of(2021, 1, 1, 0, 0, 0),
+            endDate = LocalDateTime.of(2021, 12, 31, 23, 59, 59),
+            thumbNailUrl = "testThumbNailUrl",
+            techStacks = listOf("testTechStack1", "testTechStack2"),
+            recruitments = recruitments,
+            description = "testDescription"
+          )
+          ReflectionTestUtils.setField(
+            newProject,
+            "createdAt",
+            LocalDateTime.of(2021, 1, 1, 0, 0, 0).plusDays(i.toLong())
+          )
+          withContext(Dispatchers.IO) {
+            projectRepository.save(newProject).block()
+          }
+        }
+        val performRequest = webTestClient
+          .mutateWith(mockAuthentication(mockAuthentication))
+          .get()
+          .uri {
+            it.path("/api/v1/projects/search-slice")
+              .queryParam("page", pageNumber)
+              .queryParam("size", pageSize)
+              .queryParam("sortBy", ProjectSortProperty.CREATED_AT)
+              .queryParam("direction", Direction.DESC)
+              .queryParam("filterType", ProjectFilterType.TITLE)
+              .queryParam("filterValue", "Title2")
+              .build()
+          }
+          .accept(MediaType.APPLICATION_JSON)
+          .exchange()
+
+        it("요청은 성공한다") {
+          performRequest.expectStatus().isOk
+        }
+
+        it("완료된 Project를 대상으로 PageSize만큼 Slice를 반환한다") {
+          performRequest.expectBody<RestSliceImpl<SearchProjectResponseDto>>().consumeWith { response ->
+            response.responseBody?.content?.size shouldBe 2
+            response.responseBody?.isFirst shouldBe true
+            response.responseBody?.isLast shouldBe true
+            response.responseBody?.hasNext() shouldBe false
+            response.responseBody?.content?.get(0)?.id shouldBe "testId20"
+            response.responseBody?.content?.get(1)?.id shouldBe "testId2"
+          }
+        }
+      }
+      context("인증된 유저가 JobName Type 필터로 조회하면") {
+        for (i in 1..20) {
+          val newProject = Project(
+            id = "testId$i",
+            userId = userId,
+            title = "testTitle$i",
+            startDate = LocalDateTime.of(2021, 1, 1, 0, 0, 0),
+            endDate = LocalDateTime.of(2021, 12, 31, 23, 59, 59),
+            thumbNailUrl = "testThumbNailUrl",
+            techStacks = listOf("testTechStack1", "testTechStack2"),
+            recruitments = recruitments,
+            description = "testDescription"
+          )
+          ReflectionTestUtils.setField(
+            newProject,
+            "createdAt",
+            LocalDateTime.of(2021, 1, 1, 0, 0, 0).plusDays(i.toLong())
+          )
+          withContext(Dispatchers.IO) {
+            projectRepository.save(newProject).block()
+          }
+        }
+        val performRequest = webTestClient
+          .mutateWith(mockAuthentication(mockAuthentication))
+          .get()
+          .uri {
+            it.path("/api/v1/projects/search-slice")
+              .queryParam("page", pageNumber)
+              .queryParam("size", pageSize)
+              .queryParam("sortBy", ProjectSortProperty.CREATED_AT)
+              .queryParam("direction", Direction.DESC)
+              .queryParam("filterType", ProjectFilterType.JOB_NAME)
+              .queryParam("filterValue", "testJobName")
+              .build()
+          }
+          .accept(MediaType.APPLICATION_JSON)
+          .exchange()
+
+        it("요청은 성공한다") {
+          performRequest.expectStatus().isOk
+        }
+
+        it("완료된 Project를 대상으로 PageSize만큼 Slice를 반환한다") {
+          performRequest.expectBody<RestSliceImpl<SearchProjectResponseDto>>().consumeWith { response ->
+            response.responseBody?.content?.size shouldBe 10
+            response.responseBody?.isFirst shouldBe true
+            response.responseBody?.isLast shouldBe false
+            response.responseBody?.hasNext() shouldBe true
+            response.responseBody?.forEachIndexed { index, searchProjectResponseDto ->
+              searchProjectResponseDto.id shouldBe "testId${20 - index}"
+              searchProjectResponseDto.title shouldBe "testTitle${20 - index}"
+              searchProjectResponseDto.createdAt shouldBe LocalDateTime.of(2021, 1, 1, 0, 0, 0)
+                .plusDays(20 - index.toLong())
+            }
+          }
+        }
+      }
+      context("인증된 유저가 북마크 순으로 조회하면") {
+        for (i in 1..20) {
+          val newProject = Project(
+            id = "testId$i",
+            userId = userId,
+            title = "testTitle$i",
+            startDate = LocalDateTime.of(2021, 1, 1, 0, 0, 0),
+            endDate = LocalDateTime.of(2021, 12, 31, 23, 59, 59),
+            thumbNailUrl = "testThumbNailUrl",
+            techStacks = listOf("testTechStack1", "testTechStack2"),
+            recruitments = recruitments,
+            description = "testDescription"
+          )
+          if (i == 20) {
+            newProject.bookmarkers.add(ProjectBookmark(userId, LocalDateTime.now()))
+          }
+          for (j in 1..i) {
+            newProject.bookmarkers.add(ProjectBookmark("testUserId$j", LocalDateTime.now()))
+          }
+          withContext(Dispatchers.IO) {
+            projectRepository.save(newProject).block()
+          }
+        }
+        val performRequest = webTestClient
+          .mutateWith(mockAuthentication(mockAuthentication))
+          .get()
+          .uri {
+            it.path("/api/v1/projects/search-slice")
+              .queryParam("page", pageNumber)
+              .queryParam("size", pageSize)
+              .queryParam("sortBy", ProjectSortProperty.BOOK_MARKERS)
+              .queryParam("direction", Direction.DESC)
+              .build()
+          }
+          .accept(MediaType.APPLICATION_JSON)
+          .exchange()
+
+        it("요청은 성공한다") {
+          performRequest.expectStatus().isOk
+        }
+
+        it("북마크 순으로 Project를 PageSize만큼 Slice를 반환한다") {
+          performRequest.expectBody<RestSliceImpl<SearchProjectResponseDto>>().consumeWith { response ->
+            response.responseBody?.content?.size shouldBe 10
+            response.responseBody?.isFirst shouldBe true
+            response.responseBody?.isLast shouldBe false
+            response.responseBody?.hasNext() shouldBe true
+            response.responseBody?.forEachIndexed { index, searchProjectResponseDto ->
+              searchProjectResponseDto.id shouldBe "testId${20 - index}"
+              searchProjectResponseDto.title shouldBe "testTitle${20 - index}"
+            }
+          }
+        }
+        it("요청한 유저가 북마크한 Project면 응답의 bookMarked를 True로 반환한다") {
+          performRequest.expectBody<RestSliceImpl<SearchProjectResponseDto>>().consumeWith { response ->
+            response.responseBody?.content?.get(0)?.bookmarked shouldBe true
+          }
+        }
+      }
+      context("인증된 유저가 최신등록 순으로 조회하면") {
+        for (i in 1..20) {
+          val newProject = Project(
+            id = "testId$i",
+            userId = userId,
+            title = "testTitle$i",
+            startDate = LocalDateTime.of(2021, 1, 1, 0, 0, 0),
+            endDate = LocalDateTime.of(2021, 12, 31, 23, 59, 59),
+            thumbNailUrl = "testThumbNailUrl",
+            techStacks = listOf("testTechStack1", "testTechStack2"),
+            recruitments = recruitments,
+            description = "testDescription"
+          )
+          ReflectionTestUtils.setField(
+            newProject,
+            "createdAt",
+            LocalDateTime.of(2021, 1, 1, 0, 0, 0).plusDays(i.toLong())
+          )
+          withContext(Dispatchers.IO) {
+            projectRepository.save(newProject).block()
+          }
+        }
+        val performRequest = webTestClient
+          .mutateWith(mockAuthentication(mockAuthentication))
+          .get()
+          .uri {
+            it.path("/api/v1/projects/search-slice")
+              .queryParam("page", pageNumber)
+              .queryParam("size", pageSize)
+              .queryParam("sortBy", ProjectSortProperty.CREATED_AT)
+              .queryParam("direction", Direction.DESC)
+              .build()
+          }
+          .accept(MediaType.APPLICATION_JSON)
+          .exchange()
+
+        it("요청은 성공한다") {
+          performRequest.expectStatus().isOk
+        }
+
+        it("최신등록 순으로 Project를 PageSize만큼 Slice를 반환한다") {
+          performRequest.expectBody<RestSliceImpl<SearchProjectResponseDto>>().consumeWith { response ->
+            response.responseBody?.content?.size shouldBe pageSize
+            response.responseBody?.isFirst shouldBe true
+            response.responseBody?.isLast shouldBe false
+            response.responseBody?.hasNext() shouldBe true
+            response.responseBody?.forEachIndexed { index, searchProjectResponseDto ->
+              searchProjectResponseDto.id shouldBe "testId${20 - index}"
+              searchProjectResponseDto.title shouldBe "testTitle${20 - index}"
+              searchProjectResponseDto.createdAt shouldBe LocalDateTime.of(2021, 1, 1, 0, 0, 0)
+                .plusDays(20 - index.toLong())
+            }
+          }
+        }
+      }
+      context("인증된 유저가 수정 순으로 조회하면") {
+        for (i in 1..20) {
+          val newProject = Project(
+            id = "testId$i",
+            userId = userId,
+            title = "testTitle$i",
+            startDate = LocalDateTime.of(2021, 1, 1, 0, 0, 0),
+            endDate = LocalDateTime.of(2021, 12, 31, 23, 59, 59),
+            thumbNailUrl = "testThumbNailUrl",
+            techStacks = listOf("testTechStack1", "testTechStack2"),
+            recruitments = recruitments,
+            description = "testDescription"
+          )
+          ReflectionTestUtils.setField(
+            newProject,
+            "updatedAt",
+            LocalDateTime.of(2021, 1, 1, 0, 0, 0).plusDays(i.toLong())
+          )
+          withContext(Dispatchers.IO) {
+            projectRepository.save(newProject).block()
+          }
+        }
+        val performRequest = webTestClient
+          .mutateWith(mockAuthentication(mockAuthentication))
+          .get()
+          .uri {
+            it.path("/api/v1/projects/search-slice")
+              .queryParam("page", pageNumber)
+              .queryParam("size", pageSize)
+              .queryParam("sortBy", ProjectSortProperty.UPDATED_AT)
+              .queryParam("direction", Direction.DESC)
+              .build()
+          }
+          .accept(MediaType.APPLICATION_JSON)
+          .exchange()
+
+        it("요청은 성공한다") {
+          performRequest.expectStatus().isOk
+        }
+
+        it("수정 순으로 Project를 PageSize만큼 Slice를 반환한다") {
+          performRequest.expectBody<RestSliceImpl<SearchProjectResponseDto>>().consumeWith { response ->
+            response.responseBody?.content?.size shouldBe pageSize
+            response.responseBody?.isFirst shouldBe true
+            response.responseBody?.isLast shouldBe false
+            response.responseBody?.hasNext() shouldBe true
+            response.responseBody?.forEachIndexed { index, searchProjectResponseDto ->
+              searchProjectResponseDto.id shouldBe "testId${20 - index}"
+              searchProjectResponseDto.title shouldBe "testTitle${20 - index}"
+              searchProjectResponseDto.updatedAt shouldBe LocalDateTime.of(2021, 1, 1, 0, 0, 0)
+                .plusDays(20 - index.toLong())
+            }
+          }
+        }
+      }
     }
 
-    override suspend fun afterSpec(spec: Spec) {
-        withContext(Dispatchers.IO) {
-            projectRepository.deleteAll().block()
-            projectCommentRepository.deleteAll().block()
-            projectTryoutRepository.deleteAll().block()
-            userRepository.deleteAll().block()
+    describe("PUT /api/v1/projects/{projectId}/bookmark") {
+      context("인증된 유저가 Project를 북마크하면") {
+        val mockAuthentication = UsernamePasswordAuthenticationToken(userId, null, null)
+        val projectId = project.id!!
+        val performRequest = webTestClient
+          .mutateWith(mockAuthentication(mockAuthentication))
+          .put()
+          .uri("/api/v1/projects/$projectId/bookmark")
+          .accept(MediaType.APPLICATION_JSON)
+          .exchange()
+
+        it("요청은 성공한다") {
+          performRequest.expectStatus().isOk
         }
+
+        it("projectId에 해당하는 Project의 북마크가 추가된다") {
+          withContext(Dispatchers.IO) {
+            val bookmarkedProject = projectRepository.findById(projectId).awaitSingleOrNull()
+            bookmarkedProject?.bookmarkers?.size shouldBe 1
+            bookmarkedProject?.bookmarkers?.get(0)?.userId shouldBe userId
+            bookmarkedProject?.bookmarkers?.get(0)?.addedAt shouldNotBe null
+          }
+        }
+      }
+      context("인증된 유저가 이미 북마크한 Project를 북마크하면") {
+        val localDateTime = LocalDateTime.of(2024, 7, 23, 0, 0, 0)
+        project.bookmarkers.add(ProjectBookmark(userId, localDateTime))
+        val mockAuthentication = UsernamePasswordAuthenticationToken(userId, null, null)
+        val projectId = project.id!!
+        val performRequest = webTestClient
+          .mutateWith(mockAuthentication(mockAuthentication))
+          .put()
+          .uri("/api/v1/projects/$projectId/bookmark")
+          .accept(MediaType.APPLICATION_JSON)
+          .exchange()
+
+        it("요청은 성공한다") {
+          performRequest.expectStatus().isOk
+        }
+
+        it("북마크 추가 시간을 갱신한다") {
+          withContext(Dispatchers.IO) {
+            val bookmarkedProject = projectRepository.findById(projectId).awaitSingleOrNull()
+            bookmarkedProject?.bookmarkers?.size shouldBe 1
+            bookmarkedProject?.bookmarkers?.get(0)?.userId shouldBe userId
+            bookmarkedProject?.bookmarkers?.get(0)?.addedAt shouldNotBe localDateTime
+          }
+        }
+      }
     }
 
-    init {
-        describe("GET api/v1/projects") {
-            context("유저의 프로젝트 조회 요청이 들어오면") {
-                val mockAuthentication = UsernamePasswordAuthenticationToken(userId, null, null)
+    describe("DELETE /api/v1/projects/{projectId}/bookmark") {
+      context("인증된 유저가 Project 북마크를 삭제하면") {
+        val mockAuthentication = UsernamePasswordAuthenticationToken(userId, null, null)
+        val projectId = project.id!!
+        val performRequest = webTestClient
+          .mutateWith(mockAuthentication(mockAuthentication))
+          .delete()
+          .uri("/api/v1/projects/$projectId/bookmark")
+          .accept(MediaType.APPLICATION_JSON)
+          .exchange()
 
-                val projectResponse = ProjectWithUserResponseDto.from(project, user, userId)
-
-                val performRequest =
-                    webTestClient
-                        .mutateWith(mockAuthentication(mockAuthentication))
-                        .get()
-                        .uri {
-                            it.path("/api/v1/projects/$projectId")
-                                .build()
-                        }
-                        .exchange()
-
-
-                it("요청은 성공한다") {
-                    performRequest.expectStatus().isOk
-                }
-
-                it("프로젝트를 반환한다") {
-                    performRequest.expectBody<ProjectWithUserResponseDto>().consumeWith { result ->
-                        val returnedProject = result.responseBody!!
-
-                        returnedProject.id shouldBe projectId
-                        returnedProject.userId shouldBe userId
-                        returnedProject.title shouldBe project.title
-                        returnedProject.startDate shouldBe project.startDate
-                        returnedProject.endDate shouldBe project.endDate
-                        returnedProject.thumbNailUrl shouldBe project.thumbNailUrl
-                        returnedProject.description shouldBe project.description
-                        returnedProject.isCompleted shouldBe project.isCompleted
-                        returnedProject.userInfo.id shouldBe user.id
-                        returnedProject.techStacks shouldBe project.techStacks
-                        returnedProject.recruitments.size shouldBe project.recruitments.size
-                        returnedProject.recruitments.forEachIndexed { index, recruitmentResponseDto ->
-                            recruitmentResponseDto.jobName shouldBe project.recruitments[index].jobName
-                            recruitmentResponseDto.numberOfRecruitment shouldBe project.recruitments[index].numberOfRecruitment
-                        }
-                        returnedProject.isMyBookmark shouldBe true
-                    }
-                }
-            }
+        it("요청은 성공한다") {
+          performRequest.expectStatus().isNoContent
         }
 
-        describe("POST api/v1/projects") {
-            context("인증된 유저의 Project 생성 요청이 들어오면") {
-                val mockAuthentication = UsernamePasswordAuthenticationToken(userId, null, null)
-                val requestDto = CreateProjectRequestDto(
-                    title = "TestProject",
-                    startDate = LocalDateTime.of(2021, 1, 1, 0, 0, 0),
-                    endDate = LocalDateTime.of(2021, 12, 31, 23, 59, 59),
-                    thumbNailUrl = "testThumbNailUrl",
-                    techStacks = listOf("testTechStack1", "testTechStack2"),
-                    recruitments = listOf(
-                        RecruitmentRequestDto(
-                            jobName = "testJobName",
-                            numberOfRecruitment = 1
-                        ),
-                        RecruitmentRequestDto(
-                            jobName = "testJobName2",
-                            numberOfRecruitment = 2
-                        )
-                    ),
-                    description = "testDescription"
-                )
-                val performRequest = webTestClient
-                    .mutateWith(mockAuthentication(mockAuthentication))
-                    .post()
-                    .uri("/api/v1/projects")
-                    .accept(MediaType.APPLICATION_JSON)
-                    .bodyValue(requestDto)
-                    .exchange()
+        it("projectId에 해당하는 Project의 북마크가 삭제된다") {
+          withContext(Dispatchers.IO) {
+            val bookmarkedProject = projectRepository.findById(projectId).awaitSingleOrNull()
+            bookmarkedProject?.bookmarkers?.size shouldBe 0
+          }
+        }
+      }
+      context("인증된 유저가 이미 북마크 삭제한 프로젝트 북마크를 삭제하면") {
+        val mockAuthentication = UsernamePasswordAuthenticationToken(userId, null, null)
+        val projectId = project.id!!
+        val performRequest = webTestClient
+          .mutateWith(mockAuthentication(mockAuthentication))
+          .delete()
+          .uri("/api/v1/projects/$projectId/bookmark")
+          .accept(MediaType.APPLICATION_JSON)
+          .exchange()
 
-                it("요청은 성공한다") {
-                    performRequest.expectStatus().isCreated
-                }
-
-                it("생성된 Project 정보를 반환한다") {
-                    performRequest.expectBody<ProjectResponseDto>().consumeWith { response ->
-                        response.responseBody?.id shouldNotBe project.id
-                        response.responseBody?.title shouldBe requestDto.title
-                        response.responseBody?.startDate shouldBe requestDto.startDate
-                        response.responseBody?.endDate shouldBe requestDto.endDate
-                        response.responseBody?.thumbNailUrl shouldBe requestDto.thumbNailUrl
-                        response.responseBody?.techStacks shouldBe requestDto.techStacks
-                        response.responseBody?.recruitments?.size shouldBe requestDto.recruitments.size
-                        response.responseBody?.recruitments?.forEachIndexed { index, recruitmentResponseDto ->
-                            recruitmentResponseDto.jobName shouldBe requestDto.recruitments[index].jobName
-                            recruitmentResponseDto.numberOfRecruitment shouldBe requestDto.recruitments[index].numberOfRecruitment
-                        }
-                        response.responseBody?.description shouldBe requestDto.description
-                        response.responseBody?.userId shouldBe project.userId
-                        response.responseBody?.bookmarked shouldBe false
-                        response.responseBody?.isCompleted shouldBe project.isCompleted
-                        response.responseBody?.createdAt shouldNotBe null
-                        response.responseBody?.updatedAt shouldNotBe null
-                    }
-                }
-            }
+        it("요청은 성공한다") {
+          performRequest.expectStatus().isNoContent
         }
 
-        describe("PUT api/v1/projects") {
-            context("인증된 유저의 Project 수정 요청이 들어오면") {
-                val mockAuthentication = UsernamePasswordAuthenticationToken(userId, null, null)
-                val requestDto = UpdateProjectRequestDto(
-                    id = project.id!!,
-                    title = "UpdateTitle",
-                    startDate = LocalDateTime.of(2024, 7, 20, 0, 0, 0),
-                    endDate = LocalDateTime.of(2024, 7, 22, 0, 0, 0),
-                    thumbNailUrl = "updateThumbNailUrl",
-                    techStacks = listOf("updateTechStack1", "updateTechStack2"),
-                    recruitments = listOf(
-                        RecruitmentRequestDto(
-                            jobName = "updateJobName1",
-                            numberOfRecruitment = 3
-                        ),
-                        RecruitmentRequestDto(
-                            jobName = "updateJobName2",
-                            numberOfRecruitment = 4
-                        )
-                    ),
-                    description = "updateDescription"
-                )
-                val performRequest = webTestClient
-                    .mutateWith(mockAuthentication(mockAuthentication))
-                    .put()
-                    .uri("/api/v1/projects")
-                    .accept(MediaType.APPLICATION_JSON)
-                    .bodyValue(requestDto)
-                    .exchange()
-
-                it("요청은 성공한다") {
-                    performRequest.expectStatus().isOk
-                }
-
-                it("수정된 Project 정보를 반환한다") {
-                    performRequest.expectBody<ProjectResponseDto>().consumeWith { response ->
-                        response.responseBody?.id shouldBe project.id
-                        response.responseBody?.title shouldBe requestDto.title
-                        response.responseBody?.startDate shouldBe requestDto.startDate
-                        response.responseBody?.endDate shouldBe requestDto.endDate
-                        response.responseBody?.thumbNailUrl shouldBe requestDto.thumbNailUrl
-                        response.responseBody?.techStacks shouldBe requestDto.techStacks
-                        response.responseBody?.recruitments?.size shouldBe requestDto.recruitments.size
-                        response.responseBody?.recruitments?.forEachIndexed { index, recruitmentResponseDto ->
-                            recruitmentResponseDto.jobName shouldBe requestDto.recruitments[index].jobName
-                            recruitmentResponseDto.numberOfRecruitment shouldBe requestDto.recruitments[index].numberOfRecruitment
-                        }
-                        response.responseBody?.description shouldBe requestDto.description
-                        response.responseBody?.userId shouldBe project.userId
-                        response.responseBody?.bookmarked shouldBe true
-                        response.responseBody?.isCompleted shouldBe project.isCompleted
-                        response.responseBody?.createdAt shouldNotBe null
-                        response.responseBody?.updatedAt shouldNotBe null
-                    }
-                }
-            }
+        it("북마크는 삭제된 상태를 유지한다") {
+          withContext(Dispatchers.IO) {
+            val bookmarkedProject = projectRepository.findById(projectId).awaitSingleOrNull()
+            bookmarkedProject?.bookmarkers?.size shouldBe 0
+          }
         }
-
-        describe("DELETE api/v1/projects/{projectId}") {
-            context("인증된 유저의 Project 삭제 요청이 들어오면") {
-                val mockAuthentication = UsernamePasswordAuthenticationToken(userId, null, null)
-                val performRequest = webTestClient
-                    .mutateWith(mockAuthentication(mockAuthentication))
-                    .delete()
-                    .uri("/api/v1/projects/${project.id}")
-                    .accept(MediaType.APPLICATION_JSON)
-                    .exchange()
-
-                it("요청은 성공한다") {
-                    performRequest.expectStatus().isNoContent
-                }
-
-                it("Project가 삭제된다") {
-                    withContext(Dispatchers.IO) {
-                        val deletedProject = projectRepository.findById(project.id!!).block()
-                        deletedProject shouldBe null
-                    }
-                }
-
-                it("ProjectComment가 삭제된다") {
-                    withContext(Dispatchers.IO) {
-                        val deletedProjectComment = projectCommentRepository.findById(projectComment.id!!).block()
-                        deletedProjectComment shouldBe null
-                    }
-                }
-
-                it("ProjectTryout이 삭제된다") {
-                    withContext(Dispatchers.IO) {
-                        val deletedProjectTryout = projectTryoutRepository.findById(projectTryout.id!!).block()
-                        deletedProjectTryout shouldBe null
-                    }
-                }
-            }
-        }
-
-        describe("GET api/v1/projects/{projectId}/comments") {
-            context("Project Comment 전체 조회 요청이 들어오면") {
-                val deletedProjectComment1 = ProjectComment(
-                    projectId = "testProjectId",
-                    userId = "testUserId",
-                    content = "deleted1",
-                    isDeleted = true
-                )
-                projectCommentRepository.save(deletedProjectComment1).block()
-
-                val deletedProjectComment2 = ProjectComment(
-                    projectId = "testProjectId",
-                    userId = "testUserId",
-                    content = "deleted2",
-                    isDeleted = true
-                )
-                projectCommentRepository.save(deletedProjectComment2).block()
-
-                val childProjectComment1 = ProjectComment(
-                    parentCommentId = deletedProjectComment1.id!!,
-                    projectId = "testProjectId",
-                    userId = "testUserId",
-                    content = "child",
-                    isDeleted = false
-                )
-                projectCommentRepository.save(childProjectComment1).block()
-
-                val deletedChildProjectComment1 = ProjectComment(
-                    parentCommentId = deletedProjectComment1.id!!,
-                    projectId = "testProjectId",
-                    userId = "testUserId",
-                    content = "deletedChild",
-                    isDeleted = true
-                )
-                projectCommentRepository.save(deletedChildProjectComment1).block()
-
-                val mockAuthentication = UsernamePasswordAuthenticationToken(userId, null, null)
-                val projectId = "testProjectId"
-
-                val performRequest = webTestClient
-                    .mutateWith(mockAuthentication(mockAuthentication))
-                    .get()
-                    .uri("/api/v1/projects/$projectId/comments")
-                    .accept(MediaType.APPLICATION_JSON)
-                    .exchange()
-
-                it("요청은 성공한다") {
-                    performRequest.expectStatus().isOk
-                }
-
-                it("생성된 Project 정보를 반환한다") {
-                    performRequest.expectBody<List<ProjectCommentWithChildResponseDto>>().consumeWith { response ->
-                        response.responseBody?.get(0)?.id shouldBe deletedProjectComment1.id
-                        response.responseBody?.get(0)?.parentCommentId shouldBe deletedProjectComment1.parentCommentId
-                        response.responseBody?.get(0)?.projectId shouldBe deletedProjectComment1.projectId
-                        response.responseBody?.get(0)?.userId shouldBe deletedProjectComment1.userId
-                        response.responseBody?.get(0)?.content shouldBe deletedProjectComment1.content
-                        response.responseBody?.get(0)?.isDeleted shouldBe deletedProjectComment1.isDeleted
-
-                        response.responseBody?.get(0)?.childComments?.get(0)?.id shouldBe childProjectComment1.id
-                        response.responseBody?.get(0)?.childComments?.get(0)?.content shouldBe childProjectComment1.content
-                        response.responseBody?.get(0)?.childComments?.get(0)?.userId shouldBe childProjectComment1.userId
-                        response.responseBody?.get(0)?.childComments?.get(0)?.parentCommentId shouldBe childProjectComment1.parentCommentId
-                        response.responseBody?.get(0)?.childComments?.get(0)?.projectId shouldBe childProjectComment1.projectId
-                        response.responseBody?.get(0)?.childComments?.get(0)?.isDeleted shouldBe childProjectComment1.isDeleted
-                    }
-                }
-            }
-        }
-
-        describe("GET /api/v1/projects/search-slice") {
-            withContext(Dispatchers.IO) {
-                projectRepository.deleteAll().block()
-            }
-            val userId = "1234"
-            val pageNumber = 0
-            val pageSize = 10
-            val mockAuthentication = UsernamePasswordAuthenticationToken(userId, null, null)
-            context("인증된 유저가 Filter 없이 완료되지 않은 Project Slice 조회를 하면") {
-                for (i in 1..20) {
-                    val newProject = Project(
-                        id = "testId$i",
-                        userId = userId,
-                        title = "testTitle$i",
-                        startDate = LocalDateTime.of(2021, 1, 1, 0, 0, 0),
-                        endDate = LocalDateTime.of(2021, 12, 31, 23, 59, 59),
-                        thumbNailUrl = "testThumbNailUrl",
-                        techStacks = listOf("testTechStack1", "testTechStack2"),
-                        recruitments = recruitments,
-                        description = "testDescription"
-                    )
-                    ReflectionTestUtils.setField(
-                        newProject,
-                        "createdAt",
-                        LocalDateTime.of(2021, 1, 1, 0, 0, 0).plusDays(i.toLong())
-                    )
-                    withContext(Dispatchers.IO) {
-                        projectRepository.save(newProject).block()
-                    }
-                }
-                val performRequest = webTestClient
-                    .mutateWith(mockAuthentication(mockAuthentication))
-                    .get()
-                    .uri {
-                        it.path("/api/v1/projects/search-slice")
-                            .queryParam("page", pageNumber)
-                            .queryParam("size", pageSize)
-                            .queryParam("sortBy", ProjectSortProperty.CREATED_AT)
-                            .queryParam("direction", Direction.DESC)
-                            .build()
-                    }
-                    .accept(MediaType.APPLICATION_JSON)
-                    .exchange()
-
-                it("요청은 성공한다") {
-                    performRequest.expectStatus().isOk
-                }
-
-                it("완료되지 않은 Project를 대상으로 PageSize만큼 Slice를 반환한다") {
-                    performRequest.expectBody<RestSliceImpl<SearchProjectResponseDto>>().consumeWith { response ->
-                        response.responseBody?.content?.size shouldBe pageSize
-                        response.responseBody?.isFirst shouldBe true
-                        response.responseBody?.isLast shouldBe false
-                        response.responseBody?.hasNext() shouldBe true
-                        response.responseBody?.forEachIndexed { index, searchProjectResponseDto ->
-                            searchProjectResponseDto.id shouldBe "testId${20 - index}"
-                            searchProjectResponseDto.title shouldBe "testTitle${20 - index}"
-                            searchProjectResponseDto.isCompleted shouldBe false
-                            searchProjectResponseDto.createdAt shouldBe LocalDateTime.of(2021, 1, 1, 0, 0, 0)
-                                .plusDays(20 - index.toLong())
-                        }
-                    }
-                }
-            }
-            context("인증된 유저가 Filter 없이 완료된 Project Slice 조회를 하면") {
-                for (i in 1..20) {
-                    val newProject = Project(
-                        id = "testId$i",
-                        userId = userId,
-                        title = "testTitle$i",
-                        startDate = LocalDateTime.of(2021, 1, 1, 0, 0, 0),
-                        endDate = LocalDateTime.of(2021, 12, 31, 23, 59, 59),
-                        thumbNailUrl = "testThumbNailUrl",
-                        techStacks = listOf("testTechStack1", "testTechStack2"),
-                        recruitments = recruitments,
-                        description = "testDescription",
-                        isCompleted = true
-                    )
-                    ReflectionTestUtils.setField(
-                        newProject,
-                        "createdAt",
-                        LocalDateTime.of(2021, 1, 1, 0, 0, 0).plusDays(i.toLong())
-                    )
-                    withContext(Dispatchers.IO) {
-                        projectRepository.save(newProject).block()
-                    }
-                }
-                val performRequest = webTestClient
-                    .mutateWith(mockAuthentication(mockAuthentication))
-                    .get()
-                    .uri {
-                        it.path("/api/v1/projects/search-slice")
-                            .queryParam("page", pageNumber)
-                            .queryParam("size", pageSize)
-                            .queryParam("sortBy", ProjectSortProperty.CREATED_AT)
-                            .queryParam("direction", Direction.DESC)
-                            .queryParam("isCompleted", true)
-                            .build()
-                    }
-                    .accept(MediaType.APPLICATION_JSON)
-                    .exchange()
-
-                it("요청은 성공한다") {
-                    performRequest.expectStatus().isOk
-                }
-
-                it("완료된 Project를 대상으로 PageSize만큼 Slice를 반환한다") {
-                    performRequest.expectBody<RestSliceImpl<SearchProjectResponseDto>>().consumeWith { response ->
-                        response.responseBody?.content?.size shouldBe pageSize
-                        response.responseBody?.isFirst shouldBe true
-                        response.responseBody?.isLast shouldBe false
-                        response.responseBody?.hasNext() shouldBe true
-                        response.responseBody?.forEachIndexed { index, searchProjectResponseDto ->
-                            searchProjectResponseDto.id shouldBe "testId${20 - index}"
-                            searchProjectResponseDto.title shouldBe "testTitle${20 - index}"
-                            searchProjectResponseDto.createdAt shouldBe LocalDateTime.of(2021, 1, 1, 0, 0, 0)
-                                .plusDays(20 - index.toLong())
-                            searchProjectResponseDto.isCompleted shouldBe true
-                        }
-                    }
-                }
-            }
-            context("인증된 유저가 ALL Type 필터로 조회하면") {
-                for (i in 1..20) {
-                    val newProject = Project(
-                        id = "testId$i",
-                        userId = userId,
-                        title = "testTitle$i",
-                        startDate = LocalDateTime.of(2021, 1, 1, 0, 0, 0),
-                        endDate = LocalDateTime.of(2021, 12, 31, 23, 59, 59),
-                        thumbNailUrl = "testThumbNailUrl",
-                        techStacks = listOf("testTechStack1", "testTechStack2"),
-                        recruitments = recruitments,
-                        description = "testDescription"
-                    )
-                    ReflectionTestUtils.setField(
-                        newProject,
-                        "createdAt",
-                        LocalDateTime.of(2021, 1, 1, 0, 0, 0).plusDays(i.toLong())
-                    )
-                    withContext(Dispatchers.IO) {
-                        projectRepository.save(newProject).block()
-                    }
-                }
-                val performRequest = webTestClient
-                    .mutateWith(mockAuthentication(mockAuthentication))
-                    .get()
-                    .uri {
-                        it.path("/api/v1/projects/search-slice")
-                            .queryParam("page", pageNumber)
-                            .queryParam("size", pageSize)
-                            .queryParam("sortBy", ProjectSortProperty.CREATED_AT)
-                            .queryParam("direction", Direction.DESC)
-                            .queryParam("filterType", ProjectFilterType.ALL)
-                            .queryParam("filterValue", "Title2")
-                            .build()
-                    }
-                    .accept(MediaType.APPLICATION_JSON)
-                    .exchange()
-
-                it("요청은 성공한다") {
-                    performRequest.expectStatus().isOk
-                }
-
-                it("완료된 Project를 대상으로 PageSize만큼 Slice를 반환한다") {
-                    performRequest.expectBody<RestSliceImpl<SearchProjectResponseDto>>().consumeWith { response ->
-                        response.responseBody?.content?.size shouldBe 2
-                        response.responseBody?.isFirst shouldBe true
-                        response.responseBody?.isLast shouldBe true
-                        response.responseBody?.hasNext() shouldBe false
-                        response.responseBody?.content?.get(0)?.id shouldBe "testId20"
-                        response.responseBody?.content?.get(1)?.id shouldBe "testId2"
-                    }
-                }
-            }
-            context("인증된 유저가 Title Type 필터로 조회하면") {
-                for (i in 1..20) {
-                    val newProject = Project(
-                        id = "testId$i",
-                        userId = userId,
-                        title = "testTitle$i",
-                        startDate = LocalDateTime.of(2021, 1, 1, 0, 0, 0),
-                        endDate = LocalDateTime.of(2021, 12, 31, 23, 59, 59),
-                        thumbNailUrl = "testThumbNailUrl",
-                        techStacks = listOf("testTechStack1", "testTechStack2"),
-                        recruitments = recruitments,
-                        description = "testDescription"
-                    )
-                    ReflectionTestUtils.setField(
-                        newProject,
-                        "createdAt",
-                        LocalDateTime.of(2021, 1, 1, 0, 0, 0).plusDays(i.toLong())
-                    )
-                    withContext(Dispatchers.IO) {
-                        projectRepository.save(newProject).block()
-                    }
-                }
-                val performRequest = webTestClient
-                    .mutateWith(mockAuthentication(mockAuthentication))
-                    .get()
-                    .uri {
-                        it.path("/api/v1/projects/search-slice")
-                            .queryParam("page", pageNumber)
-                            .queryParam("size", pageSize)
-                            .queryParam("sortBy", ProjectSortProperty.CREATED_AT)
-                            .queryParam("direction", Direction.DESC)
-                            .queryParam("filterType", ProjectFilterType.TITLE)
-                            .queryParam("filterValue", "Title2")
-                            .build()
-                    }
-                    .accept(MediaType.APPLICATION_JSON)
-                    .exchange()
-
-                it("요청은 성공한다") {
-                    performRequest.expectStatus().isOk
-                }
-
-                it("완료된 Project를 대상으로 PageSize만큼 Slice를 반환한다") {
-                    performRequest.expectBody<RestSliceImpl<SearchProjectResponseDto>>().consumeWith { response ->
-                        response.responseBody?.content?.size shouldBe 2
-                        response.responseBody?.isFirst shouldBe true
-                        response.responseBody?.isLast shouldBe true
-                        response.responseBody?.hasNext() shouldBe false
-                        response.responseBody?.content?.get(0)?.id shouldBe "testId20"
-                        response.responseBody?.content?.get(1)?.id shouldBe "testId2"
-                    }
-                }
-            }
-            context("인증된 유저가 JobName Type 필터로 조회하면") {
-                for (i in 1..20) {
-                    val newProject = Project(
-                        id = "testId$i",
-                        userId = userId,
-                        title = "testTitle$i",
-                        startDate = LocalDateTime.of(2021, 1, 1, 0, 0, 0),
-                        endDate = LocalDateTime.of(2021, 12, 31, 23, 59, 59),
-                        thumbNailUrl = "testThumbNailUrl",
-                        techStacks = listOf("testTechStack1", "testTechStack2"),
-                        recruitments = recruitments,
-                        description = "testDescription"
-                    )
-                    ReflectionTestUtils.setField(
-                        newProject,
-                        "createdAt",
-                        LocalDateTime.of(2021, 1, 1, 0, 0, 0).plusDays(i.toLong())
-                    )
-                    withContext(Dispatchers.IO) {
-                        projectRepository.save(newProject).block()
-                    }
-                }
-                val performRequest = webTestClient
-                    .mutateWith(mockAuthentication(mockAuthentication))
-                    .get()
-                    .uri {
-                        it.path("/api/v1/projects/search-slice")
-                            .queryParam("page", pageNumber)
-                            .queryParam("size", pageSize)
-                            .queryParam("sortBy", ProjectSortProperty.CREATED_AT)
-                            .queryParam("direction", Direction.DESC)
-                            .queryParam("filterType", ProjectFilterType.JOB_NAME)
-                            .queryParam("filterValue", "testJobName")
-                            .build()
-                    }
-                    .accept(MediaType.APPLICATION_JSON)
-                    .exchange()
-
-                it("요청은 성공한다") {
-                    performRequest.expectStatus().isOk
-                }
-
-                it("완료된 Project를 대상으로 PageSize만큼 Slice를 반환한다") {
-                    performRequest.expectBody<RestSliceImpl<SearchProjectResponseDto>>().consumeWith { response ->
-                        response.responseBody?.content?.size shouldBe 10
-                        response.responseBody?.isFirst shouldBe true
-                        response.responseBody?.isLast shouldBe false
-                        response.responseBody?.hasNext() shouldBe true
-                        response.responseBody?.forEachIndexed { index, searchProjectResponseDto ->
-                            searchProjectResponseDto.id shouldBe "testId${20 - index}"
-                            searchProjectResponseDto.title shouldBe "testTitle${20 - index}"
-                            searchProjectResponseDto.createdAt shouldBe LocalDateTime.of(2021, 1, 1, 0, 0, 0)
-                                .plusDays(20 - index.toLong())
-                        }
-                    }
-                }
-            }
-            context("인증된 유저가 북마크 순으로 조회하면") {
-                for (i in 1..20) {
-                    val newProject = Project(
-                        id = "testId$i",
-                        userId = userId,
-                        title = "testTitle$i",
-                        startDate = LocalDateTime.of(2021, 1, 1, 0, 0, 0),
-                        endDate = LocalDateTime.of(2021, 12, 31, 23, 59, 59),
-                        thumbNailUrl = "testThumbNailUrl",
-                        techStacks = listOf("testTechStack1", "testTechStack2"),
-                        recruitments = recruitments,
-                        description = "testDescription"
-                    )
-                    if (i == 20) {
-                        newProject.bookmarkers.add(ProjectBookmark(userId, LocalDateTime.now()))
-                    }
-                    for (j in 1..i) {
-                        newProject.bookmarkers.add(ProjectBookmark("testUserId$j", LocalDateTime.now()))
-                    }
-                    withContext(Dispatchers.IO) {
-                        projectRepository.save(newProject).block()
-                    }
-                }
-                val performRequest = webTestClient
-                    .mutateWith(mockAuthentication(mockAuthentication))
-                    .get()
-                    .uri {
-                        it.path("/api/v1/projects/search-slice")
-                            .queryParam("page", pageNumber)
-                            .queryParam("size", pageSize)
-                            .queryParam("sortBy", ProjectSortProperty.BOOK_MARKERS)
-                            .queryParam("direction", Direction.DESC)
-                            .build()
-                    }
-                    .accept(MediaType.APPLICATION_JSON)
-                    .exchange()
-
-                it("요청은 성공한다") {
-                    performRequest.expectStatus().isOk
-                }
-
-                it("북마크 순으로 Project를 PageSize만큼 Slice를 반환한다") {
-                    performRequest.expectBody<RestSliceImpl<SearchProjectResponseDto>>().consumeWith { response ->
-                        response.responseBody?.content?.size shouldBe 10
-                        response.responseBody?.isFirst shouldBe true
-                        response.responseBody?.isLast shouldBe false
-                        response.responseBody?.hasNext() shouldBe true
-                        response.responseBody?.forEachIndexed { index, searchProjectResponseDto ->
-                            searchProjectResponseDto.id shouldBe "testId${20 - index}"
-                            searchProjectResponseDto.title shouldBe "testTitle${20 - index}"
-                        }
-                    }
-                }
-                it("요청한 유저가 북마크한 Project면 응답의 bookMarked를 True로 반환한다") {
-                    performRequest.expectBody<RestSliceImpl<SearchProjectResponseDto>>().consumeWith { response ->
-                        response.responseBody?.content?.get(0)?.bookmarked shouldBe true
-                    }
-                }
-            }
-            context("인증된 유저가 최신등록 순으로 조회하면") {
-                for (i in 1..20) {
-                    val newProject = Project(
-                        id = "testId$i",
-                        userId = userId,
-                        title = "testTitle$i",
-                        startDate = LocalDateTime.of(2021, 1, 1, 0, 0, 0),
-                        endDate = LocalDateTime.of(2021, 12, 31, 23, 59, 59),
-                        thumbNailUrl = "testThumbNailUrl",
-                        techStacks = listOf("testTechStack1", "testTechStack2"),
-                        recruitments = recruitments,
-                        description = "testDescription"
-                    )
-                    ReflectionTestUtils.setField(
-                        newProject,
-                        "createdAt",
-                        LocalDateTime.of(2021, 1, 1, 0, 0, 0).plusDays(i.toLong())
-                    )
-                    withContext(Dispatchers.IO) {
-                        projectRepository.save(newProject).block()
-                    }
-                }
-                val performRequest = webTestClient
-                    .mutateWith(mockAuthentication(mockAuthentication))
-                    .get()
-                    .uri {
-                        it.path("/api/v1/projects/search-slice")
-                            .queryParam("page", pageNumber)
-                            .queryParam("size", pageSize)
-                            .queryParam("sortBy", ProjectSortProperty.CREATED_AT)
-                            .queryParam("direction", Direction.DESC)
-                            .build()
-                    }
-                    .accept(MediaType.APPLICATION_JSON)
-                    .exchange()
-
-                it("요청은 성공한다") {
-                    performRequest.expectStatus().isOk
-                }
-
-                it("최신등록 순으로 Project를 PageSize만큼 Slice를 반환한다") {
-                    performRequest.expectBody<RestSliceImpl<SearchProjectResponseDto>>().consumeWith { response ->
-                        response.responseBody?.content?.size shouldBe pageSize
-                        response.responseBody?.isFirst shouldBe true
-                        response.responseBody?.isLast shouldBe false
-                        response.responseBody?.hasNext() shouldBe true
-                        response.responseBody?.forEachIndexed { index, searchProjectResponseDto ->
-                            searchProjectResponseDto.id shouldBe "testId${20 - index}"
-                            searchProjectResponseDto.title shouldBe "testTitle${20 - index}"
-                            searchProjectResponseDto.createdAt shouldBe LocalDateTime.of(2021, 1, 1, 0, 0, 0)
-                                .plusDays(20 - index.toLong())
-                        }
-                    }
-                }
-            }
-            context("인증된 유저가 수정 순으로 조회하면") {
-                for (i in 1..20) {
-                    val newProject = Project(
-                        id = "testId$i",
-                        userId = userId,
-                        title = "testTitle$i",
-                        startDate = LocalDateTime.of(2021, 1, 1, 0, 0, 0),
-                        endDate = LocalDateTime.of(2021, 12, 31, 23, 59, 59),
-                        thumbNailUrl = "testThumbNailUrl",
-                        techStacks = listOf("testTechStack1", "testTechStack2"),
-                        recruitments = recruitments,
-                        description = "testDescription"
-                    )
-                    ReflectionTestUtils.setField(
-                        newProject,
-                        "updatedAt",
-                        LocalDateTime.of(2021, 1, 1, 0, 0, 0).plusDays(i.toLong())
-                    )
-                    withContext(Dispatchers.IO) {
-                        projectRepository.save(newProject).block()
-                    }
-                }
-                val performRequest = webTestClient
-                    .mutateWith(mockAuthentication(mockAuthentication))
-                    .get()
-                    .uri {
-                        it.path("/api/v1/projects/search-slice")
-                            .queryParam("page", pageNumber)
-                            .queryParam("size", pageSize)
-                            .queryParam("sortBy", ProjectSortProperty.UPDATED_AT)
-                            .queryParam("direction", Direction.DESC)
-                            .build()
-                    }
-                    .accept(MediaType.APPLICATION_JSON)
-                    .exchange()
-
-                it("요청은 성공한다") {
-                    performRequest.expectStatus().isOk
-                }
-
-                it("수정 순으로 Project를 PageSize만큼 Slice를 반환한다") {
-                    performRequest.expectBody<RestSliceImpl<SearchProjectResponseDto>>().consumeWith { response ->
-                        response.responseBody?.content?.size shouldBe pageSize
-                        response.responseBody?.isFirst shouldBe true
-                        response.responseBody?.isLast shouldBe false
-                        response.responseBody?.hasNext() shouldBe true
-                        response.responseBody?.forEachIndexed { index, searchProjectResponseDto ->
-                            searchProjectResponseDto.id shouldBe "testId${20 - index}"
-                            searchProjectResponseDto.title shouldBe "testTitle${20 - index}"
-                            searchProjectResponseDto.updatedAt shouldBe LocalDateTime.of(2021, 1, 1, 0, 0, 0)
-                                .plusDays(20 - index.toLong())
-                        }
-                    }
-                }
-            }
-        }
-
-        describe("PUT /api/v1/projects/{projectId}/bookmark") {
-            context("인증된 유저가 Project를 북마크하면") {
-                val mockAuthentication = UsernamePasswordAuthenticationToken(userId, null, null)
-                val projectId = project.id!!
-                val performRequest = webTestClient
-                    .mutateWith(mockAuthentication(mockAuthentication))
-                    .put()
-                    .uri("/api/v1/projects/$projectId/bookmark")
-                    .accept(MediaType.APPLICATION_JSON)
-                    .exchange()
-
-                it("요청은 성공한다") {
-                    performRequest.expectStatus().isOk
-                }
-
-                it("projectId에 해당하는 Project의 북마크가 추가된다") {
-                    withContext(Dispatchers.IO) {
-                        val bookmarkedProject = projectRepository.findById(projectId).awaitSingleOrNull()
-                        bookmarkedProject?.bookmarkers?.size shouldBe 1
-                        bookmarkedProject?.bookmarkers?.get(0)?.userId shouldBe userId
-                        bookmarkedProject?.bookmarkers?.get(0)?.addedAt shouldNotBe null
-                    }
-                }
-            }
-            context("인증된 유저가 이미 북마크한 Project를 북마크하면") {
-                val localDateTime = LocalDateTime.of(2024, 7, 23, 0, 0, 0)
-                project.bookmarkers.add(ProjectBookmark(userId, localDateTime))
-                val mockAuthentication = UsernamePasswordAuthenticationToken(userId, null, null)
-                val projectId = project.id!!
-                val performRequest = webTestClient
-                    .mutateWith(mockAuthentication(mockAuthentication))
-                    .put()
-                    .uri("/api/v1/projects/$projectId/bookmark")
-                    .accept(MediaType.APPLICATION_JSON)
-                    .exchange()
-
-                it("요청은 성공한다") {
-                    performRequest.expectStatus().isOk
-                }
-
-                it("북마크 추가 시간을 갱신한다") {
-                    withContext(Dispatchers.IO) {
-                        val bookmarkedProject = projectRepository.findById(projectId).awaitSingleOrNull()
-                        bookmarkedProject?.bookmarkers?.size shouldBe 1
-                        bookmarkedProject?.bookmarkers?.get(0)?.userId shouldBe userId
-                        bookmarkedProject?.bookmarkers?.get(0)?.addedAt shouldNotBe localDateTime
-                    }
-                }
-            }
-        }
-
-        describe("DELETE /api/v1/projects/{projectId}/bookmark") {
-            context("인증된 유저가 Project 북마크를 삭제하면") {
-                val mockAuthentication = UsernamePasswordAuthenticationToken(userId, null, null)
-                val projectId = project.id!!
-                val performRequest = webTestClient
-                    .mutateWith(mockAuthentication(mockAuthentication))
-                    .delete()
-                    .uri("/api/v1/projects/$projectId/bookmark")
-                    .accept(MediaType.APPLICATION_JSON)
-                    .exchange()
-
-                it("요청은 성공한다") {
-                    performRequest.expectStatus().isNoContent
-                }
-
-                it("projectId에 해당하는 Project의 북마크가 삭제된다") {
-                    withContext(Dispatchers.IO) {
-                        val bookmarkedProject = projectRepository.findById(projectId).awaitSingleOrNull()
-                        bookmarkedProject?.bookmarkers?.size shouldBe 0
-                    }
-                }
-            }
-            context("인증된 유저가 이미 북마크 삭제한 프로젝트 북마크를 삭제하면") {
-                val mockAuthentication = UsernamePasswordAuthenticationToken(userId, null, null)
-                val projectId = project.id!!
-                val performRequest = webTestClient
-                    .mutateWith(mockAuthentication(mockAuthentication))
-                    .delete()
-                    .uri("/api/v1/projects/$projectId/bookmark")
-                    .accept(MediaType.APPLICATION_JSON)
-                    .exchange()
-
-                it("요청은 성공한다") {
-                    performRequest.expectStatus().isNoContent
-                }
-
-                it("북마크는 삭제된 상태를 유지한다") {
-                    withContext(Dispatchers.IO) {
-                        val bookmarkedProject = projectRepository.findById(projectId).awaitSingleOrNull()
-                        bookmarkedProject?.bookmarkers?.size shouldBe 0
-                    }
-                }
-            }
-        }
+      }
     }
+  }
 }

--- a/src/test/kotlin/pmeet/pmeetserver/project/ProjectTryoutIntegrationTest.kt
+++ b/src/test/kotlin/pmeet/pmeetserver/project/ProjectTryoutIntegrationTest.kt
@@ -22,8 +22,8 @@ import pmeet.pmeetserver.config.BaseMongoDBTestForIntegration
 import pmeet.pmeetserver.config.TestSecurityConfig
 import pmeet.pmeetserver.project.domain.Project
 import pmeet.pmeetserver.project.domain.enum.ProjectTryoutStatus
-import pmeet.pmeetserver.project.dto.request.tryout.CreateProjectTryoutRequestDto
-import pmeet.pmeetserver.project.dto.request.tryout.ProjectTryoutResponseDto
+import pmeet.pmeetserver.project.dto.tryout.request.CreateProjectTryoutRequestDto
+import pmeet.pmeetserver.project.dto.tryout.response.ProjectTryoutResponseDto
 import pmeet.pmeetserver.project.repository.ProjectRepository
 import pmeet.pmeetserver.user.domain.resume.Resume
 import pmeet.pmeetserver.user.repository.resume.ResumeRepository

--- a/src/test/kotlin/pmeet/pmeetserver/project/controller/ProjectCommentControllerUnitTest.kt
+++ b/src/test/kotlin/pmeet/pmeetserver/project/controller/ProjectCommentControllerUnitTest.kt
@@ -5,7 +5,6 @@ import io.kotest.core.spec.style.DescribeSpec
 import io.kotest.matchers.shouldBe
 import io.mockk.coEvery
 import io.mockk.coVerify
-import java.time.LocalDateTime
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.autoconfigure.web.reactive.WebFluxTest
 import org.springframework.context.annotation.Import
@@ -14,9 +13,10 @@ import org.springframework.security.test.web.reactive.server.SecurityMockServerC
 import org.springframework.test.web.reactive.server.WebTestClient
 import org.springframework.test.web.reactive.server.expectBody
 import pmeet.pmeetserver.config.TestSecurityConfig
-import pmeet.pmeetserver.project.dto.request.comment.CreateProjectCommentRequestDto
-import pmeet.pmeetserver.project.dto.request.comment.ProjectCommentResponseDto
+import pmeet.pmeetserver.project.dto.comment.request.CreateProjectCommentRequestDto
+import pmeet.pmeetserver.project.dto.comment.response.ProjectCommentResponseDto
 import pmeet.pmeetserver.project.service.ProjectFacadeService
+import java.time.LocalDateTime
 
 @WebFluxTest(ProjectCommentController::class)
 @Import(TestSecurityConfig::class)

--- a/src/test/kotlin/pmeet/pmeetserver/project/controller/ProjectControllerUnitTest.kt
+++ b/src/test/kotlin/pmeet/pmeetserver/project/controller/ProjectControllerUnitTest.kt
@@ -15,12 +15,12 @@ import org.springframework.security.test.web.reactive.server.SecurityMockServerC
 import org.springframework.test.web.reactive.server.WebTestClient
 import org.springframework.test.web.reactive.server.expectBody
 import pmeet.pmeetserver.config.TestSecurityConfig
+import pmeet.pmeetserver.project.dto.comment.response.ProjectCommentResponseDto
+import pmeet.pmeetserver.project.dto.comment.response.ProjectCommentWithChildResponseDto
 import pmeet.pmeetserver.project.dto.request.CreateProjectRequestDto
 import pmeet.pmeetserver.project.dto.request.RecruitmentRequestDto
 import pmeet.pmeetserver.project.dto.request.SearchProjectRequestDto
 import pmeet.pmeetserver.project.dto.request.UpdateProjectRequestDto
-import pmeet.pmeetserver.project.dto.request.comment.ProjectCommentResponseDto
-import pmeet.pmeetserver.project.dto.request.comment.ProjectCommentWithChildResponseDto
 import pmeet.pmeetserver.project.dto.response.ProjectResponseDto
 import pmeet.pmeetserver.project.dto.response.ProjectWithUserResponseDto
 import pmeet.pmeetserver.project.dto.response.RecruitmentResponseDto

--- a/src/test/kotlin/pmeet/pmeetserver/project/controller/ProjectTryoutControllerUnitTest.kt
+++ b/src/test/kotlin/pmeet/pmeetserver/project/controller/ProjectTryoutControllerUnitTest.kt
@@ -14,8 +14,8 @@ import org.springframework.test.web.reactive.server.WebTestClient
 import org.springframework.test.web.reactive.server.expectBody
 import pmeet.pmeetserver.config.TestSecurityConfig
 import pmeet.pmeetserver.project.domain.enum.ProjectTryoutStatus
-import pmeet.pmeetserver.project.dto.request.tryout.CreateProjectTryoutRequestDto
-import pmeet.pmeetserver.project.dto.request.tryout.ProjectTryoutResponseDto
+import pmeet.pmeetserver.project.dto.tryout.request.CreateProjectTryoutRequestDto
+import pmeet.pmeetserver.project.dto.tryout.response.ProjectTryoutResponseDto
 import pmeet.pmeetserver.project.service.ProjectFacadeService
 import pmeet.pmeetserver.user.resume.ResumeGenerator.generateResume
 import java.time.LocalDateTime
@@ -96,17 +96,19 @@ internal class ProjectTryoutControllerUnitTest : DescribeSpec() {
         val userId = resume.userId
         val requestProjectId = "testProjectId"
         val createdAt = LocalDateTime.now()
-        val responseDto = mutableListOf(ProjectTryoutResponseDto(
-          id = "testTryoutId",
-          resumeId = resume.id!!,
-          userId = userId,
-          projectId = requestProjectId,
-          userName = "userName",
-          userSelfDescription = "userSelfDescription",
-          positionName = "positionName",
-          tryoutStatus = ProjectTryoutStatus.INREVIEW,
-          createdAt = createdAt
-        ))
+        val responseDto = mutableListOf(
+          ProjectTryoutResponseDto(
+            id = "testTryoutId",
+            resumeId = resume.id!!,
+            userId = userId,
+            projectId = requestProjectId,
+            userName = "userName",
+            userSelfDescription = "userSelfDescription",
+            positionName = "positionName",
+            tryoutStatus = ProjectTryoutStatus.INREVIEW,
+            createdAt = createdAt
+          )
+        )
 
         coEvery {
           projectFacadeService.getProjectTryoutListByProjectId(
@@ -142,6 +144,6 @@ internal class ProjectTryoutControllerUnitTest : DescribeSpec() {
         }
       }
     }
-    
+
   }
 }

--- a/src/test/kotlin/pmeet/pmeetserver/project/service/ProjectCommentServiceUnitTest.kt
+++ b/src/test/kotlin/pmeet/pmeetserver/project/service/ProjectCommentServiceUnitTest.kt
@@ -6,7 +6,6 @@ import io.kotest.matchers.shouldBe
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.verify
-import java.time.LocalDateTime
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.StandardTestDispatcher
@@ -17,11 +16,12 @@ import org.springframework.test.util.ReflectionTestUtils
 import pmeet.pmeetserver.common.ErrorCode
 import pmeet.pmeetserver.common.exception.EntityNotFoundException
 import pmeet.pmeetserver.project.domain.ProjectComment
-import pmeet.pmeetserver.project.dto.request.comment.ProjectCommentResponseDto
-import pmeet.pmeetserver.project.dto.request.comment.ProjectCommentWithChildResponseDto
+import pmeet.pmeetserver.project.dto.comment.response.ProjectCommentResponseDto
+import pmeet.pmeetserver.project.dto.comment.response.ProjectCommentWithChildResponseDto
 import pmeet.pmeetserver.project.repository.ProjectCommentRepository
 import reactor.core.publisher.Flux
 import reactor.core.publisher.Mono
+import java.time.LocalDateTime
 
 @ExperimentalCoroutinesApi
 internal class ProjectCommentServiceUnitTest : DescribeSpec({
@@ -146,7 +146,11 @@ internal class ProjectCommentServiceUnitTest : DescribeSpec({
     context("projectId가 주어지면") {
       it("댓글을 조회한다.") {
         runTest {
-          every { projectCommentRepository.findCommentsByProjectIdWithChild(projectId) } answers { Flux.fromIterable(responseDto) }
+          every { projectCommentRepository.findCommentsByProjectIdWithChild(projectId) } answers {
+            Flux.fromIterable(
+              responseDto
+            )
+          }
 
           val result = projectCommentService.getProjectCommentWithChildByProjectId(projectId)
 

--- a/src/test/kotlin/pmeet/pmeetserver/user/UserIntegrationTest.kt
+++ b/src/test/kotlin/pmeet/pmeetserver/user/UserIntegrationTest.kt
@@ -2,6 +2,7 @@ package pmeet.pmeetserver.user
 
 import io.kotest.core.spec.Spec
 import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.reactive.awaitFirst
@@ -47,7 +48,8 @@ internal class UserIntegrationTest : BaseMongoDBTestForIntegration() {
     password = "password",
     phoneNumber = "1234567890",
     gender = Gender.MALE,
-    introductionComment = "testIntroduction"
+    introductionComment = "testIntroduction",
+    profileImageUrl = "http://test.image.url"
   )
 
   lateinit var userId: String
@@ -82,7 +84,7 @@ internal class UserIntegrationTest : BaseMongoDBTestForIntegration() {
               userSummary.email shouldBe user.email
               userSummary.nickname shouldBe user.nickname
               userSummary.isEmployed shouldBe user.isEmployed
-              userSummary.profileImageUrl shouldBe user.profileImageUrl
+              userSummary.profileImageUrl shouldNotBe user.profileImageUrl
             }
         }
       }
@@ -104,7 +106,7 @@ internal class UserIntegrationTest : BaseMongoDBTestForIntegration() {
               userResponse.email shouldBe user.email
               userResponse.nickname shouldBe user.nickname
               userResponse.isEmployed shouldBe user.isEmployed
-              userResponse.profileImageUrl shouldBe user.profileImageUrl
+              userResponse.profileImageUrl shouldNotBe user.profileImageUrl
               userResponse.gender shouldBe user.gender
               userResponse.introductionComment shouldBe user.introductionComment
               userResponse.phoneNumber shouldBe user.phoneNumber
@@ -139,7 +141,7 @@ internal class UserIntegrationTest : BaseMongoDBTestForIntegration() {
             .expectBody<UserResponseDto>()
             .consumeWith {
               val userResponse = it.responseBody!!
-              userResponse.profileImageUrl shouldBe updateUserRequestDto.profileImageUrl
+              userResponse.profileImageUrl shouldNotBe updateUserRequestDto.profileImageUrl
               userResponse.name shouldBe updateUserRequestDto.name
               userResponse.nickname shouldBe updateUserRequestDto.nickname
               userResponse.phoneNumber shouldBe updateUserRequestDto.phoneNumber

--- a/src/test/kotlin/pmeet/pmeetserver/user/resume/ResumeGenerator.kt
+++ b/src/test/kotlin/pmeet/pmeetserver/user/resume/ResumeGenerator.kt
@@ -153,7 +153,8 @@ object ResumeGenerator {
   }
 
   internal fun createMockResumeResponseDtoList(): List<ResumeResponseDto> {
-    return generateResumeList().map { ResumeResponseDto.from(it) }
+    val resumes = generateResumeList()
+    return resumes.map { ResumeResponseDto.of(it, "profileImageDownloadUrl", "portfolioFileDownloadUrl") }
   }
 
   internal fun createMockResumeCopyResponseDto(): ResumeResponseDto {

--- a/src/test/kotlin/pmeet/pmeetserver/user/resume/ResumeIntegrationTest.kt
+++ b/src/test/kotlin/pmeet/pmeetserver/user/resume/ResumeIntegrationTest.kt
@@ -4,6 +4,7 @@ import io.kotest.core.spec.IsolationMode
 import io.kotest.core.spec.Spec
 import io.kotest.matchers.date.shouldBeAfter
 import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.withContext
@@ -136,12 +137,12 @@ class ResumeIntegrationTest : BaseMongoDBTestForIntegration() {
             returnedResume.userBirthDate shouldBe resumeResponse.userBirthDate
             returnedResume.userPhoneNumber shouldBe resumeResponse.userPhoneNumber
             returnedResume.userEmail shouldBe resumeResponse.userEmail
-            returnedResume.userProfileImageUrl shouldBe resumeResponse.userProfileImageUrl
+            returnedResume.userProfileImageUrl shouldNotBe resumeResponse.userProfileImageUrl
             returnedResume.desiredJobs shouldBe resumeResponse.desiredJobs
             returnedResume.techStacks shouldBe resumeResponse.techStacks
             returnedResume.jobExperiences shouldBe resumeResponse.jobExperiences
             returnedResume.projectExperiences shouldBe resumeResponse.projectExperiences
-            returnedResume.portfolioFileUrl shouldBe resumeResponse.portfolioFileUrl
+            returnedResume.portfolioFileUrl shouldNotBe resumeResponse.portfolioFileUrl
             returnedResume.portfolioUrl shouldBe resumeResponse.portfolioUrl
             returnedResume.selfDescription shouldBe resumeResponse.selfDescription
           }
@@ -184,12 +185,12 @@ class ResumeIntegrationTest : BaseMongoDBTestForIntegration() {
             returnedResume.userBirthDate shouldBe resumeResponse.userBirthDate
             returnedResume.userPhoneNumber shouldBe resumeResponse.userPhoneNumber
             returnedResume.userEmail shouldBe resumeResponse.userEmail
-            returnedResume.userProfileImageUrl shouldBe resumeResponse.userProfileImageUrl
+            returnedResume.userProfileImageUrl shouldNotBe resumeResponse.userProfileImageUrl
             returnedResume.desiredJobs shouldBe resumeResponse.desiredJobs
             returnedResume.techStacks shouldBe resumeResponse.techStacks
             returnedResume.jobExperiences shouldBe resumeResponse.jobExperiences
             returnedResume.projectExperiences shouldBe resumeResponse.projectExperiences
-            returnedResume.portfolioFileUrl shouldBe resumeResponse.portfolioFileUrl
+            returnedResume.portfolioFileUrl shouldNotBe resumeResponse.portfolioFileUrl
             returnedResume.portfolioUrl shouldBe resumeResponse.portfolioUrl
             returnedResume.selfDescription shouldBe resumeResponse.selfDescription
           }
@@ -268,12 +269,12 @@ class ResumeIntegrationTest : BaseMongoDBTestForIntegration() {
 
             returnedResume.title shouldBe resumeResponse.title
             returnedResume.isActive shouldBe resumeResponse.isActive
-            returnedResume.userProfileImageUrl shouldBe resumeResponse.userProfileImageUrl
-            returnedResume.desiredJobs.first.name shouldBe resumeResponse.desiredJobs.first.name
-            returnedResume.techStacks.first.name shouldBe resumeResponse.techStacks.first.name
-            returnedResume.jobExperiences.first.companyName shouldBe resumeResponse.jobExperiences.first.companyName
-            returnedResume.projectExperiences.first.projectName shouldBe resumeResponse.projectExperiences.first.projectName
-            returnedResume.portfolioFileUrl shouldBe resumeResponse.portfolioFileUrl
+            returnedResume.userProfileImageUrl shouldNotBe resumeResponse.userProfileImageUrl
+            returnedResume.desiredJobs.first().name shouldBe resumeResponse.desiredJobs.first().name
+            returnedResume.techStacks.first().name shouldBe resumeResponse.techStacks.first().name
+            returnedResume.jobExperiences.first().companyName shouldBe resumeResponse.jobExperiences.first().companyName
+            returnedResume.projectExperiences.first().projectName shouldBe resumeResponse.projectExperiences.first().projectName
+            returnedResume.portfolioFileUrl shouldNotBe resumeResponse.portfolioFileUrl
             returnedResume.portfolioUrl shouldBe resumeResponse.portfolioUrl
             returnedResume.selfDescription shouldBe resumeResponse.selfDescription
             returnedResume.updatedAt shouldBeAfter requestTime
@@ -330,12 +331,12 @@ class ResumeIntegrationTest : BaseMongoDBTestForIntegration() {
             returnedResume.userBirthDate shouldBe resumeResponse.userBirthDate
             returnedResume.userPhoneNumber shouldBe resumeResponse.userPhoneNumber
             returnedResume.userEmail shouldBe resumeResponse.userEmail
-            returnedResume.userProfileImageUrl shouldBe resumeResponse.userProfileImageUrl
+            returnedResume.userProfileImageUrl shouldNotBe resumeResponse.userProfileImageUrl
             returnedResume.desiredJobs shouldBe resumeResponse.desiredJobs
             returnedResume.techStacks shouldBe resumeResponse.techStacks
             returnedResume.jobExperiences shouldBe resumeResponse.jobExperiences
             returnedResume.projectExperiences shouldBe resumeResponse.projectExperiences
-            returnedResume.portfolioFileUrl shouldBe resumeResponse.portfolioFileUrl
+            returnedResume.portfolioFileUrl shouldNotBe resumeResponse.portfolioFileUrl
             returnedResume.portfolioUrl shouldBe resumeResponse.portfolioUrl
             returnedResume.selfDescription shouldBe resumeResponse.selfDescription
           }


### PR DESCRIPTION
## Related issue

## Description
클라리언트가 ObjectName으로 다시 백엔드 서버에 DownloadURL을 요청 할 필요 없이 사전에 생성 후 응답
## Changes detail
- FileService를 Facade와 Service로 분리
### Checklist
- [x] Test case
- [x] End of work
