### PR TITLE
fix: 빈 문자열의 파일 이름의 경우 FileService에서 발생하는 예외 방지

### DIFF
--- a/src/main/kotlin/pmeet/pmeetserver/file/service/FileFacadeService.kt
+++ b/src/main/kotlin/pmeet/pmeetserver/file/service/FileFacadeService.kt
@@ -13,6 +13,6 @@ class FileFacadeService(
   }
 
   suspend fun getPreSignedUrlToDownload(objectName: String): FileUrlResponseDto {
-    return FileUrlResponseDto.of(fileService.generatePreSignedUrlToDownload(objectName), objectName)
+    return FileUrlResponseDto.of(fileService.generatePreSignedUrlToDownload(objectName)!!, objectName)
   }
 }

--- a/src/main/kotlin/pmeet/pmeetserver/file/service/FileService.kt
+++ b/src/main/kotlin/pmeet/pmeetserver/file/service/FileService.kt
@@ -12,7 +12,7 @@ import software.amazon.awssdk.services.s3.presigner.model.GetObjectPresignReques
 import software.amazon.awssdk.services.s3.presigner.model.PutObjectPresignRequest
 import java.time.Duration
 import java.time.LocalDate
-import java.util.UUID
+import java.util.*
 
 
 @Service
@@ -42,12 +42,19 @@ class FileService(
               .build()
           )
           .build().run {
-            return FileUrlResponseDto.of(presigner.presignPutObject(this).url().toExternalForm(), objectName)
+            return FileUrlResponseDto.of(
+              presigner.presignPutObject(this).url().toExternalForm(),
+              objectName
+            )
           }
       }
   }
 
-  suspend fun generatePreSignedUrlToDownload(objectName: String): String {
+  suspend fun generatePreSignedUrlToDownload(objectName: String): String? {
+    if (objectName.isBlank()) {
+      return null
+    }
+
     S3Presigner.builder()
       .credentialsProvider(awsCredentialsProvider)
       .region(Region.of(region))


### PR DESCRIPTION
## Related issue
## Description
- 파일 이름이 빈 문자열인 경우 FileService에서 Exception이 발생하는 문제를 Null을 반환하도록 하여 해결
## Changes detail

### Checklist
- [x] Test case
- [x] End of work
