### PR TITLE
✨ feat: 프밋 지원 현황 상태 변경 기능 구현

### DIFF
--- a/src/main/kotlin/pmeet/pmeetserver/common/ErrorCode.kt
+++ b/src/main/kotlin/pmeet/pmeetserver/common/ErrorCode.kt
@@ -45,8 +45,11 @@ enum class ErrorCode(private val code: String, private val message: String) {
   PROJECT_COMMENT_NOT_FOUND("PROJECT-COMMENT-40400", "해당하는 ID의 댓글을 찾을 수 없습니다."),
   PROJECT_COMMENT_DELETE_FORBIDDEN("PROJECT-COMMENT-40300", "해당하는 댓글을 삭제할 권한이 없습니다."),
 
-    // Project Tryout
-    PROJECT_TRYOUT_STATUS_UPDATE_FAIL("PROJECT-TRYOUT-40401", "상태가 검토중이 아닌 지원서는 상태를 변경할 수 없습니다."),
+  // Project Tryout
+  PROJECT_TRYOUT_STATUS_UPDATE_FAIL("PROJECT-TRYOUT-40401", "상태가 검토중이 아닌 지원서는 상태를 변경할 수 없습니다."),
+
+  // Project Member
+  PROJECT_MEMBER_MODIFY_FORBIDDEN("PROJECT-MEMBER-40401", "프로젝트 멤버를 수정할 권한이 없습니다."),
 
   ;
 

--- a/src/main/kotlin/pmeet/pmeetserver/common/ErrorCode.kt
+++ b/src/main/kotlin/pmeet/pmeetserver/common/ErrorCode.kt
@@ -45,6 +45,9 @@ enum class ErrorCode(private val code: String, private val message: String) {
   PROJECT_COMMENT_NOT_FOUND("PROJECT-COMMENT-40400", "해당하는 ID의 댓글을 찾을 수 없습니다."),
   PROJECT_COMMENT_DELETE_FORBIDDEN("PROJECT-COMMENT-40300", "해당하는 댓글을 삭제할 권한이 없습니다."),
 
+    // Project Tryout
+    PROJECT_TRYOUT_STATUS_UPDATE_FAIL("PROJECT-TRYOUT-40401", "상태가 검토중이 아닌 지원서는 상태를 변경할 수 없습니다."),
+
   ;
 
   fun getCode(): String {

--- a/src/main/kotlin/pmeet/pmeetserver/project/controller/ProjectMemberController.kt
+++ b/src/main/kotlin/pmeet/pmeetserver/project/controller/ProjectMemberController.kt
@@ -1,0 +1,24 @@
+package pmeet.pmeetserver.project.controller
+
+import kotlinx.coroutines.reactor.awaitSingle
+import org.springframework.http.HttpStatus
+import org.springframework.security.core.annotation.AuthenticationPrincipal
+import org.springframework.web.bind.annotation.*
+import pmeet.pmeetserver.project.service.ProjectFacadeService
+import reactor.core.publisher.Mono
+
+@RestController
+@RequestMapping("/api/v1/project-members")
+class ProjectMemberController(private val projectFacadeService: ProjectFacadeService) {
+
+    @DeleteMapping
+    @ResponseStatus(HttpStatus.OK)
+    suspend fun deleteProjectMember(
+        @AuthenticationPrincipal userId: Mono<String>,
+        @RequestParam("projectid") projectId: String,
+        @RequestParam("memberid") memberId: String
+    ) {
+        projectFacadeService.deleteProjectMember(userId.awaitSingle(), projectId, memberId)
+    }
+
+}

--- a/src/main/kotlin/pmeet/pmeetserver/project/controller/ProjectTryoutController.kt
+++ b/src/main/kotlin/pmeet/pmeetserver/project/controller/ProjectTryoutController.kt
@@ -4,14 +4,9 @@ import jakarta.validation.Valid
 import kotlinx.coroutines.reactor.awaitSingle
 import org.springframework.http.HttpStatus
 import org.springframework.security.core.annotation.AuthenticationPrincipal
-import org.springframework.web.bind.annotation.GetMapping
-import org.springframework.web.bind.annotation.PathVariable
-import org.springframework.web.bind.annotation.PostMapping
-import org.springframework.web.bind.annotation.RequestBody
-import org.springframework.web.bind.annotation.RequestMapping
-import org.springframework.web.bind.annotation.ResponseStatus
-import org.springframework.web.bind.annotation.RestController
+import org.springframework.web.bind.annotation.*
 import pmeet.pmeetserver.project.dto.tryout.request.CreateProjectTryoutRequestDto
+import pmeet.pmeetserver.project.dto.tryout.request.PatchProjectTryoutRequestDto
 import pmeet.pmeetserver.project.dto.tryout.response.ProjectTryoutResponseDto
 import pmeet.pmeetserver.project.service.ProjectFacadeService
 import reactor.core.publisher.Mono
@@ -40,4 +35,21 @@ class ProjectTryoutController(
     return projectFacadeService.getProjectTryoutListByProjectId(userId.awaitSingle(), projectId)
   }
 
+  @PatchMapping("/accept")
+  @ResponseStatus(HttpStatus.OK)
+  suspend fun patchProjectTryoutToAccepted(
+    @AuthenticationPrincipal userId: Mono<String>,
+    @RequestBody @Valid requestDto: PatchProjectTryoutRequestDto
+  ): ProjectTryoutResponseDto {
+    return projectFacadeService.patchProjectTryoutStatusToAccept(userId.awaitSingle(), requestDto)
+  }
+
+  @PatchMapping("/reject")
+  @ResponseStatus(HttpStatus.OK)
+  suspend fun patchProjectTryoutToRejected(
+    @AuthenticationPrincipal userId: Mono<String>,
+    @RequestBody @Valid requestDto: PatchProjectTryoutRequestDto
+  ): ProjectTryoutResponseDto {
+    return projectFacadeService.pathProjectTryoutStatusToReject(userId.awaitSingle(), requestDto)
+  }
 }

--- a/src/main/kotlin/pmeet/pmeetserver/project/domain/ProjectMember.kt
+++ b/src/main/kotlin/pmeet/pmeetserver/project/domain/ProjectMember.kt
@@ -1,0 +1,19 @@
+package pmeet.pmeetserver.project.domain
+
+import org.springframework.data.annotation.Id
+import org.springframework.data.mongodb.core.mapping.Document
+import java.time.LocalDateTime
+
+@Document
+class ProjectMember(
+    @Id
+    var id: String? = null,
+    val resumeId: String,
+    val userId: String,
+    val userName: String,
+    val userSelfDescription: String,
+    var positionName: String? = null,
+    val projectId: String,
+    val createdAt: LocalDateTime,
+) {
+}

--- a/src/main/kotlin/pmeet/pmeetserver/project/domain/ProjectMember.kt
+++ b/src/main/kotlin/pmeet/pmeetserver/project/domain/ProjectMember.kt
@@ -9,6 +9,7 @@ class ProjectMember(
     @Id
     var id: String? = null,
     val resumeId: String,
+    val tryoutId: String,
     val userId: String,
     val userName: String,
     val userSelfDescription: String,

--- a/src/main/kotlin/pmeet/pmeetserver/project/domain/ProjectTryout.kt
+++ b/src/main/kotlin/pmeet/pmeetserver/project/domain/ProjectTryout.kt
@@ -32,6 +32,7 @@ class ProjectTryout(
         return ProjectMember(
             resumeId = resumeId,
             userId = userId,
+            tryoutId = id!!,
             userName = userName,
             userSelfDescription = userSelfDescription,
             projectId = projectId,

--- a/src/main/kotlin/pmeet/pmeetserver/project/domain/ProjectTryout.kt
+++ b/src/main/kotlin/pmeet/pmeetserver/project/domain/ProjectTryout.kt
@@ -2,19 +2,40 @@ package pmeet.pmeetserver.project.domain
 
 import org.springframework.data.annotation.Id
 import org.springframework.data.mongodb.core.mapping.Document
+import pmeet.pmeetserver.common.ErrorCode
+import pmeet.pmeetserver.common.exception.ForbiddenRequestException
 import pmeet.pmeetserver.project.domain.enum.ProjectTryoutStatus
 import java.time.LocalDateTime
 
 @Document
 class ProjectTryout(
-  @Id
-  var id: String? = null,
-  val resumeId: String,
-  val userId: String,
-  val userName: String,
-  val userSelfDescription: String,
-  val positionName: String,
-  val tryoutStatus: ProjectTryoutStatus,
-  val projectId: String,
-  val createdAt: LocalDateTime,
-)
+    @Id
+    var id: String? = null,
+    val resumeId: String,
+    val userId: String,
+    val userName: String,
+    val userSelfDescription: String,
+    val positionName: String,
+    var tryoutStatus: ProjectTryoutStatus,
+    val projectId: String,
+    val createdAt: LocalDateTime,
+) {
+    fun updateStatus(tryoutStatus: ProjectTryoutStatus) {
+        if (this.tryoutStatus === ProjectTryoutStatus.INREVIEW) {
+            this.tryoutStatus = tryoutStatus
+        } else {
+            throw ForbiddenRequestException(ErrorCode.PROJECT_TRYOUT_STATUS_UPDATE_FAIL)
+        }
+    }
+
+    fun createProjectMember(): ProjectMember {
+        return ProjectMember(
+            resumeId = resumeId,
+            userId = userId,
+            userName = userName,
+            userSelfDescription = userSelfDescription,
+            projectId = projectId,
+            createdAt = LocalDateTime.now()
+        )
+    }
+}

--- a/src/main/kotlin/pmeet/pmeetserver/project/dto/tryout/request/PatchProjectTryoutRequestDto.kt
+++ b/src/main/kotlin/pmeet/pmeetserver/project/dto/tryout/request/PatchProjectTryoutRequestDto.kt
@@ -1,0 +1,8 @@
+package pmeet.pmeetserver.project.dto.tryout.request
+
+import jakarta.validation.constraints.NotBlank
+
+data class PatchProjectTryoutRequestDto(
+    @field:NotBlank(message = "프로젝트 id는 필수입니다.") val projectId: String,
+    @field:NotBlank(message = "지원서 id는 필수입니다.") val tryoutId: String,
+)

--- a/src/main/kotlin/pmeet/pmeetserver/project/repository/ProjectMemberRepository.kt
+++ b/src/main/kotlin/pmeet/pmeetserver/project/repository/ProjectMemberRepository.kt
@@ -1,0 +1,8 @@
+package pmeet.pmeetserver.project.repository
+
+import org.springframework.data.mongodb.repository.ReactiveMongoRepository
+import pmeet.pmeetserver.project.domain.ProjectMember
+
+interface ProjectMemberRepository : ReactiveMongoRepository<ProjectMember, String> {
+
+}

--- a/src/main/kotlin/pmeet/pmeetserver/project/service/ProjectFacadeService.kt
+++ b/src/main/kotlin/pmeet/pmeetserver/project/service/ProjectFacadeService.kt
@@ -240,7 +240,7 @@ class ProjectFacadeService(
    * 요청을 보낸 사용자가 해당 프밋의 생성자인지 검증한다.
    * 생성자가 맞는 경우엔 Project 를 반환한다.
    */
-  internal suspend fun checkUserHasAuthToProject(projectId: String, userId: String, errorCode: ErrorCode): Project {
+  private suspend fun checkUserHasAuthToProject(projectId: String, userId: String, errorCode: ErrorCode): Project {
     val project = projectService.getProjectById(projectId)
     if (project.userId != userId) {
       throw ForbiddenRequestException(errorCode)

--- a/src/main/kotlin/pmeet/pmeetserver/project/service/ProjectFacadeService.kt
+++ b/src/main/kotlin/pmeet/pmeetserver/project/service/ProjectFacadeService.kt
@@ -236,6 +236,14 @@ class ProjectFacadeService(
     return ProjectTryoutResponseDto.from(projectTryout)
   }
 
+  @Transactional
+  suspend fun deleteProjectMember(userId: String, projectId: String, memberId: String) {
+    checkUserHasAuthToProject(projectId, userId, ErrorCode.PROJECT_MEMBER_MODIFY_FORBIDDEN)
+    val projectMember = projectMemberService.findMemberById(memberId);
+    projectTryoutService.deleteTryout(projectMember.tryoutId)
+    projectMemberService.deleteProjectMember(memberId)
+  }
+
   /**
    * 요청을 보낸 사용자가 해당 프밋의 생성자인지 검증한다.
    * 생성자가 맞는 경우엔 Project 를 반환한다.

--- a/src/main/kotlin/pmeet/pmeetserver/project/service/ProjectMemberService.kt
+++ b/src/main/kotlin/pmeet/pmeetserver/project/service/ProjectMemberService.kt
@@ -1,0 +1,19 @@
+package pmeet.pmeetserver.project.service
+
+import kotlinx.coroutines.reactor.awaitSingle
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+import pmeet.pmeetserver.project.domain.ProjectMember
+import pmeet.pmeetserver.project.repository.ProjectMemberRepository
+
+@Service
+class ProjectMemberService(
+    private val projectMemberRepository: ProjectMemberRepository
+) {
+
+    @Transactional
+    suspend fun save(projectMember: ProjectMember): ProjectMember {
+        return projectMemberRepository.save(projectMember).awaitSingle()
+    }
+
+}

--- a/src/main/kotlin/pmeet/pmeetserver/project/service/ProjectMemberService.kt
+++ b/src/main/kotlin/pmeet/pmeetserver/project/service/ProjectMemberService.kt
@@ -1,6 +1,7 @@
 package pmeet.pmeetserver.project.service
 
 import kotlinx.coroutines.reactor.awaitSingle
+import kotlinx.coroutines.reactor.awaitSingleOrNull
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 import pmeet.pmeetserver.project.domain.ProjectMember
@@ -14,6 +15,16 @@ class ProjectMemberService(
     @Transactional
     suspend fun save(projectMember: ProjectMember): ProjectMember {
         return projectMemberRepository.save(projectMember).awaitSingle()
+    }
+
+    @Transactional
+    suspend fun deleteProjectMember(projectMemberId: String) {
+        projectMemberRepository.deleteById(projectMemberId).awaitSingleOrNull()
+    }
+
+    @Transactional
+    suspend fun findMemberById(memberId: String): ProjectMember {
+        return projectMemberRepository.findById(memberId).awaitSingle()
     }
 
 }

--- a/src/main/kotlin/pmeet/pmeetserver/project/service/ProjectTryoutService.kt
+++ b/src/main/kotlin/pmeet/pmeetserver/project/service/ProjectTryoutService.kt
@@ -5,6 +5,7 @@ import kotlinx.coroutines.reactor.awaitSingleOrNull
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 import pmeet.pmeetserver.project.domain.ProjectTryout
+import pmeet.pmeetserver.project.domain.enum.ProjectTryoutStatus
 import pmeet.pmeetserver.project.repository.ProjectTryoutRepository
 
 @Service
@@ -25,6 +26,13 @@ class ProjectTryoutService(
   @Transactional(readOnly = true)
   suspend fun findAllByProjectId(projectId: String): List<ProjectTryout> {
     return projectTryoutRepository.findAllByProjectId(projectId).collectList().awaitSingle()
+  }
+
+  @Transactional
+  suspend fun updateTryoutStatus(tryoutId: String, accepted: ProjectTryoutStatus): ProjectTryout {
+    val projectTryout = projectTryoutRepository.findById(tryoutId).awaitSingle()
+    projectTryout.updateStatus(accepted)
+    return projectTryoutRepository.save(projectTryout).awaitSingle()
   }
 
 }

--- a/src/main/kotlin/pmeet/pmeetserver/project/service/ProjectTryoutService.kt
+++ b/src/main/kotlin/pmeet/pmeetserver/project/service/ProjectTryoutService.kt
@@ -35,4 +35,9 @@ class ProjectTryoutService(
     return projectTryoutRepository.save(projectTryout).awaitSingle()
   }
 
+  @Transactional
+  suspend fun deleteTryout(tryoutId: String) {
+    projectTryoutRepository.deleteById(tryoutId).awaitSingleOrNull()
+  }
+
 }

--- a/src/test/kotlin/pmeet/pmeetserver/project/ProjectMemberIntegrationTest.kt
+++ b/src/test/kotlin/pmeet/pmeetserver/project/ProjectMemberIntegrationTest.kt
@@ -1,0 +1,140 @@
+package pmeet.pmeetserver.project
+
+import io.kotest.core.spec.IsolationMode
+import io.kotest.core.spec.Spec
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.withContext
+import org.junit.jupiter.api.extension.ExtendWith
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.autoconfigure.web.reactive.AutoConfigureWebTestClient
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.context.annotation.Import
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken
+import org.springframework.security.test.web.reactive.server.SecurityMockServerConfigurers.mockAuthentication
+import org.springframework.test.context.ActiveProfiles
+import org.springframework.test.context.junit.jupiter.SpringExtension
+import org.springframework.test.web.reactive.server.WebTestClient
+import pmeet.pmeetserver.config.BaseMongoDBTestForIntegration
+import pmeet.pmeetserver.config.TestSecurityConfig
+import pmeet.pmeetserver.project.domain.Project
+import pmeet.pmeetserver.project.domain.ProjectMember
+import pmeet.pmeetserver.project.domain.ProjectTryout
+import pmeet.pmeetserver.project.domain.enum.ProjectTryoutStatus
+import pmeet.pmeetserver.project.repository.ProjectMemberRepository
+import pmeet.pmeetserver.project.repository.ProjectRepository
+import pmeet.pmeetserver.project.repository.ProjectTryoutRepository
+import pmeet.pmeetserver.user.domain.resume.Resume
+import pmeet.pmeetserver.user.repository.resume.ResumeRepository
+import pmeet.pmeetserver.user.resume.ResumeGenerator.generateResume
+import java.time.LocalDateTime
+
+@ExtendWith(SpringExtension::class)
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+@AutoConfigureWebTestClient
+@Import(TestSecurityConfig::class)
+@ExperimentalCoroutinesApi
+@ActiveProfiles("test")
+class ProjectMemberIntegrationTest : BaseMongoDBTestForIntegration() {
+
+    override fun isolationMode(): IsolationMode? {
+        return IsolationMode.InstancePerLeaf
+    }
+
+    @Autowired
+    private lateinit var resumeRepository: ResumeRepository
+
+    @Autowired
+    private lateinit var projectRepository: ProjectRepository
+
+    @Autowired
+    private lateinit var projectTryoutRepository: ProjectTryoutRepository
+
+    @Autowired
+    private lateinit var projectMemberRepository: ProjectMemberRepository
+
+    @Autowired
+    lateinit var webTestClient: WebTestClient
+
+    lateinit var project: Project
+    lateinit var resume: Resume
+    lateinit var userId: String
+    lateinit var projectId: String
+    lateinit var projectTryout: ProjectTryout
+    lateinit var projectTryoutId: String
+    lateinit var projectMember: ProjectMember
+
+    override suspend fun beforeSpec(spec: Spec) {
+        resume = generateResume()
+        userId = resume.userId
+        projectId = "testProjectId"
+
+        project = Project(
+            id = projectId,
+            userId = userId,
+            title = "testTitle",
+            startDate = LocalDateTime.of(2021, 1, 1, 0, 0, 0),
+            endDate = LocalDateTime.of(2021, 12, 31, 23, 59, 59),
+            thumbNailUrl = "testThumbNailUrl",
+            techStacks = listOf("testTechStack1", "testTechStack2"),
+            recruitments = emptyList(),
+            description = "testDescription"
+        )
+
+        projectTryoutId = "testProjectTryoutId"
+
+        projectTryout = ProjectTryout(
+            id = projectTryoutId,
+            resumeId = resume.id!!,
+            userId = userId,
+            userName = resume.userName,
+            userSelfDescription = resume.selfDescription.orEmpty(),
+            positionName = "testPositionName",
+            tryoutStatus = ProjectTryoutStatus.INREVIEW,
+            projectId = projectId,
+            createdAt = LocalDateTime.now()
+        )
+
+        projectMember = projectTryout.createProjectMember()
+
+        withContext(Dispatchers.IO) {
+            projectRepository.save(project).block()
+            resumeRepository.save(resume).block()
+            projectTryoutRepository.save(projectTryout).block()
+            projectMemberRepository.save(projectMember).block()
+        }
+    }
+
+    override suspend fun afterSpec(spec: Spec) {
+        withContext(Dispatchers.IO) {
+            projectRepository.deleteAll().block()
+            resumeRepository.deleteAll().block()
+            projectTryoutRepository.deleteAll().block()
+            projectMemberRepository.deleteAll().block()
+        }
+    }
+
+    init {
+        describe("POST /api/v1/project-members") {
+            context("인증된 유저의 프로젝트에 대한 멤버 삭제 요청이 들어오면") {
+                val mockAuthentication = UsernamePasswordAuthenticationToken(userId, null, null)
+                val performRequest =
+                    webTestClient
+                        .mutateWith(mockAuthentication(mockAuthentication))
+                        .delete()
+                        .uri { uriBuilder ->
+                            uriBuilder
+                                .path("/api/v1/project-members")
+                                .queryParam("projectid", projectId)
+                                .queryParam("memberid", projectMember.id)
+                                .build()
+                        }
+                        .exchange()
+
+                it("요청은 성공한다") {
+                    performRequest.expectStatus().isOk
+                }
+            }
+        }
+    }
+}

--- a/src/test/kotlin/pmeet/pmeetserver/project/controller/ProjectMemberControllerUnitTest.kt
+++ b/src/test/kotlin/pmeet/pmeetserver/project/controller/ProjectMemberControllerUnitTest.kt
@@ -1,0 +1,61 @@
+package pmeet.pmeetserver.project.controller
+
+import com.ninjasquad.springmockk.MockkBean
+import io.kotest.core.spec.style.DescribeSpec
+import io.mockk.coEvery
+import io.mockk.coVerify
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.autoconfigure.web.reactive.WebFluxTest
+import org.springframework.context.annotation.Import
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken
+import org.springframework.security.test.web.reactive.server.SecurityMockServerConfigurers.mockAuthentication
+import org.springframework.test.web.reactive.server.WebTestClient
+import pmeet.pmeetserver.config.TestSecurityConfig
+import pmeet.pmeetserver.project.service.ProjectFacadeService
+
+@WebFluxTest(ProjectMemberController::class)
+@Import(TestSecurityConfig::class)
+class ProjectMemberControllerUnitTest : DescribeSpec() {
+
+    @Autowired
+    private lateinit var webTestClient: WebTestClient
+
+    @MockkBean
+    lateinit var projectFacadeService: ProjectFacadeService
+
+    init {
+
+        describe("deleteProjectMember") {
+            context("인증된 유저의 프로젝트 멤버에 대한 삭제 요청이 들어오면") {
+                val userId = "1234"
+                val projectId = "testProjectId"
+                val memberId = "testMemberId"
+
+                coEvery { projectFacadeService.deleteProjectMember(userId, projectId, memberId) } answers { Unit }
+
+                val mockAuthentication = UsernamePasswordAuthenticationToken(userId, null, null)
+                val performRequest =
+                    webTestClient
+                        .mutateWith(mockAuthentication(mockAuthentication))
+                        .delete()
+                        .uri { uriBuilder ->
+                            uriBuilder
+                                .path("/api/v1/project-members")
+                                .queryParam("projectid", projectId)
+                                .queryParam("memberid", memberId)
+                                .build()
+                        }
+                        .exchange()
+
+                it("서비스를 통해 데이터를 업데이트한다.") {
+                    coVerify(exactly = 1) { projectFacadeService.deleteProjectMember(userId, projectId, memberId) }
+                }
+
+                it("요청은 성공한다") {
+                    performRequest.expectStatus().isOk
+                }
+            }
+        }
+    }
+
+}

--- a/src/test/kotlin/pmeet/pmeetserver/project/controller/ProjectTryoutControllerUnitTest.kt
+++ b/src/test/kotlin/pmeet/pmeetserver/project/controller/ProjectTryoutControllerUnitTest.kt
@@ -15,6 +15,7 @@ import org.springframework.test.web.reactive.server.expectBody
 import pmeet.pmeetserver.config.TestSecurityConfig
 import pmeet.pmeetserver.project.domain.enum.ProjectTryoutStatus
 import pmeet.pmeetserver.project.dto.tryout.request.CreateProjectTryoutRequestDto
+import pmeet.pmeetserver.project.dto.tryout.request.PatchProjectTryoutRequestDto
 import pmeet.pmeetserver.project.dto.tryout.response.ProjectTryoutResponseDto
 import pmeet.pmeetserver.project.service.ProjectFacadeService
 import pmeet.pmeetserver.user.resume.ResumeGenerator.generateResume
@@ -145,5 +146,102 @@ internal class ProjectTryoutControllerUnitTest : DescribeSpec() {
       }
     }
 
+    describe("patchProjectTryoutToAccepted") {
+      context("인증된 유저의 프로젝트에 대한 지원 현황 합격 업데이트 요청이 들어오면") {
+        val resume = generateResume()
+        val userId = resume.userId
+        val requestProjectId = "testProjectId"
+        val requestTryoutId = "testTryoutId"
+        val createdAt = LocalDateTime.now()
+        val responseDto =
+          ProjectTryoutResponseDto(
+            id = requestTryoutId,
+            resumeId = resume.id!!,
+            userId = userId,
+            projectId = requestProjectId,
+            userName = "userName",
+            userSelfDescription = "userSelfDescription",
+            positionName = "positionName",
+            tryoutStatus = ProjectTryoutStatus.INREVIEW,
+            createdAt = createdAt
+          )
+
+
+        val requestDto = PatchProjectTryoutRequestDto(requestProjectId, requestTryoutId)
+
+        coEvery {
+          projectFacadeService.patchProjectTryoutStatusToAccept(
+            userId,
+            requestDto
+          )
+        } answers { responseDto }
+
+        val mockAuthentication = UsernamePasswordAuthenticationToken(userId, null, null)
+        val performRequest =
+          webTestClient
+            .mutateWith(mockAuthentication(mockAuthentication))
+            .patch()
+            .uri("/api/v1/project-tryouts/accept")
+            .bodyValue(requestDto)
+            .exchange()
+
+        it("서비스를 통해 데이터를 업데이트한다.") {
+          coVerify(exactly = 1) { projectFacadeService.patchProjectTryoutStatusToAccept(userId, requestDto) }
+        }
+
+        it("요청은 성공한다") {
+          performRequest.expectStatus().isOk
+        }
+      }
+    }
+
+    describe("patchProjectTryoutToAccepted") {
+      context("인증된 유저의 프로젝트에 대한 지원 현황 불합격 업데이트 요청이 들어오면") {
+        val resume = generateResume()
+        val userId = resume.userId
+        val requestProjectId = "testProjectId"
+        val requestTryoutId = "testTryoutId"
+        val createdAt = LocalDateTime.now()
+        val responseDto =
+          ProjectTryoutResponseDto(
+            id = requestTryoutId,
+            resumeId = resume.id!!,
+            userId = userId,
+            projectId = requestProjectId,
+            userName = "userName",
+            userSelfDescription = "userSelfDescription",
+            positionName = "positionName",
+            tryoutStatus = ProjectTryoutStatus.INREVIEW,
+            createdAt = createdAt
+          )
+
+
+        val requestDto = PatchProjectTryoutRequestDto(requestProjectId, requestTryoutId)
+
+        coEvery {
+          projectFacadeService.pathProjectTryoutStatusToReject(
+            userId,
+            requestDto
+          )
+        } answers { responseDto }
+
+        val mockAuthentication = UsernamePasswordAuthenticationToken(userId, null, null)
+        val performRequest =
+          webTestClient
+            .mutateWith(mockAuthentication(mockAuthentication))
+            .patch()
+            .uri("/api/v1/project-tryouts/reject")
+            .bodyValue(requestDto)
+            .exchange()
+
+        it("서비스를 통해 데이터를 업데이트한다.") {
+          coVerify(exactly = 1) { projectFacadeService.pathProjectTryoutStatusToReject(userId, requestDto) }
+        }
+
+        it("요청은 성공한다") {
+          performRequest.expectStatus().isOk
+        }
+      }
+    }
   }
 }

--- a/src/test/kotlin/pmeet/pmeetserver/project/service/ProjectMemberServiceUnitTest.kt
+++ b/src/test/kotlin/pmeet/pmeetserver/project/service/ProjectMemberServiceUnitTest.kt
@@ -1,0 +1,93 @@
+package pmeet.pmeetserver.project.service
+
+import io.kotest.core.spec.style.DescribeSpec
+import io.kotest.matchers.shouldBe
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.setMain
+import org.springframework.test.util.ReflectionTestUtils
+import pmeet.pmeetserver.project.domain.ProjectMember
+import pmeet.pmeetserver.project.repository.ProjectMemberRepository
+import reactor.core.publisher.Mono
+import java.time.LocalDateTime
+
+@ExperimentalCoroutinesApi
+internal class ProjectMemberServiceUnitTest : DescribeSpec({
+    val testDispatcher = StandardTestDispatcher()
+
+    val projectMemberRepository = mockk<ProjectMemberRepository>(relaxed = true)
+
+    lateinit var projectMemberService: ProjectMemberService
+
+    lateinit var projectMember: ProjectMember
+    lateinit var userId: String
+    lateinit var projectId: String
+    lateinit var tryoutId: String
+
+    beforeSpec {
+        Dispatchers.setMain(testDispatcher)
+        projectMemberService = ProjectMemberService(projectMemberRepository)
+
+        userId = "testUserId"
+        projectId = "testProjectId"
+        tryoutId = "testTryoutId"
+
+        projectMember = ProjectMember(
+            resumeId = "testResumeId",
+            tryoutId = tryoutId,
+            userId = userId,
+            userName = "testUserName",
+            userSelfDescription = "selfDescription",
+            positionName = "testPositionName",
+            createdAt = LocalDateTime.now(),
+            projectId = projectId
+        )
+        ReflectionTestUtils.setField(projectMember, "id", "testProjectMemberId")
+    }
+
+    afterSpec {
+        Dispatchers.resetMain()
+    }
+
+    describe("save") {
+        context("프로젝트 멤버가 주어지면") {
+            it("저장 후 프로젝트 멤버를 반환한다") {
+                runTest {
+                    every { projectMemberRepository.save(any()) } answers { Mono.just(projectMember) }
+
+                    val result = projectMemberService.save(projectMember)
+
+                    result.id shouldBe projectMember.id
+                    result.resumeId shouldBe projectMember.resumeId
+                    result.userId shouldBe projectMember.userId
+                    result.userName shouldBe projectMember.userName
+                    result.userSelfDescription shouldBe projectMember.userSelfDescription
+                    result.positionName shouldBe projectMember.positionName
+                    result.projectId shouldBe projectMember.projectId
+                }
+            }
+        }
+    }
+
+    describe("deleteProjectMember") {
+        context("프로젝트 멤버 삭제 요청이 주어지면") {
+            it("프로젝트 멤버를 삭제한다") {
+                runTest {
+                    every { projectMemberRepository.deleteById(projectMember.id!!) } answers { Mono.empty() }
+
+                    projectMemberService.deleteProjectMember(projectMember.id!!)
+
+                    verify(exactly = 1) { projectMemberRepository.deleteById(projectMember.id!!) }
+                }
+            }
+        }
+    }
+
+}) {
+}

--- a/src/test/kotlin/pmeet/pmeetserver/project/service/ProjectTryoutServiceUnitTest.kt
+++ b/src/test/kotlin/pmeet/pmeetserver/project/service/ProjectTryoutServiceUnitTest.kt
@@ -128,4 +128,19 @@ internal class ProjectTryoutServiceUnitTest : DescribeSpec({
       }
     }
   }
+
+  describe("updateTryoutStatus") {
+    context("지원 현황에 대한 업데이트 요청이 주어지면") {
+      it("지원 현황의 업데이트 결과가 반환된다.") {
+        runTest {
+          every { projectTryoutRepository.findById(projectTryout.id!!) } answers { Mono.just(projectTryout) }
+          every { projectTryoutRepository.save(any()) } answers { Mono.just(projectTryout) }
+
+          val result = projectTryoutService.updateTryoutStatus(projectTryout.id!!, ProjectTryoutStatus.ACCEPTED)
+
+          result.tryoutStatus shouldBe ProjectTryoutStatus.ACCEPTED
+        }
+      }
+    }
+  }
 })

--- a/src/test/kotlin/pmeet/pmeetserver/project/service/ProjectTryoutServiceUnitTest.kt
+++ b/src/test/kotlin/pmeet/pmeetserver/project/service/ProjectTryoutServiceUnitTest.kt
@@ -143,4 +143,21 @@ internal class ProjectTryoutServiceUnitTest : DescribeSpec({
       }
     }
   }
+
+  describe("deleteTryout") {
+    context("지원 현황에 대한 삭제 요청이 주어지면") {
+      it("지원 현황이 삭제된다.") {
+        runTest {
+          every { projectTryoutRepository.deleteById(projectTryout.id!!) } answers { Mono.empty() }
+
+          projectTryoutService.deleteTryout(projectTryout.id!!)
+
+          verify(exactly = 1) { projectTryoutRepository.deleteById(projectTryout.id!!) }
+        }
+      }
+    }
+  }
+
+
+
 })


### PR DESCRIPTION
## Related issue
resolves #130 

## Description
✨ feat: 프밋 지원 현황 상태 변경 기능 구현

## Changes detail
- ♻️ refactor: ProjectFacadeService 에서 project cud 권한 확인하는 로직 분리
- ✨ feat: 프밋 지원 현황 상태 변경 기능 구현
- ✨ feat: 프밋 멤버 내보내기 기능 구현
### Checklist
- [X] Test case
- [X] End of work
