### PR TITLE
✨ feat: SSE 를 이용한 알림 수신 기능 구현

### DIFF
--- a/src/main/kotlin/pmeet/pmeetserver/user/controller/NotificationController.kt
+++ b/src/main/kotlin/pmeet/pmeetserver/user/controller/NotificationController.kt
@@ -3,6 +3,7 @@ package pmeet.pmeetserver.user.controller
 import kotlinx.coroutines.flow.Flow
 import org.springframework.http.MediaType
 import org.springframework.http.codec.ServerSentEvent
+import org.springframework.web.bind.annotation.DeleteMapping
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.PutMapping
@@ -25,6 +26,21 @@ class NotificationController(
   @PutMapping("/{id}/read")
   suspend fun markNotificationAsRead(@PathVariable id: String): Notification {
     return notificationService.markNotificationAsRead(id)
+  }
+
+  @PutMapping("/read/all/{userId}")
+  suspend fun markAllNotificationsAsRead(@PathVariable userId: String): List<Notification> {
+    return notificationService.markAllNotificationAsRead(userId)
+  }
+
+  @DeleteMapping("/{id}/delete")
+  suspend fun deleteNotification(@PathVariable id: String): Unit {
+    notificationService.deleteNotification(id)
+  }
+
+  @DeleteMapping("/delete/all/{userId}")
+  suspend fun deleteAllNotifications(@PathVariable userId: String): Unit {
+    notificationService.deleteAllNotification(userId)
   }
 
   @GetMapping("/unread-count/{userId}")

--- a/src/main/kotlin/pmeet/pmeetserver/user/controller/NotificationController.kt
+++ b/src/main/kotlin/pmeet/pmeetserver/user/controller/NotificationController.kt
@@ -1,0 +1,34 @@
+package pmeet.pmeetserver.user.controller
+
+import kotlinx.coroutines.flow.Flow
+import org.springframework.http.MediaType
+import org.springframework.http.codec.ServerSentEvent
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.PutMapping
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RestController
+import pmeet.pmeetserver.user.domain.notification.Notification
+import pmeet.pmeetserver.user.service.notification.NotificationService
+
+@RestController
+@RequestMapping("/api/v1/notifications")
+class NotificationController(
+  private val notificationService: NotificationService
+) {
+
+  @GetMapping("/subscribe/{userId}", produces = [MediaType.TEXT_EVENT_STREAM_VALUE])
+  fun subscribeToNotifications(@PathVariable userId: String): Flow<ServerSentEvent<Notification>> {
+    return notificationService.subscribeToUserNotifications(userId)
+  }
+
+  @PutMapping("/{id}/read")
+  suspend fun markNotificationAsRead(@PathVariable id: String): Notification {
+    return notificationService.markNotificationAsRead(id)
+  }
+
+  @GetMapping("/unread-count/{userId}")
+  suspend fun getUnreadNotificationsCount(@PathVariable userId: String): Int {
+    return notificationService.getUnreadNotificationsCount(userId)
+  }
+}

--- a/src/main/kotlin/pmeet/pmeetserver/user/domain/notification/Notification.kt
+++ b/src/main/kotlin/pmeet/pmeetserver/user/domain/notification/Notification.kt
@@ -11,7 +11,7 @@ class Notification(
   var id: String? = null,
   val notificationType: NotificationType,
   val targetUserId: String,
-  val isRead: Boolean = false,
+  var isRead: Boolean = false,
   val createdAt: LocalDateTime = LocalDateTime.now(),
 ) {
 

--- a/src/main/kotlin/pmeet/pmeetserver/user/repository/notification/CustomNotificationRepository.kt
+++ b/src/main/kotlin/pmeet/pmeetserver/user/repository/notification/CustomNotificationRepository.kt
@@ -1,0 +1,10 @@
+package pmeet.pmeetserver.user.repository.notification
+
+import org.springframework.http.codec.ServerSentEvent
+import pmeet.pmeetserver.user.domain.notification.Notification
+import reactor.core.publisher.Flux
+
+interface CustomNotificationRepository {
+  fun subscribeToUserNotifications(userId: String): Flux<ServerSentEvent<Notification>>
+  fun emitNotification(notification: Notification)
+}

--- a/src/main/kotlin/pmeet/pmeetserver/user/repository/notification/CustomNotificationRepositoryImpl.kt
+++ b/src/main/kotlin/pmeet/pmeetserver/user/repository/notification/CustomNotificationRepositoryImpl.kt
@@ -1,0 +1,24 @@
+package pmeet.pmeetserver.user.repository.notification
+
+import org.springframework.http.codec.ServerSentEvent
+import pmeet.pmeetserver.user.domain.notification.Notification
+import reactor.core.publisher.Flux
+import reactor.core.publisher.Sinks
+
+
+class CustomNotificationRepositoryImpl : CustomNotificationRepository {
+  private val sinks = mutableMapOf<String, Sinks.Many<ServerSentEvent<Notification>>>()
+
+  override fun subscribeToUserNotifications(userId: String): Flux<ServerSentEvent<Notification>> {
+    val sink = sinks.getOrPut(userId) { Sinks.many().multicast().onBackpressureBuffer() }
+    return sink.asFlux().doOnCancel {
+      sinks.remove(userId)
+    }
+  }
+
+  override fun emitNotification(notification: Notification) {
+    sinks[notification.targetUserId]?.tryEmitNext(
+      ServerSentEvent.builder(notification).build()
+    )
+  }
+}

--- a/src/main/kotlin/pmeet/pmeetserver/user/repository/notification/NotificationRepository.kt
+++ b/src/main/kotlin/pmeet/pmeetserver/user/repository/notification/NotificationRepository.kt
@@ -4,7 +4,7 @@ import org.springframework.data.mongodb.repository.ReactiveMongoRepository
 import pmeet.pmeetserver.user.domain.notification.Notification
 import reactor.core.publisher.Flux
 
-interface NotificationRepository : ReactiveMongoRepository<Notification, String> {
+interface NotificationRepository : ReactiveMongoRepository<Notification, String>, CustomNotificationRepository {
 
   fun findAllByTargetUserIdAndIsReadFalse(userId: String): Flux<Notification>
 

--- a/src/main/kotlin/pmeet/pmeetserver/user/repository/notification/NotificationRepository.kt
+++ b/src/main/kotlin/pmeet/pmeetserver/user/repository/notification/NotificationRepository.kt
@@ -3,9 +3,13 @@ package pmeet.pmeetserver.user.repository.notification
 import org.springframework.data.mongodb.repository.ReactiveMongoRepository
 import pmeet.pmeetserver.user.domain.notification.Notification
 import reactor.core.publisher.Flux
+import reactor.core.publisher.Mono
 
 interface NotificationRepository : ReactiveMongoRepository<Notification, String>, CustomNotificationRepository {
 
   fun findAllByTargetUserIdAndIsReadFalse(userId: String): Flux<Notification>
 
+  fun findAllByTargetUserId(userId: String): Flux<Notification>
+
+  fun deleteAllByTargetUserId(userId: String): Mono<Boolean>
 }

--- a/src/main/kotlin/pmeet/pmeetserver/user/service/notification/NotificationService.kt
+++ b/src/main/kotlin/pmeet/pmeetserver/user/service/notification/NotificationService.kt
@@ -1,6 +1,11 @@
 package pmeet.pmeetserver.user.service.notification
 
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.merge
+import kotlinx.coroutines.reactive.asFlow
 import kotlinx.coroutines.reactor.awaitSingle
+import org.springframework.http.codec.ServerSentEvent
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 import pmeet.pmeetserver.user.domain.enum.NotificationType
@@ -15,12 +20,30 @@ class NotificationService(
   @Transactional
   suspend fun createNotification(notificationType: NotificationType, userId: String): Notification {
     val notification = Notification(notificationType = notificationType, targetUserId = userId)
+    val savedNotification = notificationRepository.save(notification).awaitSingle()
+    notificationRepository.emitNotification(savedNotification)
+    return savedNotification
+  }
+
+  fun subscribeToUserNotifications(userId: String): Flow<ServerSentEvent<Notification>> {
+    val existingNotifications = notificationRepository.findAllByTargetUserIdAndIsReadFalse(userId)
+      .asFlow()
+      .map { notification -> ServerSentEvent.builder(notification).build() }
+
+    val newNotifications = notificationRepository.subscribeToUserNotifications(userId)
+      .asFlow()
+
+    return merge(existingNotifications, newNotifications)
+  }
+
+  suspend fun markNotificationAsRead(id: String): Notification {
+    val notification = notificationRepository.findById(id).awaitSingle()
+    notification.isRead = true
     return notificationRepository.save(notification).awaitSingle()
   }
 
-  @Transactional(readOnly = true)
-  suspend fun findUnreadNotificationByUserId(userId: String): List<Notification> {
-    return notificationRepository.findAllByTargetUserIdAndIsReadFalse(userId).collectList().awaitSingle()
+  suspend fun getUnreadNotificationsCount(userId: String): Int {
+    return notificationRepository.findAllByTargetUserIdAndIsReadFalse(userId).collectList().awaitSingle().size
   }
-
 }
+

--- a/src/test/kotlin/pmeet/pmeetserver/user/notification/NotificationIntegrationTest.kt
+++ b/src/test/kotlin/pmeet/pmeetserver/user/notification/NotificationIntegrationTest.kt
@@ -1,0 +1,228 @@
+package pmeet.pmeetserver.user.notification
+
+import io.kotest.core.spec.IsolationMode
+import io.kotest.core.spec.Spec
+import io.kotest.matchers.shouldBe
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.withContext
+import org.junit.jupiter.api.extension.ExtendWith
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.autoconfigure.web.reactive.AutoConfigureWebTestClient
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.http.MediaType
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken
+import org.springframework.security.test.web.reactive.server.SecurityMockServerConfigurers
+import org.springframework.test.context.ActiveProfiles
+import org.springframework.test.context.junit.jupiter.SpringExtension
+import org.springframework.test.web.reactive.server.WebTestClient
+import org.springframework.test.web.reactive.server.expectBody
+import pmeet.pmeetserver.config.BaseMongoDBTestForIntegration
+import pmeet.pmeetserver.user.domain.User
+import pmeet.pmeetserver.user.domain.enum.Gender
+import pmeet.pmeetserver.user.domain.enum.NotificationType
+import pmeet.pmeetserver.user.domain.notification.Notification
+import pmeet.pmeetserver.user.repository.UserRepository
+import pmeet.pmeetserver.user.repository.notification.NotificationRepository
+import pmeet.pmeetserver.user.service.notification.NotificationService
+
+@ExtendWith(SpringExtension::class)
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+@AutoConfigureWebTestClient
+@ExperimentalCoroutinesApi
+@ActiveProfiles("test")
+class NotificationIntegrationTest : BaseMongoDBTestForIntegration() {
+
+  override fun isolationMode(): IsolationMode? {
+    return IsolationMode.InstancePerLeaf
+  }
+
+  @Autowired
+  private lateinit var notificationService: NotificationService
+
+  @Autowired
+  lateinit var webTestClient: WebTestClient
+
+  @Autowired
+  lateinit var userRepository: UserRepository
+
+  @Autowired
+  lateinit var notificationRepository: NotificationRepository
+
+  lateinit var user: User
+  var userId: String = "test-user-id"
+
+  override suspend fun beforeSpec(spec: Spec) {
+    user = User(
+      id = userId,
+      email = "testEmail@test.com",
+      name = "testName",
+      nickname = "nickname",
+      phoneNumber = "phone",
+      gender = Gender.MALE,
+      profileImageUrl = "image-url"
+    )
+
+    withContext(Dispatchers.IO) {
+      userRepository.save(user).block()
+    }
+  }
+
+  override suspend fun afterSpec(spec: Spec) {
+    withContext(Dispatchers.IO) {
+      userRepository.deleteAll().block()
+      notificationRepository.deleteAll().block()
+    }
+  }
+
+  init {
+    val mockAuthentication = UsernamePasswordAuthenticationToken(userId, null, null)
+    describe("GET api/v1/notifications/subscribe/{userId}") {
+
+      notificationRepository.save(
+        Notification(
+          notificationType = NotificationType.APPLY,
+          targetUserId = userId,
+        )
+      ).block()
+
+      notificationRepository.save(
+        Notification(
+          notificationType = NotificationType.ACCEPTED,
+          targetUserId = userId,
+        )
+      ).block()
+
+      notificationRepository.save(
+        Notification(
+          notificationType = NotificationType.REJECTED,
+          targetUserId = userId,
+        )
+      ).block()
+
+      notificationRepository.save(
+        Notification(
+          notificationType = NotificationType.COMMENT,
+          targetUserId = userId,
+        )
+      ).block()
+
+      notificationRepository.save(
+        Notification(
+          notificationType = NotificationType.REPLY,
+          targetUserId = userId,
+        )
+      ).block()
+
+      context("유저의 알림 구독 요청이 들어오면") {
+        it("알림을 전송한다") {
+
+          webTestClient
+            .mutateWith(SecurityMockServerConfigurers.mockAuthentication(mockAuthentication))
+            .get()
+            .uri("/api/v1/notifications/subscribe/$userId")
+            .accept(MediaType.TEXT_EVENT_STREAM)
+            .exchange()
+            .expectStatus().isOk
+            .expectHeader().valueMatches("Content-Type", "text/event-stream(;charset=UTF-8)?")
+            .returnResult(String::class.java)
+            .responseBody
+            .take(5)
+            .collectList()
+            .block()
+        }
+      }
+    }
+
+    describe("PUT api/v1/notifications/{id}/read") {
+      context("유저의 알림 읽음 처리 요청이 들어오면") {
+        val notification = notificationRepository.save(
+          Notification(
+            notificationType = NotificationType.APPLY,
+            targetUserId = userId,
+          )
+        ).block()
+
+        val notificationId = notification?.id
+
+        val performedRequest = webTestClient
+          .mutateWith(SecurityMockServerConfigurers.mockAuthentication(mockAuthentication))
+          .put()
+          .uri("/api/v1/notifications/$notificationId/read")
+          .exchange()
+
+        it("요청은 성공한다") {
+          performedRequest.expectStatus().isOk
+        }
+
+        it("응답으로 오는 알림은 읽음으로 반환된다") {
+          performedRequest.expectBody<Notification>().consumeWith { result ->
+            val returnedNotification = result.responseBody!!
+
+            returnedNotification.id shouldBe notificationId
+            returnedNotification.isRead shouldBe true
+          }
+        }
+      }
+    }
+
+    describe("GET /api/v1/notifications/unread-count/{userId}") {
+      context("유저의 읽지 않은 알림 개수 조회 요청이 들어오면") {
+
+        notificationRepository.save(
+          Notification(
+            notificationType = NotificationType.APPLY,
+            targetUserId = userId,
+          )
+        ).block()
+
+        notificationRepository.save(
+          Notification(
+            notificationType = NotificationType.ACCEPTED,
+            targetUserId = userId,
+          )
+        ).block()
+
+        notificationRepository.save(
+          Notification(
+            notificationType = NotificationType.REJECTED,
+            targetUserId = userId,
+          )
+        ).block()
+
+        notificationRepository.save(
+          Notification(
+            notificationType = NotificationType.COMMENT,
+            targetUserId = userId,
+          )
+        ).block()
+
+        notificationRepository.save(
+          Notification(
+            notificationType = NotificationType.REPLY,
+            targetUserId = userId,
+          )
+        ).block()
+
+        val performRequest = webTestClient
+          .mutateWith(SecurityMockServerConfigurers.mockAuthentication(mockAuthentication))
+          .get()
+          .uri("/api/v1/notifications/unread-count/$userId")
+          .exchange()
+
+
+        it("요청은 성공한다") {
+          performRequest.expectStatus().isOk
+        }
+
+        it("알림 개수는 읽지 않은 개수와 동일한다.") {
+          performRequest.expectBody<Int>().consumeWith { result ->
+            val returnedNotification = result.responseBody!!
+
+            returnedNotification shouldBe 5
+          }
+        }
+      }
+    }
+  }
+}

--- a/src/test/kotlin/pmeet/pmeetserver/user/notification/controller/NotificationControllerUnitTest.kt
+++ b/src/test/kotlin/pmeet/pmeetserver/user/notification/controller/NotificationControllerUnitTest.kt
@@ -1,0 +1,137 @@
+package pmeet.pmeetserver.user.notification.controller
+
+import com.ninjasquad.springmockk.MockkBean
+import io.kotest.core.spec.style.DescribeSpec
+import io.kotest.matchers.shouldBe
+import io.mockk.coEvery
+import io.mockk.coVerify
+import kotlinx.coroutines.flow.flowOf
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.autoconfigure.web.reactive.WebFluxTest
+import org.springframework.context.annotation.Import
+import org.springframework.http.MediaType
+import org.springframework.http.codec.ServerSentEvent
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken
+import org.springframework.security.test.web.reactive.server.SecurityMockServerConfigurers
+import org.springframework.test.web.reactive.server.WebTestClient
+import org.springframework.test.web.reactive.server.expectBody
+import pmeet.pmeetserver.config.TestSecurityConfig
+import pmeet.pmeetserver.user.controller.NotificationController
+import pmeet.pmeetserver.user.domain.enum.NotificationType
+import pmeet.pmeetserver.user.domain.notification.Notification
+import pmeet.pmeetserver.user.service.notification.NotificationService
+
+@WebFluxTest(NotificationController::class)
+@Import(TestSecurityConfig::class)
+internal class NotificationControllerUnitTest : DescribeSpec() {
+
+  @Autowired
+  private lateinit var webTestClient: WebTestClient
+
+  @MockkBean
+  lateinit var notificationService: NotificationService
+
+  init {
+    val userId = "test-user-id"
+    val mockAuthentication = UsernamePasswordAuthenticationToken(userId, null, null)
+    describe("GET api/v1/notifications/subscribe/{userId}") {
+      context("유저의 알림 구독 요청이 들어오면") {
+        it("알림을 전송한다") {
+          val notification1 = Notification(id = "1", notificationType = NotificationType.COMMENT, targetUserId = userId)
+          val notification2 = Notification(id = "2", notificationType = NotificationType.REPLY, targetUserId = userId)
+
+          coEvery { notificationService.subscribeToUserNotifications(userId) } returns flowOf(
+            ServerSentEvent.builder(notification1).build(),
+            ServerSentEvent.builder(notification2).build()
+          )
+
+          webTestClient
+            .mutateWith(SecurityMockServerConfigurers.mockAuthentication(mockAuthentication))
+            .get()
+            .uri("/api/v1/notifications/subscribe/$userId")
+            .accept(MediaType.TEXT_EVENT_STREAM)
+            .exchange()
+            .expectStatus().isOk
+            .expectHeader().valueMatches("Content-Type", "text/event-stream(;charset=UTF-8)?")
+            .returnResult(String::class.java)
+            .responseBody
+            .take(2)
+            .collectList()
+            .block()
+
+          coVerify { notificationService.subscribeToUserNotifications(userId) }
+        }
+      }
+    }
+
+    describe("PUT api/v1/notifications/{id}/read") {
+      context("유저의 알림 읽음 처리 요청이 들어오면") {
+        val notificationId = "test-notification-id"
+        val updatedNotification = Notification(
+          id = notificationId,
+          notificationType = NotificationType.COMMENT,
+          targetUserId = "user-id",
+          isRead = true
+        )
+
+        coEvery { notificationService.markNotificationAsRead(notificationId) } returns updatedNotification
+
+        val performedRequest = webTestClient
+          .mutateWith(SecurityMockServerConfigurers.mockAuthentication(mockAuthentication))
+          .put()
+          .uri("/api/v1/notifications/$notificationId/read")
+          .exchange()
+
+        it("알림 읽음 처리 로직이 수행된다") {
+          coVerify(exactly = 1) { notificationService.markNotificationAsRead(notificationId) }
+        }
+
+        it("요청은 성공한다") {
+          performedRequest.expectStatus().isOk
+        }
+
+        it("응답으로 오는 알림은 읽음으로 반환된다") {
+          performedRequest.expectBody<Notification>().consumeWith { result ->
+            val returnedNotification = result.responseBody!!
+
+            returnedNotification.id shouldBe notificationId
+            returnedNotification.isRead shouldBe true
+          }
+        }
+      }
+    }
+
+    describe("GET /api/v1/notifications/unread-count/{userId}") {
+      context("유저의 읽지 않은 알림 개수 조회 요청이 들어오면") {
+        val userId = "test-user-id"
+        val unreadCount = 5
+
+        coEvery { notificationService.getUnreadNotificationsCount(userId) } returns unreadCount
+
+        val performRequest = webTestClient
+          .mutateWith(SecurityMockServerConfigurers.mockAuthentication(mockAuthentication))
+          .get()
+          .uri("/api/v1/notifications/unread-count/$userId")
+          .exchange()
+
+        it("알림의 개수를 확인하는 메서드가 수행된다") {
+          coVerify { notificationService.getUnreadNotificationsCount(userId) }
+        }
+
+        it("요청은 성공한다") {
+          performRequest.expectStatus().isOk
+        }
+
+        it("알림 개수는 읽지 않은 개수와 동일한다.") {
+          performRequest.expectBody<Int>().consumeWith { result ->
+            val returnedNotification = result.responseBody!!
+
+            returnedNotification shouldBe unreadCount
+          }
+        }
+      }
+    }
+  }
+
+}
+

--- a/src/test/kotlin/pmeet/pmeetserver/user/notification/repository/NotificationRepositoryUnitTest.kt
+++ b/src/test/kotlin/pmeet/pmeetserver/user/notification/repository/NotificationRepositoryUnitTest.kt
@@ -76,4 +76,28 @@ class NotificationRepositoryUnitTest(
       }
     }
   }
+
+  describe("deleteAllByTargetUserId") {
+    context("targetUserId가 주어지면") {
+      it("해당 사용자의 모든 알림을 삭제한다") {
+        runTest {
+          // Setup
+          val notification1 = Notification(notificationType = NotificationType.COMMENT, targetUserId = testUserId)
+          val notification2 = Notification(notificationType = NotificationType.REPLY, targetUserId = testUserId)
+          val otherUserNotification =
+            Notification(notificationType = NotificationType.COMMENT, targetUserId = testUserId2)
+
+          notificationRepository.saveAll(listOf(notification1, notification2, otherUserNotification)).collectList()
+            .block()
+
+          // Execute
+          notificationRepository.deleteAllByTargetUserId(testUserId).block()
+
+          // Verify
+          notificationRepository.findAllByTargetUserId(testUserId).collectList().block()?.size shouldBe 0
+          notificationRepository.findAllByTargetUserId(testUserId2).collectList().block()?.size shouldBe 1
+        }
+      }
+    }
+  }
 })

--- a/src/test/kotlin/pmeet/pmeetserver/user/notification/service/NotificationServiceUnitTest.kt
+++ b/src/test/kotlin/pmeet/pmeetserver/user/notification/service/NotificationServiceUnitTest.kt
@@ -15,7 +15,6 @@ import pmeet.pmeetserver.user.domain.enum.NotificationType
 import pmeet.pmeetserver.user.domain.notification.Notification
 import pmeet.pmeetserver.user.repository.notification.NotificationRepository
 import pmeet.pmeetserver.user.service.notification.NotificationService
-import reactor.core.publisher.Flux
 import reactor.core.publisher.Mono
 
 @ExperimentalCoroutinesApi
@@ -89,32 +88,6 @@ class NotificationServiceUnitTest : DescribeSpec({
             result.isRead shouldBe false
             result.targetUserId shouldBe testUserId
           }
-        }
-      }
-    }
-  }
-
-  describe("findUnreadNotificationByUserId") {
-    context("알림 수신자의 userId 가 주어지면") {
-      it("해당 수신자의 알림 중 읽음 상태가 아닌 것을 반환한다") {
-        runTest {
-
-          every { notificationRepository.findAllByTargetUserIdAndIsReadFalse(any()) } answers {
-            Flux.fromIterable(
-              mutableListOf(
-                notificationApply,
-                notificationReply,
-                notificationComment,
-                notificationRejected,
-                notificationAccepted
-              )
-            )
-          }
-
-          val result = notificationService.findUnreadNotificationByUserId(testUserId)
-
-          result.size shouldBe 5
-          result.filter { it.isRead }.size shouldBe 0
         }
       }
     }

--- a/src/test/kotlin/pmeet/pmeetserver/user/notification/service/NotificationServiceUnitTest.kt
+++ b/src/test/kotlin/pmeet/pmeetserver/user/notification/service/NotificationServiceUnitTest.kt
@@ -3,18 +3,28 @@ package pmeet.pmeetserver.user.notification.service
 import io.kotest.core.spec.IsolationMode
 import io.kotest.core.spec.style.DescribeSpec
 import io.kotest.matchers.shouldBe
+import io.mockk.Runs
+import io.mockk.coEvery
+import io.mockk.coVerify
 import io.mockk.every
+import io.mockk.just
 import io.mockk.mockk
+import io.mockk.verify
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.take
+import kotlinx.coroutines.flow.toList
 import kotlinx.coroutines.test.StandardTestDispatcher
 import kotlinx.coroutines.test.resetMain
 import kotlinx.coroutines.test.runTest
 import kotlinx.coroutines.test.setMain
+import kotlinx.coroutines.withTimeout
+import org.springframework.http.codec.ServerSentEvent
 import pmeet.pmeetserver.user.domain.enum.NotificationType
 import pmeet.pmeetserver.user.domain.notification.Notification
 import pmeet.pmeetserver.user.repository.notification.NotificationRepository
 import pmeet.pmeetserver.user.service.notification.NotificationService
+import reactor.core.publisher.Flux
 import reactor.core.publisher.Mono
 
 @ExperimentalCoroutinesApi
@@ -80,14 +90,110 @@ class NotificationServiceUnitTest : DescribeSpec({
               targetUserId = testUserId,
             )
 
-            every { notificationRepository.save(any()) } answers { Mono.just(notification) }
+            coEvery { notificationRepository.save(any()) } answers { Mono.just(notification) }
+            coEvery { notificationRepository.emitNotification(any()) } just Runs
 
             val result = notificationService.createNotification(type, testUserId)
 
             result.notificationType shouldBe type
             result.isRead shouldBe false
             result.targetUserId shouldBe testUserId
+
+            coVerify(exactly = 1) {
+              notificationRepository.emitNotification(notification)
+            }
           }
+        }
+      }
+    }
+  }
+
+
+  describe("subscribeToUserNotifications") {
+    context("userId 가 주어지면") {
+      it("ServerSentEvents 를 반환한다.") {
+        runTest {
+          val existingNotifications = listOf(
+            Notification(notificationType = NotificationType.COMMENT, targetUserId = testUserId),
+            Notification(notificationType = NotificationType.REPLY, targetUserId = testUserId)
+          )
+          val newNotification = Notification(notificationType = NotificationType.COMMENT, targetUserId = testUserId)
+
+          every { notificationRepository.findAllByTargetUserIdAndIsReadFalse(testUserId) } returns Flux.fromIterable(
+            existingNotifications
+          )
+          every { notificationRepository.subscribeToUserNotifications(testUserId) } returns Flux.just(
+            ServerSentEvent.builder(
+              newNotification
+            ).build()
+          )
+
+          val resultFlow = notificationService.subscribeToUserNotifications(testUserId)
+
+          val collectedEvents = withTimeout(5000) {
+            resultFlow.take(3).toList()
+          }
+          collectedEvents.size shouldBe 3
+          collectedEvents[0].data()?.notificationType shouldBe NotificationType.COMMENT
+          collectedEvents[1].data()?.notificationType shouldBe NotificationType.REPLY
+          collectedEvents[2].data()?.notificationType shouldBe NotificationType.COMMENT
+
+          verify {
+            notificationRepository.findAllByTargetUserIdAndIsReadFalse(testUserId)
+            notificationRepository.subscribeToUserNotifications(testUserId)
+          }
+        }
+      }
+    }
+  }
+
+  describe("markNotificationAsRead") {
+    context("알림 id 가 주어지면") {
+      it("해당 id 를 읽음 처리한다") {
+        runTest {
+          val notification =
+            Notification(id = "test-id", notificationType = NotificationType.COMMENT, targetUserId = testUserId)
+
+
+          coEvery { notificationRepository.findById("test-id") } answers { Mono.just(notification) }
+
+          notification.isRead = true
+
+          coEvery { notificationRepository.save(any()) } answers { Mono.just(notification) }
+
+          val result = notificationService.markNotificationAsRead("test-id")
+
+          result.isRead shouldBe true
+          result.id shouldBe "test-id"
+
+          coVerify(exactly = 1) {
+            notificationRepository.findById("test-id")
+            notificationRepository.save(any())
+          }
+        }
+      }
+    }
+  }
+
+  describe("getUnreadNotificationsCount") {
+    context("userId 가 주어지면") {
+      it("해당 사용자의 읽지 않은 알림 개수를 반환한다.") {
+        runTest {
+          coEvery { notificationRepository.findAllByTargetUserIdAndIsReadFalse(testUserId) } returns Flux.fromIterable(
+            mutableListOf(
+              notificationApply,
+              notificationReply,
+              notificationComment,
+              notificationAccepted,
+              notificationRejected
+            )
+          )
+
+          val result = notificationService.getUnreadNotificationsCount(testUserId)
+
+          result shouldBe 5
+
+          coVerify(exactly = 1) { notificationRepository.findAllByTargetUserIdAndIsReadFalse(testUserId) }
         }
       }
     }


### PR DESCRIPTION
## Related issue
resolves #173 
resolves #132 

## Description
✨ feat: SSE 를 이용한 알림 수신 기능 구현

### 구조 설계
- 알림 객체는 서버 내 여러 이벤트로 인해서 생성이 됩니다.
- 생성된 알림 객체는 mongo DB 에 저장됩니다.
- DB 에 저장과 동시에 emitter 를 통해서 이벤트로 생성이 됩니다.
- 이벤트에 대한 구독자가 있다면 이벤트를 송신합니다.

### Checklist
- [x] Test case
- [x] End of work

### TODO
- [x] service layer Test 추가
- [x] contorller layer Test 추가