### PR TITLE
feat: 댓글에 유저 닉네임, 프로필 이미지 url 추가

### DIFF
--- a/src/main/kotlin/pmeet/pmeetserver/project/controller/ProjectController.kt
+++ b/src/main/kotlin/pmeet/pmeetserver/project/controller/ProjectController.kt
@@ -16,7 +16,7 @@ import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RequestParam
 import org.springframework.web.bind.annotation.ResponseStatus
 import org.springframework.web.bind.annotation.RestController
-import pmeet.pmeetserver.project.dto.comment.response.ProjectCommentWithChildResponseDto
+import pmeet.pmeetserver.project.dto.comment.response.GetProjectCommentWithChildResponseDto
 import pmeet.pmeetserver.project.dto.request.CreateProjectRequestDto
 import pmeet.pmeetserver.project.dto.request.SearchProjectRequestDto
 import pmeet.pmeetserver.project.dto.request.UpdateProjectRequestDto
@@ -74,7 +74,7 @@ class ProjectController(
   @ResponseStatus(HttpStatus.OK)
   suspend fun getProjectCommentList(
     @PathVariable projectId: String
-  ): List<ProjectCommentWithChildResponseDto> {
+  ): List<GetProjectCommentWithChildResponseDto> {
     return projectFacadeService.getProjectCommentList(projectId)
   }
 

--- a/src/main/kotlin/pmeet/pmeetserver/project/dto/comment/ProjectCommentWithChildDto.kt
+++ b/src/main/kotlin/pmeet/pmeetserver/project/dto/comment/ProjectCommentWithChildDto.kt
@@ -1,9 +1,10 @@
-package pmeet.pmeetserver.project.dto.comment.response
+package pmeet.pmeetserver.project.dto.comment
 
 import pmeet.pmeetserver.project.domain.ProjectComment
 import java.time.LocalDateTime
+import pmeet.pmeetserver.project.dto.comment.response.ProjectCommentResponseDto
 
-data class ProjectCommentWithChildResponseDto(
+data class ProjectCommentWithChildDto(
   val id: String,
   val parentCommentId: String?,
   val projectId: String,
@@ -15,8 +16,8 @@ data class ProjectCommentWithChildResponseDto(
   val childComments: List<ProjectCommentResponseDto>
 ) {
   companion object {
-    fun from(comment: ProjectComment, childComments: List<ProjectComment>): ProjectCommentWithChildResponseDto {
-      return ProjectCommentWithChildResponseDto(
+    fun from(comment: ProjectComment, childComments: List<ProjectComment>): ProjectCommentWithChildDto {
+      return ProjectCommentWithChildDto(
         id = comment.id!!,
         parentCommentId = comment.parentCommentId,
         projectId = comment.projectId,

--- a/src/main/kotlin/pmeet/pmeetserver/project/dto/comment/response/GetProjectCommentResponseDto.kt
+++ b/src/main/kotlin/pmeet/pmeetserver/project/dto/comment/response/GetProjectCommentResponseDto.kt
@@ -1,25 +1,29 @@
 package pmeet.pmeetserver.project.dto.comment.response
 
 import java.time.LocalDateTime
-import pmeet.pmeetserver.project.domain.ProjectComment
+import pmeet.pmeetserver.user.domain.User
 
-data class ProjectCommentResponseDto(
+data class GetProjectCommentResponseDto(
   val id: String,
   val parentCommentId: String?,
   val projectId: String,
   val userId: String,
+  val userNickname: String,
+  val userProfileImageUrl: String?,
   val content: String,
   val likerIdList: List<String>,
   val createdAt: LocalDateTime,
   val isDeleted: Boolean
 ) {
   companion object {
-    fun from(comment: ProjectComment): ProjectCommentResponseDto {
-      return ProjectCommentResponseDto(
-        id = comment.id!!,
+    fun from(comment: ProjectCommentResponseDto, user: User, url: String?): GetProjectCommentResponseDto {
+      return GetProjectCommentResponseDto(
+        id = comment.id,
         parentCommentId = comment.parentCommentId,
         projectId = comment.projectId,
         userId = comment.userId,
+        userNickname = user.nickname,
+        userProfileImageUrl = url,
         content = comment.content,
         likerIdList = comment.likerIdList,
         createdAt = comment.createdAt,

--- a/src/main/kotlin/pmeet/pmeetserver/project/dto/comment/response/GetProjectCommentWithChildResponseDto.kt
+++ b/src/main/kotlin/pmeet/pmeetserver/project/dto/comment/response/GetProjectCommentWithChildResponseDto.kt
@@ -1,0 +1,42 @@
+package pmeet.pmeetserver.project.dto.comment.response
+
+import java.time.LocalDateTime
+import pmeet.pmeetserver.project.dto.comment.ProjectCommentWithChildDto
+import pmeet.pmeetserver.user.domain.User
+
+data class GetProjectCommentWithChildResponseDto(
+  val id: String,
+  val parentCommentId: String?,
+  val projectId: String,
+  val userId: String,
+  val userNickname: String,
+  val userProfileImageUrl: String?,
+  val content: String,
+  val likerIdList: List<String>,
+  val createdAt: LocalDateTime,
+  val isDeleted: Boolean,
+  val childComments: List<GetProjectCommentResponseDto>
+) {
+  companion object {
+    fun from(
+      comment: ProjectCommentWithChildDto,
+      user: User,
+      url: String?,
+      childList: List<GetProjectCommentResponseDto>
+    ): GetProjectCommentWithChildResponseDto {
+      return GetProjectCommentWithChildResponseDto(
+        id = comment.id,
+        parentCommentId = comment.parentCommentId,
+        projectId = comment.projectId,
+        userId = comment.userId,
+        userNickname = user.nickname,
+        userProfileImageUrl = url,
+        content = comment.content,
+        likerIdList = comment.likerIdList,
+        createdAt = comment.createdAt,
+        isDeleted = comment.isDeleted,
+        childComments = childList
+      )
+    }
+  }
+}

--- a/src/main/kotlin/pmeet/pmeetserver/project/repository/ProjectCommentRepositoryCustom.kt
+++ b/src/main/kotlin/pmeet/pmeetserver/project/repository/ProjectCommentRepositoryCustom.kt
@@ -1,8 +1,8 @@
 package pmeet.pmeetserver.project.repository
 
-import pmeet.pmeetserver.project.dto.comment.response.ProjectCommentWithChildResponseDto
+import pmeet.pmeetserver.project.dto.comment.ProjectCommentWithChildDto
 import reactor.core.publisher.Flux
 
 interface ProjectCommentRepositoryCustom {
-  fun findCommentsByProjectIdWithChild(projectId: String): Flux<ProjectCommentWithChildResponseDto>
+  fun findCommentsByProjectIdWithChild(projectId: String): Flux<ProjectCommentWithChildDto>
 }

--- a/src/main/kotlin/pmeet/pmeetserver/project/repository/ProjectCommentRepositoryCustomImpl.kt
+++ b/src/main/kotlin/pmeet/pmeetserver/project/repository/ProjectCommentRepositoryCustomImpl.kt
@@ -14,13 +14,13 @@ import org.springframework.data.mongodb.core.aggregation.AggregationOperation
 import org.springframework.data.mongodb.core.aggregation.AggregationOperationContext
 import org.springframework.data.mongodb.core.query.Criteria
 import pmeet.pmeetserver.project.dto.comment.response.ProjectCommentResponseDto
-import pmeet.pmeetserver.project.dto.comment.response.ProjectCommentWithChildResponseDto
+import pmeet.pmeetserver.project.dto.comment.ProjectCommentWithChildDto
 import reactor.core.publisher.Flux
 
 class ProjectCommentRepositoryCustomImpl(
   @Autowired private val mongoTemplate: ReactiveMongoTemplate
 ) : ProjectCommentRepositoryCustom {
-  override fun findCommentsByProjectIdWithChild(projectId: String): Flux<ProjectCommentWithChildResponseDto> {
+  override fun findCommentsByProjectIdWithChild(projectId: String): Flux<ProjectCommentWithChildDto> {
 
     val matchProjectId = match(Criteria.where("projectId").`is`(projectId))
 
@@ -78,7 +78,7 @@ class ProjectCommentRepositoryCustomImpl(
 
     return mongoTemplate.aggregate(aggregation, "projectComment", Document::class.java)
       .map { doc ->
-        ProjectCommentWithChildResponseDto(
+        ProjectCommentWithChildDto(
           id = doc.getObjectId("_id")!!.toString(),
           parentCommentId = doc.getString("parentCommentId"),
           projectId = doc.getString("projectId"),

--- a/src/main/kotlin/pmeet/pmeetserver/project/service/ProjectCommentService.kt
+++ b/src/main/kotlin/pmeet/pmeetserver/project/service/ProjectCommentService.kt
@@ -7,7 +7,7 @@ import org.springframework.transaction.annotation.Transactional
 import pmeet.pmeetserver.common.ErrorCode
 import pmeet.pmeetserver.common.exception.EntityNotFoundException
 import pmeet.pmeetserver.project.domain.ProjectComment
-import pmeet.pmeetserver.project.dto.comment.response.ProjectCommentWithChildResponseDto
+import pmeet.pmeetserver.project.dto.comment.ProjectCommentWithChildDto
 import pmeet.pmeetserver.project.repository.ProjectCommentRepository
 
 @Service
@@ -32,7 +32,7 @@ class ProjectCommentService(
   }
 
   @Transactional(readOnly = true)
-  suspend fun getProjectCommentWithChildByProjectId(projectId: String): List<ProjectCommentWithChildResponseDto> {
+  suspend fun getProjectCommentWithChildByProjectId(projectId: String): List<ProjectCommentWithChildDto> {
     return projectCommentRepository.findCommentsByProjectIdWithChild(projectId).collectList().awaitSingle()
   }
 }

--- a/src/test/kotlin/pmeet/pmeetserver/project/ProjectIntegrationTest.kt
+++ b/src/test/kotlin/pmeet/pmeetserver/project/ProjectIntegrationTest.kt
@@ -28,7 +28,7 @@ import pmeet.pmeetserver.project.domain.ProjectComment
 import pmeet.pmeetserver.project.domain.ProjectTryout
 import pmeet.pmeetserver.project.domain.Recruitment
 import pmeet.pmeetserver.project.domain.enum.ProjectTryoutStatus
-import pmeet.pmeetserver.project.dto.comment.response.ProjectCommentWithChildResponseDto
+import pmeet.pmeetserver.project.dto.comment.ProjectCommentWithChildDto
 import pmeet.pmeetserver.project.dto.request.CreateProjectRequestDto
 import pmeet.pmeetserver.project.dto.request.RecruitmentRequestDto
 import pmeet.pmeetserver.project.dto.request.UpdateProjectRequestDto
@@ -364,7 +364,7 @@ internal class ProjectIntegrationTest : BaseMongoDBTestForIntegration() {
       context("Project Comment 전체 조회 요청이 들어오면") {
         val deletedProjectComment1 = ProjectComment(
           projectId = "testProjectId",
-          userId = "testUserId",
+          userId = userId,
           content = "deleted1",
           isDeleted = true
         )
@@ -372,7 +372,7 @@ internal class ProjectIntegrationTest : BaseMongoDBTestForIntegration() {
 
         val deletedProjectComment2 = ProjectComment(
           projectId = "testProjectId",
-          userId = "testUserId",
+          userId = userId,
           content = "deleted2",
           isDeleted = true
         )
@@ -381,7 +381,7 @@ internal class ProjectIntegrationTest : BaseMongoDBTestForIntegration() {
         val childProjectComment1 = ProjectComment(
           parentCommentId = deletedProjectComment1.id!!,
           projectId = "testProjectId",
-          userId = "testUserId",
+          userId = userId,
           content = "child",
           isDeleted = false
         )
@@ -390,7 +390,7 @@ internal class ProjectIntegrationTest : BaseMongoDBTestForIntegration() {
         val deletedChildProjectComment1 = ProjectComment(
           parentCommentId = deletedProjectComment1.id!!,
           projectId = "testProjectId",
-          userId = "testUserId",
+          userId = userId,
           content = "deletedChild",
           isDeleted = true
         )
@@ -410,8 +410,8 @@ internal class ProjectIntegrationTest : BaseMongoDBTestForIntegration() {
           performRequest.expectStatus().isOk
         }
 
-        it("생성된 Project 정보를 반환한다") {
-          performRequest.expectBody<List<ProjectCommentWithChildResponseDto>>().consumeWith { response ->
+        it("조회된 댓글 정보를 반환한다") {
+          performRequest.expectBody<List<ProjectCommentWithChildDto>>().consumeWith { response ->
             response.responseBody?.get(0)?.id shouldBe deletedProjectComment1.id
             response.responseBody?.get(0)?.parentCommentId shouldBe deletedProjectComment1.parentCommentId
             response.responseBody?.get(0)?.projectId shouldBe deletedProjectComment1.projectId

--- a/src/test/kotlin/pmeet/pmeetserver/project/controller/ProjectControllerUnitTest.kt
+++ b/src/test/kotlin/pmeet/pmeetserver/project/controller/ProjectControllerUnitTest.kt
@@ -16,7 +16,7 @@ import org.springframework.test.web.reactive.server.WebTestClient
 import org.springframework.test.web.reactive.server.expectBody
 import pmeet.pmeetserver.config.TestSecurityConfig
 import pmeet.pmeetserver.project.dto.comment.response.ProjectCommentResponseDto
-import pmeet.pmeetserver.project.dto.comment.response.ProjectCommentWithChildResponseDto
+import pmeet.pmeetserver.project.dto.comment.ProjectCommentWithChildDto
 import pmeet.pmeetserver.project.dto.request.CreateProjectRequestDto
 import pmeet.pmeetserver.project.dto.request.RecruitmentRequestDto
 import pmeet.pmeetserver.project.dto.request.SearchProjectRequestDto
@@ -33,6 +33,8 @@ import pmeet.pmeetserver.user.dto.response.UserResponseDtoInProject
 import pmeet.pmeetserver.util.RestSliceImpl
 import java.time.LocalDate
 import java.time.LocalDateTime
+import pmeet.pmeetserver.project.dto.comment.response.GetProjectCommentResponseDto
+import pmeet.pmeetserver.project.dto.comment.response.GetProjectCommentWithChildResponseDto
 
 @WebFluxTest(ProjectController::class)
 @Import(TestSecurityConfig::class)
@@ -369,21 +371,25 @@ internal class ProjectControllerUnitTest : DescribeSpec() {
         val userId = "userId"
         val projectId = "testProjectId"
         val responseDto = listOf(
-          ProjectCommentWithChildResponseDto(
+          GetProjectCommentWithChildResponseDto(
             id = "testCommentId",
             parentCommentId = null,
             projectId = "testProjectId",
             userId = userId,
+            userNickname = "testNickname",
+            userProfileImageUrl = null,
             content = "testContent",
             likerIdList = listOf(),
             createdAt = LocalDateTime.of(2024, 7, 16, 0, 0, 0),
             isDeleted = false,
             childComments = listOf(
-              ProjectCommentResponseDto(
+              GetProjectCommentResponseDto(
                 id = "childCommentId",
                 parentCommentId = "testCommentId",
                 projectId = "testProjectId",
                 userId = userId,
+                userNickname = "testNickname",
+                userProfileImageUrl = null,
                 content = "testContent",
                 likerIdList = listOf(),
                 createdAt = LocalDateTime.of(2024, 7, 16, 0, 0, 0),
@@ -411,7 +417,7 @@ internal class ProjectControllerUnitTest : DescribeSpec() {
         }
 
         it("조회한 댓글 정보를 반환한다") {
-          performRequest.expectBody<List<ProjectCommentWithChildResponseDto>>().consumeWith { response ->
+          performRequest.expectBody<List<ProjectCommentWithChildDto>>().consumeWith { response ->
             response.responseBody?.get(0)?.id shouldBe responseDto[0].id
             response.responseBody?.get(0)?.parentCommentId shouldBe responseDto[0].parentCommentId
             response.responseBody?.get(0)?.projectId shouldBe responseDto[0].projectId

--- a/src/test/kotlin/pmeet/pmeetserver/project/service/ProjectCommentServiceUnitTest.kt
+++ b/src/test/kotlin/pmeet/pmeetserver/project/service/ProjectCommentServiceUnitTest.kt
@@ -17,7 +17,7 @@ import pmeet.pmeetserver.common.ErrorCode
 import pmeet.pmeetserver.common.exception.EntityNotFoundException
 import pmeet.pmeetserver.project.domain.ProjectComment
 import pmeet.pmeetserver.project.dto.comment.response.ProjectCommentResponseDto
-import pmeet.pmeetserver.project.dto.comment.response.ProjectCommentWithChildResponseDto
+import pmeet.pmeetserver.project.dto.comment.ProjectCommentWithChildDto
 import pmeet.pmeetserver.project.repository.ProjectCommentRepository
 import reactor.core.publisher.Flux
 import reactor.core.publisher.Mono
@@ -119,7 +119,7 @@ internal class ProjectCommentServiceUnitTest : DescribeSpec({
   describe("getProjectCommentWithChildByProjectId") {
     val projectId = "testProjectId"
     val responseDto = listOf(
-      ProjectCommentWithChildResponseDto(
+      ProjectCommentWithChildDto(
         id = "testCommentId",
         parentCommentId = null,
         projectId = "testProjectId",

--- a/src/test/kotlin/pmeet/pmeetserver/project/service/ProjectFacadeServiceUnitTest.kt
+++ b/src/test/kotlin/pmeet/pmeetserver/project/service/ProjectFacadeServiceUnitTest.kt
@@ -24,7 +24,7 @@ import pmeet.pmeetserver.project.domain.*
 import pmeet.pmeetserver.project.domain.enum.ProjectTryoutStatus
 import pmeet.pmeetserver.project.dto.comment.request.CreateProjectCommentRequestDto
 import pmeet.pmeetserver.project.dto.comment.response.ProjectCommentResponseDto
-import pmeet.pmeetserver.project.dto.comment.response.ProjectCommentWithChildResponseDto
+import pmeet.pmeetserver.project.dto.comment.ProjectCommentWithChildDto
 import pmeet.pmeetserver.project.dto.request.CreateProjectRequestDto
 import pmeet.pmeetserver.project.dto.request.RecruitmentRequestDto
 import pmeet.pmeetserver.project.dto.request.SearchProjectRequestDto
@@ -450,7 +450,7 @@ internal class ProjectFacadeServiceUnitTest : DescribeSpec({
   describe("getProjectCommentList") {
     val projectId = project.id!!
     val responseDto = listOf(
-      ProjectCommentWithChildResponseDto(
+      ProjectCommentWithChildDto(
         id = "testCommentId",
         parentCommentId = null,
         projectId = "testProjectId",
@@ -475,6 +475,8 @@ internal class ProjectFacadeServiceUnitTest : DescribeSpec({
     )
 
     coEvery { projectCommentService.getProjectCommentWithChildByProjectId(projectId) } answers { responseDto }
+    coEvery { fileService.generatePreSignedUrlToDownload(any()) } answers { "test" }
+
     context("projectId를 입력받으면") {
       it("ProjectCommentWithChildResponseDto를 조회한다.") {
         runTest {


### PR DESCRIPTION
## Related issue
resolves #152 

## Description
댓글 조회 시 유저 닉네임, 프로필 이미지 url 추가

## Changes detail
- Repository의 Return을 ResponseDto -> Dto로 변경
- Facade Service에서 Dto를 ResponseDto로 변경 (여기서 UserService를 활용하여 objectname 추출)
- 댓글 생성 시 parentCommentId가 주어질 시 검증 로직 추가

### Checklist
- [x] Test case
- [x] End of work
