### PR TITLE
✨ feat: 이력서 조건 목록 조회 결과에 필드 및 값 수정

### DIFF
--- a/src/main/kotlin/pmeet/pmeetserver/user/controller/ResumeController.kt
+++ b/src/main/kotlin/pmeet/pmeetserver/user/controller/ResumeController.kt
@@ -6,12 +6,26 @@ import org.springframework.data.domain.PageRequest
 import org.springframework.data.domain.Slice
 import org.springframework.http.HttpStatus
 import org.springframework.security.core.annotation.AuthenticationPrincipal
-import org.springframework.web.bind.annotation.*
-import pmeet.pmeetserver.user.domain.enum.ResumeOrderType
+import org.springframework.web.bind.annotation.DeleteMapping
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PatchMapping
+import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.PutMapping
+import org.springframework.web.bind.annotation.RequestBody
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RequestParam
+import org.springframework.web.bind.annotation.ResponseStatus
+import org.springframework.web.bind.annotation.RestController
 import pmeet.pmeetserver.user.domain.enum.ResumeFilterType
-import pmeet.pmeetserver.user.dto.resume.request.*
-import pmeet.pmeetserver.user.dto.resume.response.SearchedResumeResponseDto
+import pmeet.pmeetserver.user.domain.enum.ResumeOrderType
+import pmeet.pmeetserver.user.dto.resume.request.ChangeResumeActiveRequestDto
+import pmeet.pmeetserver.user.dto.resume.request.CopyResumeRequestDto
+import pmeet.pmeetserver.user.dto.resume.request.CreateResumeRequestDto
+import pmeet.pmeetserver.user.dto.resume.request.DeleteResumeRequestDto
+import pmeet.pmeetserver.user.dto.resume.request.UpdateResumeRequestDto
 import pmeet.pmeetserver.user.dto.resume.response.ResumeResponseDto
+import pmeet.pmeetserver.user.dto.resume.response.SearchedResumeResponseDto
 import pmeet.pmeetserver.user.service.resume.ResumeFacadeService
 import reactor.core.publisher.Mono
 
@@ -112,12 +126,19 @@ class ResumeController(
   @GetMapping("/search-slice")
   @ResponseStatus(HttpStatus.OK)
   suspend fun getResumeListByCondition(
+    @AuthenticationPrincipal userId: Mono<String>,
     @RequestParam(required = true) filterType: ResumeFilterType,
     @RequestParam(required = true) filterValue: String,
     @RequestParam(required = true) orderType: ResumeOrderType,
     @RequestParam(defaultValue = "0") page: Int,
     @RequestParam(defaultValue = "8") size: Int,
   ): Slice<SearchedResumeResponseDto> {
-    return resumeFacadeService.searchResumeSlice(filterType, filterValue, orderType, PageRequest.of(page, size))
+    return resumeFacadeService.searchResumeSlice(
+      userId.awaitSingle(),
+      filterType,
+      filterValue,
+      orderType,
+      PageRequest.of(page, size)
+    )
   }
 }

--- a/src/main/kotlin/pmeet/pmeetserver/user/dto/resume/response/SearchedResumeResponseDto.kt
+++ b/src/main/kotlin/pmeet/pmeetserver/user/dto/resume/response/SearchedResumeResponseDto.kt
@@ -11,10 +11,15 @@ data class SearchedResumeResponseDto(
   val userName: String,
   val techStacks: List<TechStackResponseDto>,
   val userProfileImageUrl: String?,
+  val bookMarkerNumber: Int,
+  val isMyBookmark: Boolean,
   val updatedAt: LocalDateTime,
 ) {
   companion object {
-    fun of(resume: Resume, profileImageDownloadUrl: String?): SearchedResumeResponseDto {
+    fun of(resume: Resume, profileImageDownloadUrl: String?, userId: String? = null): SearchedResumeResponseDto {
+      val isMyBookmark = userId?.let { id ->
+        resume.bookmarkers.any { it.userId == id }
+      } ?: false
       return SearchedResumeResponseDto(
         id = resume.id!!,
         title = resume.title,
@@ -22,6 +27,8 @@ data class SearchedResumeResponseDto(
         userName = resume.userName,
         techStacks = resume.techStacks.map { TechStackResponseDto.from(it) },
         userProfileImageUrl = profileImageDownloadUrl,
+        bookMarkerNumber = resume.bookmarkers.size,
+        isMyBookmark = isMyBookmark,
         updatedAt = resume.updatedAt
       )
     }

--- a/src/main/kotlin/pmeet/pmeetserver/user/repository/resume/CustomResumeRepository.kt
+++ b/src/main/kotlin/pmeet/pmeetserver/user/repository/resume/CustomResumeRepository.kt
@@ -1,8 +1,8 @@
 package pmeet.pmeetserver.user.repository.resume
 
-import pmeet.pmeetserver.user.domain.enum.ResumeOrderType
-import pmeet.pmeetserver.user.domain.enum.ResumeFilterType
 import org.springframework.data.domain.Pageable
+import pmeet.pmeetserver.user.domain.enum.ResumeFilterType
+import pmeet.pmeetserver.user.domain.enum.ResumeOrderType
 import pmeet.pmeetserver.user.domain.resume.Resume
 import reactor.core.publisher.Flux
 
@@ -18,6 +18,7 @@ interface CustomResumeRepository {
    *
    */
   fun findAllByFilter(
+    searchedUserId: String,
     filterType: ResumeFilterType,
     filterValue: String,
     orderType: ResumeOrderType,

--- a/src/main/kotlin/pmeet/pmeetserver/user/repository/resume/CustomResumeRepositoryImpl.kt
+++ b/src/main/kotlin/pmeet/pmeetserver/user/repository/resume/CustomResumeRepositoryImpl.kt
@@ -4,16 +4,12 @@ import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.data.domain.Pageable
 import org.springframework.data.domain.Sort
 import org.springframework.data.mongodb.core.ReactiveMongoTemplate
-import org.springframework.data.mongodb.core.aggregate
 import org.springframework.data.mongodb.core.aggregation.Aggregation
-import org.springframework.data.mongodb.core.aggregation.ArithmeticOperators
 import org.springframework.data.mongodb.core.aggregation.ArrayOperators
-import org.springframework.data.mongodb.core.aggregation.ComparisonOperators
 import org.springframework.data.mongodb.core.aggregation.ConditionalOperators
-import org.springframework.data.mongodb.core.aggregation.DateOperators
 import org.springframework.data.mongodb.core.query.Criteria
-import pmeet.pmeetserver.user.domain.enum.ResumeOrderType
 import pmeet.pmeetserver.user.domain.enum.ResumeFilterType
+import pmeet.pmeetserver.user.domain.enum.ResumeOrderType
 import pmeet.pmeetserver.user.domain.resume.Resume
 import pmeet.pmeetserver.user.domain.resume.ResumeBookMarker
 import reactor.core.publisher.Flux
@@ -24,6 +20,7 @@ class CustomResumeRepositoryImpl(
 
   companion object {
     private const val DOCUMENT_NAME = "resume"
+    private const val PROPERTY_NAME_USER_ID = "userId"
     private const val PROPERTY_NAME_BOOK_MARKERS = "bookmarkers"
     private const val PROPERTY_NAME_BOOK_MARKERS_SIZE = "bookmarkersSize"
     private const val PROPERTY_NAME_UPDATEDAT = "updatedAt"
@@ -34,18 +31,20 @@ class CustomResumeRepositoryImpl(
   }
 
   override fun findAllByFilter(
+    searchedUserId: String,
     filterType: ResumeFilterType,
     filterValue: String,
     orderType: ResumeOrderType,
     pageable: Pageable
   ): Flux<Resume> {
-    val criteria = createCriteria(filterType, filterValue)
+    val criteria = createCriteria(filterType, filterValue).andOperator(
+      Criteria.where(PROPERTY_NAME_USER_ID).ne(searchedUserId)
+    )
     return aggregateResumes(orderType, criteria, pageable)
   }
 
   /**
    * 이력서 필터 조건인 Criteria 생성
-   *
    * @param filterType 필터 타입(TOTAL, TITLE, JOB, NICKNAME)
    * @param filterValue 필터 값
    */

--- a/src/main/kotlin/pmeet/pmeetserver/user/service/resume/ResumeFacadeService.kt
+++ b/src/main/kotlin/pmeet/pmeetserver/user/service/resume/ResumeFacadeService.kt
@@ -7,17 +7,16 @@ import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 import pmeet.pmeetserver.common.ErrorCode
 import pmeet.pmeetserver.common.exception.ForbiddenRequestException
-import pmeet.pmeetserver.common.utils.page.SliceResponse
 import pmeet.pmeetserver.file.service.FileService
-import pmeet.pmeetserver.user.domain.enum.ResumeOrderType
 import pmeet.pmeetserver.user.domain.enum.ResumeFilterType
+import pmeet.pmeetserver.user.domain.enum.ResumeOrderType
 import pmeet.pmeetserver.user.dto.resume.request.ChangeResumeActiveRequestDto
 import pmeet.pmeetserver.user.dto.resume.request.CopyResumeRequestDto
 import pmeet.pmeetserver.user.dto.resume.request.CreateResumeRequestDto
 import pmeet.pmeetserver.user.dto.resume.request.DeleteResumeRequestDto
 import pmeet.pmeetserver.user.dto.resume.request.UpdateResumeRequestDto
-import pmeet.pmeetserver.user.dto.resume.response.SearchedResumeResponseDto
 import pmeet.pmeetserver.user.dto.resume.response.ResumeResponseDto
+import pmeet.pmeetserver.user.dto.resume.response.SearchedResumeResponseDto
 import pmeet.pmeetserver.user.service.UserService
 
 @Service
@@ -143,13 +142,15 @@ class ResumeFacadeService(
     return resumeList.filter { it.isActive }.map {
       SearchedResumeResponseDto.of(
         it,
-        it.userProfileImageUrl?.let { it1 -> fileService.generatePreSignedUrlToDownload(it1) }
+        it.userProfileImageUrl?.let { it1 -> fileService.generatePreSignedUrlToDownload(it1) },
+        userId
       )
     }.toList()
   }
 
   @Transactional
   suspend fun searchResumeSlice(
+    userId: String,
     filterType: ResumeFilterType,
     filterValue: String,
     orderType: ResumeOrderType,
@@ -160,7 +161,9 @@ class ResumeFacadeService(
       resumes.content.map {
         SearchedResumeResponseDto.of(
           it,
-          it.userProfileImageUrl?.let { it1 -> fileService.generatePreSignedUrlToDownload(it1) })
+          it.userProfileImageUrl?.let { it1 -> fileService.generatePreSignedUrlToDownload(it1) },
+          userId
+        )
       },
       resumes.pageable,
       resumes.hasNext()

--- a/src/main/kotlin/pmeet/pmeetserver/user/service/resume/ResumeFacadeService.kt
+++ b/src/main/kotlin/pmeet/pmeetserver/user/service/resume/ResumeFacadeService.kt
@@ -156,7 +156,7 @@ class ResumeFacadeService(
     orderType: ResumeOrderType,
     pageable: PageRequest
   ): Slice<SearchedResumeResponseDto> {
-    val resumes = resumeService.searchSliceByFilter(filterType, filterValue, orderType, pageable)
+    val resumes = resumeService.searchSliceByFilter(userId, filterType, filterValue, orderType, pageable)
     return SliceImpl(
       resumes.content.map {
         SearchedResumeResponseDto.of(

--- a/src/main/kotlin/pmeet/pmeetserver/user/service/resume/ResumeService.kt
+++ b/src/main/kotlin/pmeet/pmeetserver/user/service/resume/ResumeService.kt
@@ -10,8 +10,8 @@ import pmeet.pmeetserver.common.ErrorCode
 import pmeet.pmeetserver.common.exception.BadRequestException
 import pmeet.pmeetserver.common.exception.EntityNotFoundException
 import pmeet.pmeetserver.common.utils.page.SliceResponse
-import pmeet.pmeetserver.user.domain.enum.ResumeOrderType
 import pmeet.pmeetserver.user.domain.enum.ResumeFilterType
+import pmeet.pmeetserver.user.domain.enum.ResumeOrderType
 import pmeet.pmeetserver.user.domain.resume.Resume
 import pmeet.pmeetserver.user.repository.resume.ResumeRepository
 
@@ -61,13 +61,15 @@ class ResumeService(private val resumeRepository: ResumeRepository) {
 
   @Transactional(readOnly = true)
   suspend fun searchSliceByFilter(
+    searchedUserId: String,
     filterType: ResumeFilterType,
     filterValue: String,
     orderType: ResumeOrderType,
     pageable: PageRequest
   ): Slice<Resume> {
     return SliceResponse.of(
-      resumeRepository.findAllByFilter(filterType, filterValue, orderType, pageable).collectList().awaitSingle(),
+      resumeRepository.findAllByFilter(searchedUserId, filterType, filterValue, orderType, pageable).collectList()
+        .awaitSingle(),
       pageable
     )
   }

--- a/src/test/kotlin/pmeet/pmeetserver/user/resume/controller/ResumeControllerUnitTest.kt
+++ b/src/test/kotlin/pmeet/pmeetserver/user/resume/controller/ResumeControllerUnitTest.kt
@@ -381,7 +381,7 @@ internal class ResumeControllerUnitTest : DescribeSpec() {
 
         coEvery {
           resumeFacadeService.searchResumeSlice(
-            ResumeFilterType.ALL, "", ResumeOrderType.POPULAR, PageRequest.of(pageNumber, pageSize)
+            userId, ResumeFilterType.ALL, "", ResumeOrderType.POPULAR, PageRequest.of(pageNumber, pageSize)
           )
         } answers {
           SliceImpl(
@@ -399,7 +399,7 @@ internal class ResumeControllerUnitTest : DescribeSpec() {
 
         coVerify(exactly = 1) {
           resumeFacadeService.searchResumeSlice(
-            ResumeFilterType.ALL, "", ResumeOrderType.POPULAR, PageRequest.of(pageNumber, pageSize)
+            userId, ResumeFilterType.ALL, "", ResumeOrderType.POPULAR, PageRequest.of(pageNumber, pageSize)
           )
         }
 

--- a/src/test/kotlin/pmeet/pmeetserver/user/resume/repository/ResumeRepositoryUnitTest.kt
+++ b/src/test/kotlin/pmeet/pmeetserver/user/resume/repository/ResumeRepositoryUnitTest.kt
@@ -175,10 +175,12 @@ internal class ResumeRepositoryUnitTest(
   }
 
   describe("findAllByFilter") {
+    val userId = "testUserId"
     context("전체 검색이고, 검색어가 있으며 인기순 조회인 경우") {
       it("조건에 맞는 Resume 를 반환한다.") {
         runTest {
           val result = resumeRepository.findAllByFilter(
+            userId,
             ResumeFilterType.ALL,
             "1",
             ResumeOrderType.POPULAR,
@@ -188,6 +190,7 @@ internal class ResumeRepositoryUnitTest(
           result?.get(0)?.title shouldBe resumeListForSlice.get(12).title
 
           val resultWithTitle = resumeRepository.findAllByFilter(
+            userId,
             ResumeFilterType.ALL,
             "5",
             ResumeOrderType.POPULAR,
@@ -203,6 +206,7 @@ internal class ResumeRepositoryUnitTest(
       it("조건에 맞는 Resume 를 반환한다.") {
         runTest {
           val result = resumeRepository.findAllByFilter(
+            userId,
             ResumeFilterType.ALL,
             "",
             ResumeOrderType.POPULAR,
@@ -218,6 +222,7 @@ internal class ResumeRepositoryUnitTest(
       it("조건에 맞는 Resume 를 반환한다.") {
         runTest {
           val result = resumeRepository.findAllByFilter(
+            userId,
             ResumeFilterType.ALL,
             "title",
             ResumeOrderType.RECENT,
@@ -227,6 +232,7 @@ internal class ResumeRepositoryUnitTest(
           result?.get(0)?.title shouldBe resumeListForSlice.get(0).title
 
           val resultWithTitle = resumeRepository.findAllByFilter(
+            userId,
             ResumeFilterType.ALL,
             "nickname1",
             ResumeOrderType.RECENT,
@@ -242,6 +248,7 @@ internal class ResumeRepositoryUnitTest(
       it("조건에 맞는 Resume 를 반환한다.") {
         runTest {
           val result = resumeRepository.findAllByFilter(
+            userId,
             ResumeFilterType.TITLE,
             "title",
             ResumeOrderType.POPULAR,
@@ -251,6 +258,7 @@ internal class ResumeRepositoryUnitTest(
           result?.get(0)?.title shouldBe resumeListForSlice.get(12).title
 
           val resultWithTitle = resumeRepository.findAllByFilter(
+            userId,
             ResumeFilterType.TITLE,
             "no_title",
             ResumeOrderType.POPULAR,
@@ -265,6 +273,7 @@ internal class ResumeRepositoryUnitTest(
       it("조건에 맞는 Resume 를 반환한다.") {
         runTest {
           val result = resumeRepository.findAllByFilter(
+            userId,
             ResumeFilterType.TITLE,
             "title",
             ResumeOrderType.RECENT,
@@ -274,6 +283,7 @@ internal class ResumeRepositoryUnitTest(
           result?.get(0)?.title shouldBe resumeListForSlice.get(0).title
 
           val resultWithTitle = resumeRepository.findAllByFilter(
+            userId,
             ResumeFilterType.TITLE,
             "no_title",
             ResumeOrderType.RECENT,
@@ -288,6 +298,7 @@ internal class ResumeRepositoryUnitTest(
       it("조건에 맞는 Resume 를 반환한다.") {
         runTest {
           val result = resumeRepository.findAllByFilter(
+            userId,
             ResumeFilterType.JOB,
             "job",
             ResumeOrderType.POPULAR,
@@ -297,6 +308,7 @@ internal class ResumeRepositoryUnitTest(
           result?.get(0)?.title shouldBe resumeListForSlice.get(12).title
 
           val resultWithTitle = resumeRepository.findAllByFilter(
+            userId,
             ResumeFilterType.JOB,
             "no_job",
             ResumeOrderType.POPULAR,
@@ -311,6 +323,7 @@ internal class ResumeRepositoryUnitTest(
       it("조건에 맞는 Resume 를 반환한다.") {
         runTest {
           val result = resumeRepository.findAllByFilter(
+            userId,
             ResumeFilterType.JOB,
             "job",
             ResumeOrderType.RECENT,
@@ -320,12 +333,28 @@ internal class ResumeRepositoryUnitTest(
           result?.get(0)?.title shouldBe resumeListForSlice.get(0).title
 
           val resultWithTitle = resumeRepository.findAllByFilter(
+            userId,
             ResumeFilterType.JOB,
             "no_job",
             ResumeOrderType.RECENT,
             PageRequest.of(0, 8)
           ).collectList().block()
           resultWithTitle?.size shouldBe 0
+        }
+      }
+    }
+
+    context("조회를 하는 경우에 ") {
+      it("조회 요청자의 이력서는 제외하고 조건에 맞는 Resume 를 반환한다.") {
+        runTest {
+          val result = resumeRepository.findAllByFilter(
+            "John-id",
+            ResumeFilterType.TITLE,
+            "title",
+            ResumeOrderType.RECENT,
+            PageRequest.of(0, 8)
+          ).collectList().block()
+          result?.size shouldBe 0
         }
       }
     }

--- a/src/test/kotlin/pmeet/pmeetserver/user/resume/service/ResumeFacadeServiceUnitTest.kt
+++ b/src/test/kotlin/pmeet/pmeetserver/user/resume/service/ResumeFacadeServiceUnitTest.kt
@@ -377,6 +377,7 @@ class ResumeFacadeServiceUnitTest : DescribeSpec({
     context("사용자가 조건에 따른 이력서 목록을 조회하는 경우") {
       val pageNumber = 0
       val pageSize = 10
+      val userId = "1"
       val resumeListForSlice = generateMockResumeListForSlice().subList(0, pageSize + 1)
 
       it("조건에 따라서 Slice<Resume> 가 조회된다.") {
@@ -390,6 +391,7 @@ class ResumeFacadeServiceUnitTest : DescribeSpec({
           coEvery { fileService.generatePreSignedUrlToDownload(any()) } answers { "profile-url" }
 
           val result = resumeFacadeService.searchResumeSlice(
+            userId,
             ResumeFilterType.ALL,
             "",
             ResumeOrderType.RECENT,
@@ -399,9 +401,11 @@ class ResumeFacadeServiceUnitTest : DescribeSpec({
           result.size shouldBe pageSize
           result.isFirst shouldBe true
           result.isLast shouldBe false
+          for (i in 1..<pageSize) {
+            result.content.get(i).isMyBookmark shouldBe true
+          }
         }
       }
-
     }
   }
 })

--- a/src/test/kotlin/pmeet/pmeetserver/user/resume/service/ResumeFacadeServiceUnitTest.kt
+++ b/src/test/kotlin/pmeet/pmeetserver/user/resume/service/ResumeFacadeServiceUnitTest.kt
@@ -382,7 +382,7 @@ class ResumeFacadeServiceUnitTest : DescribeSpec({
 
       it("조건에 따라서 Slice<Resume> 가 조회된다.") {
         runTest {
-          coEvery { resumeService.searchSliceByFilter(any(), any(), any(), any()) } answers {
+          coEvery { resumeService.searchSliceByFilter(any(), any(), any(), any(), any()) } answers {
             SliceResponse.of(
               resumeListForSlice.toMutableList(),
               PageRequest.of(pageNumber, pageSize)

--- a/src/test/kotlin/pmeet/pmeetserver/user/resume/service/ResumeServiceUnitTest.kt
+++ b/src/test/kotlin/pmeet/pmeetserver/user/resume/service/ResumeServiceUnitTest.kt
@@ -232,11 +232,13 @@ internal class ResumeServiceUnitTest : DescribeSpec({
               any(),
               any(),
               any(),
+              any(),
               any()
             )
           } answers { Flux.fromIterable(resumeListForSlice) }
 
           val result = resumeService.searchSliceByFilter(
+            "testUserId",
             ResumeFilterType.ALL,
             "",
             ResumeOrderType.RECENT,


### PR DESCRIPTION
## Related issue
resolves #168 

## Description
- 이력서 목록 조회 시, 본인의 이력서를 제외하는 조건을 추가
- book 수와 bookmark 여부 필드 추가

## Changes detail
- ✨ feat: 이력서 조건 목록 조회 결과에 나의 이력서는 제외된다.
- ✨ feat: 이력서 조건 목록 조회 결과에, 총 bookmark 수와 검색자 bookmark 여부 필드 추가
- [x] Test case
- [x] End of work
