### PR TITLE
fix: 암묵적 승인 방식 OAuth RedirectURL에서 Refresh Token 제거

### DIFF
--- a/src/main/kotlin/pmeet/pmeetserver/user/controller/AuthController.kt
+++ b/src/main/kotlin/pmeet/pmeetserver/user/controller/AuthController.kt
@@ -11,7 +11,6 @@ import org.springframework.web.bind.annotation.RequestParam
 import org.springframework.web.bind.annotation.ResponseStatus
 import org.springframework.web.bind.annotation.RestController
 import org.springframework.web.server.ServerWebExchange
-import pmeet.pmeetserver.user.service.oauth.OauthFacadeService
 import pmeet.pmeetserver.user.dto.request.CheckMailRequestDto
 import pmeet.pmeetserver.user.dto.request.CheckNickNameRequestDto
 import pmeet.pmeetserver.user.dto.request.SendVerificationCodeRequestDto
@@ -22,6 +21,7 @@ import pmeet.pmeetserver.user.dto.request.VerifyVerificationCodeRequestDto
 import pmeet.pmeetserver.user.dto.response.UserJwtDto
 import pmeet.pmeetserver.user.dto.response.UserSignUpResponseDto
 import pmeet.pmeetserver.user.service.UserFacadeService
+import pmeet.pmeetserver.user.service.oauth.OauthFacadeService
 import java.net.URI
 
 @RestController
@@ -49,8 +49,7 @@ class AuthController(
     val redirectUrl = buildString {
       append("https://pmeet.site/?")
       append("userId=${userJwt.userId}&")
-      append("accessToken=${userJwt.accessToken}&")
-      append("refreshToken=${userJwt.refreshToken}")
+      append("accessToken=${userJwt.accessToken}")
     }
     exchange.response.statusCode = HttpStatus.SEE_OTHER
     exchange.response.headers.location = URI.create(redirectUrl)
@@ -62,8 +61,7 @@ class AuthController(
     val redirectUrl = buildString {
       append("https://pmeet.site/?")
       append("userId=${userJwt.userId}&")
-      append("accessToken=${userJwt.accessToken}&")
-      append("refreshToken=${userJwt.refreshToken}")
+      append("accessToken=${userJwt.accessToken}")
     }
     exchange.response.statusCode = HttpStatus.SEE_OTHER
     exchange.response.headers.location = URI.create(redirectUrl)
@@ -76,8 +74,7 @@ class AuthController(
     val redirectUrl = buildString {
       append("https://pmeet.site/?")
       append("userId=${userJwt.userId}&")
-      append("accessToken=${userJwt.accessToken}&")
-      append("refreshToken=${userJwt.refreshToken}")
+      append("accessToken=${userJwt.accessToken}")
     }
     exchange.response.statusCode = HttpStatus.SEE_OTHER
     exchange.response.headers.location = URI.create(redirectUrl)

--- a/src/test/kotlin/pmeet/pmeetserver/user/controller/AuthControllerUnitTest.kt
+++ b/src/test/kotlin/pmeet/pmeetserver/user/controller/AuthControllerUnitTest.kt
@@ -11,7 +11,6 @@ import org.springframework.context.annotation.Import
 import org.springframework.test.web.reactive.server.WebTestClient
 import org.springframework.test.web.reactive.server.expectBody
 import org.springframework.web.util.UriBuilder
-import pmeet.pmeetserver.user.service.oauth.OauthFacadeService
 import pmeet.pmeetserver.config.TestSecurityConfig
 import pmeet.pmeetserver.user.dto.request.CheckMailRequestDto
 import pmeet.pmeetserver.user.dto.request.CheckNickNameRequestDto
@@ -23,6 +22,7 @@ import pmeet.pmeetserver.user.dto.request.VerifyVerificationCodeRequestDto
 import pmeet.pmeetserver.user.dto.response.UserJwtDto
 import pmeet.pmeetserver.user.dto.response.UserSignUpResponseDto
 import pmeet.pmeetserver.user.service.UserFacadeService
+import pmeet.pmeetserver.user.service.oauth.OauthFacadeService
 
 @WebFluxTest(AuthController::class)
 @Import(TestSecurityConfig::class)
@@ -117,7 +117,7 @@ internal class AuthControllerUnitTest : DescribeSpec() {
         it("리다이렉트 URL을 반환한다") {
           performRequest.expectHeader().valueEquals(
             "Location",
-            "https://pmeet.site/?userId=${responseDto.userId}&accessToken=${responseDto.accessToken}&refreshToken=${responseDto.refreshToken}"
+            "https://pmeet.site/?userId=${responseDto.userId}&accessToken=${responseDto.accessToken}"
           )
         }
       }
@@ -148,7 +148,7 @@ internal class AuthControllerUnitTest : DescribeSpec() {
         it("리다이렉트 URL을 반환한다") {
           performRequest.expectHeader().valueEquals(
             "Location",
-            "https://pmeet.site/?userId=${responseDto.userId}&accessToken=${responseDto.accessToken}&refreshToken=${responseDto.refreshToken}"
+            "https://pmeet.site/?userId=${responseDto.userId}&accessToken=${responseDto.accessToken}"
           )
         }
       }
@@ -176,7 +176,7 @@ internal class AuthControllerUnitTest : DescribeSpec() {
           it("리다이렉트 URL을 반환한다") {
             performRequest.expectHeader().valueEquals(
               "Location",
-              "https://pmeet.site/?userId=${responseDto.userId}&accessToken=${responseDto.accessToken}&refreshToken=${responseDto.refreshToken}"
+              "https://pmeet.site/?userId=${responseDto.userId}&accessToken=${responseDto.accessToken}"
             )
           }
         }


### PR DESCRIPTION
## Related issue

## Description
 - 암묵적 승인 방식은 백엔드 서버 인증 없이 동작하기 때문에 만료 기간이 긴 Refresh Token은 오용 가능성이 있음
## Changes detail
- Redirect URL 에서 Refresh Token 제거
### Checklist
- [ ] Test case
- [x] End of work
