### PR TITLE
✨ feat: 직무 및 기술 스택 검색 시, 대소문자 구분 조건 제거

### DIFF
--- a/src/main/kotlin/pmeet/pmeetserver/common/generator/AggregationGenerator.kt
+++ b/src/main/kotlin/pmeet/pmeetserver/common/generator/AggregationGenerator.kt
@@ -9,7 +9,7 @@ object AggregationGenerator {
 
   fun generateAggregationFindByNameSearchSlice(name: String?, pageable: Pageable): Aggregation {
     val criteria = if (name != null) {
-      Criteria.where("name").regex(".*${name}.*")
+      Criteria.where("name").regex(".*${name}.*", "i")
     } else {
       Criteria()
     }

--- a/src/test/kotlin/pmeet/pmeetserver/user/job/repository/JobRepositoryUnitTest.kt
+++ b/src/test/kotlin/pmeet/pmeetserver/user/job/repository/JobRepositoryUnitTest.kt
@@ -67,6 +67,9 @@ internal class JobRepositoryUnitTest(
       for (i in 1..pageSize) {
         jobRepository.save(Job(name = name + i)).block()
       }
+      val capitalName = "ABCDEFGH"
+      jobRepository.save(Job(name = capitalName)).block()
+
       it("이름을 포함하는 직무들을 이름 오름차순, 이름 길이 오름차순으로 반환한다") {
         runTest {
           val result =
@@ -75,6 +78,15 @@ internal class JobRepositoryUnitTest(
           result?.size shouldBe pageSize + 1
           result?.first()?.name shouldBe name
           result?.last()?.name shouldBe name + pageSize
+        }
+      }
+      it("직무 이름 검색에는 대소문자 구분 없이 검색된 결과를 반환한다") {
+        runTest {
+          val result =
+            jobRepository.findByNameSearchSlice("abc", PageRequest.of(pageNumber, pageSize)).collectList().block()
+
+          result?.size shouldBe 1
+          result?.first()?.name shouldBe capitalName
         }
       }
     }

--- a/src/test/kotlin/pmeet/pmeetserver/user/techStack/repository/TechStackRepositoryUnitTest.kt
+++ b/src/test/kotlin/pmeet/pmeetserver/user/techStack/repository/TechStackRepositoryUnitTest.kt
@@ -67,6 +67,9 @@ internal class TechStackRepositoryUnitTest(
       for (i in 1..pageSize) {
         techStackRepository.save(TechStack(name = name + i)).block()
       }
+      val capitalName = "ABCDEFGH"
+      techStackRepository.save(TechStack(name = capitalName)).block()
+
       it("이름을 포함하는 기술 스택들은 이름 오름차순, 이름 길이 오름차순으로 반환한다") {
         runTest {
           val result =
@@ -75,6 +78,16 @@ internal class TechStackRepositoryUnitTest(
           result?.size shouldBe pageSize + 1
           result?.first()?.name shouldBe name
           result?.last()?.name shouldBe name + pageSize
+        }
+      }
+
+      it("대소문자 구분 없이 기술 스택을 검색해서 반환한다") {
+        runTest {
+          val result =
+            techStackRepository.findByNameSearchSlice("abc", PageRequest.of(pageNumber, pageSize)).collectList().block()
+
+          result?.size shouldBe 1
+          result?.first()?.name shouldBe capitalName
         }
       }
     }


### PR DESCRIPTION
## Related issue
- UX 향상을 위해 대문자 조건 제거
![image](https://github.com/user-attachments/assets/1ea06aa1-d5b4-480d-b637-327570e3fab4)


## Description
✨ feat: 직무 및 기술 스택 검색 시, 대소문자 구분 조건 제거

### Checklist
- [x] Test case
- [x] End of work
