### PR TITLE
fix: 이력서 포트폴리오 파일 업로드 여러개 가능 하도록 수정

### DIFF
--- a/src/main/kotlin/pmeet/pmeetserver/file/service/FileService.kt
+++ b/src/main/kotlin/pmeet/pmeetserver/file/service/FileService.kt
@@ -73,6 +73,10 @@ class FileService(
       }
   }
 
+  suspend fun generatePreSignedUrlsToDownload(objectNames: List<String>): List<String>? {
+    return objectNames.takeIf { it.isNotEmpty() }?.mapNotNull { generatePreSignedUrlToDownload(it) }
+  }
+
   /**
    * 파일 고유 ID를 생성
    * @return 36자리의 UUID

--- a/src/main/kotlin/pmeet/pmeetserver/user/controller/ResumeController.kt
+++ b/src/main/kotlin/pmeet/pmeetserver/user/controller/ResumeController.kt
@@ -38,6 +38,7 @@ class ResumeController(
 
   @PostMapping
   @ResponseStatus(HttpStatus.CREATED)
+  @Operation(summary = "이력서 생성", description = "포트폴리오 파일 리스트는 null 불가, 빈 리스트 허용")
   suspend fun createResume(
     @Valid @RequestBody requestDto: CreateResumeRequestDto
   ): ResumeResponseDto {
@@ -63,6 +64,7 @@ class ResumeController(
 
   @PutMapping
   @ResponseStatus(HttpStatus.OK)
+  @Operation(summary = "이력서 수정", description = "포트폴리오 파일 리스트는 null 불가, 빈 리스트 허용")
   suspend fun updateResume(
     @AuthenticationPrincipal userId: Mono<String>,
     @Valid @RequestBody requestDto: UpdateResumeRequestDto

--- a/src/main/kotlin/pmeet/pmeetserver/user/domain/resume/Resume.kt
+++ b/src/main/kotlin/pmeet/pmeetserver/user/domain/resume/Resume.kt
@@ -46,21 +46,22 @@ class Resume(
   var techStacks: List<TechStack>,
   var jobExperiences: List<JobExperience>,
   var projectExperiences: List<ProjectExperience>,
-  var portfolioFileUrl: String?,
+  var portfolioFileUrls: List<String>,
   var portfolioUrl: List<String>,
   var selfDescription: String?,
   var bookmarkers: MutableList<ResumeBookMarker> = mutableListOf(),
   var updatedAt: LocalDateTime = LocalDateTime.now(),
   val createdAt: LocalDateTime = LocalDateTime.now(),
 ) {
-  fun update(title: String? = null, userProfileImageUrl: String? = null,
-             desiredJobs: List<Job>? = null,
-             techStacks: List<TechStack>? = null,
-             jobExperiences: List<JobExperience>? = null,
-             projectExperiences: List<ProjectExperience>? = null,
-             portfolioFileUrl: String? = null,
-             portfolioUrl: List<String>? = null,
-             selfDescription: String? = null
+  fun update(
+    title: String? = null, userProfileImageUrl: String? = null,
+    desiredJobs: List<Job>? = null,
+    techStacks: List<TechStack>? = null,
+    jobExperiences: List<JobExperience>? = null,
+    projectExperiences: List<ProjectExperience>? = null,
+    portfolioFileUrls: List<String>? = null,
+    portfolioUrl: List<String>? = null,
+    selfDescription: String? = null
   ): Resume {
     if (title != null) this.title = title
     if (userProfileImageUrl != null) this.userProfileImageUrl = userProfileImageUrl
@@ -68,7 +69,7 @@ class Resume(
     if (techStacks != null) this.techStacks = techStacks
     if (jobExperiences != null) this.jobExperiences = jobExperiences
     if (projectExperiences != null) this.projectExperiences = projectExperiences
-    if (portfolioFileUrl != null) this.portfolioFileUrl = portfolioFileUrl
+    if (portfolioFileUrls != null) this.portfolioFileUrls = portfolioFileUrls
     if (portfolioUrl != null) this.portfolioUrl = portfolioUrl
     if (selfDescription != null) this.selfDescription = selfDescription
     this.updatedAt = LocalDateTime.now()
@@ -91,7 +92,7 @@ class Resume(
       techStacks = techStacks.toList(),
       jobExperiences = jobExperiences.toList(),
       projectExperiences = projectExperiences.toList(),
-      portfolioFileUrl = portfolioFileUrl,
+      portfolioFileUrls = portfolioFileUrls,
       portfolioUrl = portfolioUrl.toList(),
       bookmarkers = mutableListOf(),
       selfDescription = selfDescription

--- a/src/main/kotlin/pmeet/pmeetserver/user/dto/resume/request/CreateResumeRequestDto.kt
+++ b/src/main/kotlin/pmeet/pmeetserver/user/dto/resume/request/CreateResumeRequestDto.kt
@@ -1,5 +1,6 @@
 package pmeet.pmeetserver.user.dto.resume.request
 
+import io.swagger.v3.oas.annotations.media.Schema
 import jakarta.validation.constraints.Email
 import jakarta.validation.constraints.NotBlank
 import jakarta.validation.constraints.NotNull
@@ -38,7 +39,9 @@ data class CreateResumeRequestDto(
   val techStacks: List<ResumeTechStackRequestDto>,
   val jobExperiences: List<ResumeJobExperienceRequestDto>,
   val projectExperiences: List<ResumeProjectExperienceRequestDto>,
-  val portfolioFileUrl: String?,
+  @field:Schema(description = "포트폴리오 파일 리스트 (null 불가, 빈 배열 허용)")
+  @field:NotNull(message = "포트폴리오 파일 리스트는 null 불가, 빈 리스트 허용")
+  val portfolioFileUrls: List<String> = emptyList(),
   @field:Size(max = 3, message = "최대 3개의 포트폴리오 링크만 입력 가능합니다.")
   val portfolioUrl: List<String>,
   @field:Size(max = 500, message = "자기소개는 최대 500자까지 입력 가능합니다.")
@@ -59,7 +62,7 @@ data class CreateResumeRequestDto(
       techStacks = this.techStacks.map { it.toEntity() },
       jobExperiences = this.jobExperiences.map { it.toEntity() },
       projectExperiences = this.projectExperiences.map { it.toEntity() },
-      portfolioFileUrl = this.portfolioFileUrl,
+      portfolioFileUrls = this.portfolioFileUrls,
       portfolioUrl = this.portfolioUrl,
       selfDescription = this.selfDescription
     )

--- a/src/main/kotlin/pmeet/pmeetserver/user/dto/resume/request/UpdateResumeRequestDto.kt
+++ b/src/main/kotlin/pmeet/pmeetserver/user/dto/resume/request/UpdateResumeRequestDto.kt
@@ -1,5 +1,8 @@
 package pmeet.pmeetserver.user.dto.resume.request
+
+import io.swagger.v3.oas.annotations.media.Schema
 import jakarta.validation.constraints.NotBlank
+import jakarta.validation.constraints.NotNull
 import jakarta.validation.constraints.Pattern
 import jakarta.validation.constraints.Size
 
@@ -20,7 +23,9 @@ data class UpdateResumeRequestDto(
   val techStacks: List<ResumeTechStackRequestDto>,
   val jobExperiences: List<ResumeJobExperienceRequestDto>,
   val projectExperiences: List<ResumeProjectExperienceRequestDto>,
-  val portfolioFileUrl: String?,
+  @field:Schema(description = "포트폴리오 파일 리스트 (null 불가, 빈 배열 허용)")
+  @field:NotNull(message = "포트폴리오 파일 리스트는 null 불가, 빈 리스트 허용")
+  val portfolioFileUrls: List<String> = emptyList(),
   @field:Size(max = 3, message = "최대 3개의 포트폴리오 링크만 입력 가능합니다.")
   val portfolioUrl: List<String>,
   @field:Size(max = 500, message = "자기소개는 최대 500자까지 입력 가능합니다.")

--- a/src/main/kotlin/pmeet/pmeetserver/user/dto/resume/response/ResumeResponseDto.kt
+++ b/src/main/kotlin/pmeet/pmeetserver/user/dto/resume/response/ResumeResponseDto.kt
@@ -57,7 +57,7 @@ data class ResumeResponseDto(
   val techStacks: List<TechStackResponseDto>,
   val jobExperiences: List<ResumeJobExperienceResponseDto>,
   val projectExperiences: List<ResumeProjectExperienceResponseDto>,
-  val portfolioFileUrl: String?,
+  val portfolioFileUrls: List<String>?,
   val portfolioUrl: List<String>,
   val selfDescription: String,
   val updatedAt: LocalDateTime,
@@ -67,7 +67,7 @@ data class ResumeResponseDto(
     fun of(
       resume: Resume,
       profileImageDownloadUrl: String?,
-      portfolioFileDownloadUrl: String? = null
+      portfolioFileDownloadUrls: List<String>? = null
     ): ResumeResponseDto {
       return ResumeResponseDto(
         id = resume.id!!,
@@ -84,7 +84,7 @@ data class ResumeResponseDto(
         techStacks = resume.techStacks.map { TechStackResponseDto.from(it) },
         jobExperiences = resume.jobExperiences.map { ResumeJobExperienceResponseDto.from(it) },
         projectExperiences = resume.projectExperiences.map { ResumeProjectExperienceResponseDto.from(it) },
-        portfolioFileUrl = portfolioFileDownloadUrl,
+        portfolioFileUrls = portfolioFileDownloadUrls,
         portfolioUrl = resume.portfolioUrl,
         selfDescription = resume.selfDescription ?: "",
         updatedAt = resume.updatedAt,

--- a/src/main/kotlin/pmeet/pmeetserver/user/service/resume/ResumeFacadeService.kt
+++ b/src/main/kotlin/pmeet/pmeetserver/user/service/resume/ResumeFacadeService.kt
@@ -32,7 +32,7 @@ class ResumeFacadeService(
     return ResumeResponseDto.of(
       resumeService.save(resume),
       resume.userProfileImageUrl?.let { fileService.generatePreSignedUrlToDownload(it) },
-      resume.portfolioFileUrl?.let { fileService.generatePreSignedUrlToDownload(it) }
+      resume.portfolioFileUrls.let { fileService.generatePreSignedUrlsToDownload(it) }
     )
   }
 
@@ -42,7 +42,7 @@ class ResumeFacadeService(
     return ResumeResponseDto.of(
       resume,
       resume.userProfileImageUrl?.let { fileService.generatePreSignedUrlToDownload(it) },
-      resume.portfolioFileUrl?.let { fileService.generatePreSignedUrlToDownload(it) }
+      resume.portfolioFileUrls.let { fileService.generatePreSignedUrlsToDownload(it) }
     )
   }
 
@@ -53,7 +53,7 @@ class ResumeFacadeService(
       ResumeResponseDto.of(
         it,
         it.userProfileImageUrl?.let { fileService.generatePreSignedUrlToDownload(it) },
-        it.portfolioFileUrl?.let { fileService.generatePreSignedUrlToDownload(it) }
+        it.portfolioFileUrls.let { fileService.generatePreSignedUrlsToDownload(it) }
       )
     }
   }
@@ -71,7 +71,7 @@ class ResumeFacadeService(
       techStacks = requestDto.techStacks.map { it.toEntity() },
       jobExperiences = requestDto.jobExperiences.map { it.toEntity() },
       projectExperiences = requestDto.projectExperiences.map { it.toEntity() },
-      portfolioFileUrl = requestDto.portfolioFileUrl,
+      portfolioFileUrls = requestDto.portfolioFileUrls,
       portfolioUrl = requestDto.portfolioUrl,
       selfDescription = requestDto.selfDescription
     )
@@ -79,7 +79,7 @@ class ResumeFacadeService(
     return ResumeResponseDto.of(
       updatedResume,
       updatedResume.userProfileImageUrl?.let { fileService.generatePreSignedUrlToDownload(it) },
-      updatedResume.portfolioFileUrl?.let { fileService.generatePreSignedUrlToDownload(it) }
+      updatedResume.portfolioFileUrls.let { fileService.generatePreSignedUrlsToDownload(it) }
     )
   }
 
@@ -102,7 +102,7 @@ class ResumeFacadeService(
     return ResumeResponseDto.of(
       copiedResume,
       copiedResume.userProfileImageUrl?.let { fileService.generatePreSignedUrlToDownload(it) },
-      copiedResume.portfolioFileUrl?.let { fileService.generatePreSignedUrlToDownload(it) }
+      copiedResume.portfolioFileUrls.let { fileService.generatePreSignedUrlsToDownload(it) }
     )
   }
 

--- a/src/test/kotlin/pmeet/pmeetserver/user/resume/ResumeGenerator.kt
+++ b/src/test/kotlin/pmeet/pmeetserver/user/resume/ResumeGenerator.kt
@@ -83,7 +83,7 @@ object ResumeGenerator {
           responsibilities = "Contributed to backend services"
         )
       ),
-      portfolioFileUrl = "http://example.com/portfolio.pdf",
+      portfolioFileUrls = listOf("http://example.com/portfolio.pdf", "http://example.com/portfolio2.pdf"),
       portfolioUrl = listOf("http://example.com/project1", "http://example.com/project2"),
       selfDescription = "Passionate software engineer with a focus on backend development."
     )
@@ -145,7 +145,7 @@ object ResumeGenerator {
           responsibilities = "Contributed to backend services"
         )
       ),
-      portfolioFileUrl = "http://example.com/portfolio.pdf",
+      portfolioFileUrls = listOf("http://example.com/portfolio.pdf", "http://example.com/portfolio2.pdf"),
       portfolioUrl = listOf("http://example.com/project1", "http://example.com/project2"),
       selfDescription = "Passionate software engineer with a focus on backend development.",
       updatedAt = LocalDateTime.now(),
@@ -155,7 +155,13 @@ object ResumeGenerator {
 
   internal fun createMockResumeResponseDtoList(): List<ResumeResponseDto> {
     val resumes = generateResumeList()
-    return resumes.map { ResumeResponseDto.of(it, "profileImageDownloadUrl", "portfolioFileDownloadUrl") }
+    return resumes.map {
+      ResumeResponseDto.of(
+        it,
+        "profileImageDownloadUrl",
+        listOf("portfolioFileDownloadUrl", "portfolioFileDownloadUrl2")
+      )
+    }
   }
 
   internal fun createMockResumeCopyResponseDto(): ResumeResponseDto {
@@ -214,7 +220,7 @@ object ResumeGenerator {
           responsibilities = "Contributed to backend services"
         )
       ),
-      portfolioFileUrl = "http://example.com/portfolio.pdf",
+      portfolioFileUrls = listOf("http://example.com/portfolio.pdf", "http://example.com/portfolio2.pdf"),
       portfolioUrl = listOf("http://example.com/project1", "http://example.com/project2"),
       selfDescription = "Passionate software engineer with a focus on backend development.",
       updatedAt = LocalDateTime.now(),
@@ -277,7 +283,7 @@ object ResumeGenerator {
           responsibilities = "Contributed to backend services"
         )
       ),
-      portfolioFileUrl = "http://example.com/portfolio.pdf",
+      portfolioFileUrls = listOf("http://example.com/portfolio.pdf", "http://example.com/portfolio2.pdf"),
       portfolioUrl = listOf("http://example.com/project1", "http://example.com/project2"),
       selfDescription = "Passionate software engineer with a focus on backend development."
     )
@@ -339,7 +345,7 @@ object ResumeGenerator {
           responsibilities = "Contributed to backend services"
         )
       ),
-      portfolioFileUrl = "http://example.com/portfolio.pdf",
+      portfolioFileUrls = listOf("http://example.com/portfolio.pdf", "http://example.com/portfolio2.pdf"),
       portfolioUrl = listOf("http://example.com/project1", "http://example.com/project2"),
       selfDescription = "Passionate software engineer with a focus on backend development."
     )
@@ -400,7 +406,7 @@ object ResumeGenerator {
           responsibilities = "Contributed to backend services"
         )
       ),
-      portfolioFileUrl = "http://example.com/portfolio.pdf",
+      portfolioFileUrls = listOf("http://example.com/portfolio.pdf", "http://example.com/portfolio2.pdf"),
       portfolioUrl = listOf("http://example.com/project1", "http://example.com/project2"),
       selfDescription = "Passionate software engineer with a focus on backend development."
     )
@@ -470,7 +476,7 @@ object ResumeGenerator {
           responsibilities = "Contributed to backend services"
         )
       ),
-      portfolioFileUrl = "http://example.com/portfolio.pdf",
+      portfolioFileUrls = listOf("http://example.com/portfolio.pdf", "http://example.com/portfolio2.pdf"),
       portfolioUrl = listOf("http://example.com/project1", "http://example.com/project2"),
       selfDescription = "Passionate software engineer with a focus on backend development."
     )
@@ -532,7 +538,7 @@ object ResumeGenerator {
           responsibilities = "Contributed to backend services"
         )
       ),
-      portfolioFileUrl = "http://example.com/portfolio.pdf",
+      portfolioFileUrls = listOf("http://example.com/portfolio.pdf", "http://example.com/portfolio2.pdf"),
       portfolioUrl = listOf("http://example.com/project1", "http://example.com/project2"),
       selfDescription = "Passionate software engineer with a focus on backend development."
     )
@@ -620,7 +626,7 @@ object ResumeGenerator {
           responsibilities = "Contributed to backend services"
         )
       ),
-      portfolioFileUrl = "http://example.com/portfolio.pdf",
+      portfolioFileUrls = listOf("http://example.com/portfolio.pdf", "http://example.com/portfolio2.pdf"),
       portfolioUrl = listOf("http://example.com/project1", "http://example.com/project2"),
       selfDescription = "Passionate software engineer with a focus on backend development.",
       updatedAt = LocalDateTime.of(2022, Month.DECEMBER, 5, 0, 0, 0).minusDays(bookmarkNumber.toLong()),

--- a/src/test/kotlin/pmeet/pmeetserver/user/resume/ResumeIntegrationTest.kt
+++ b/src/test/kotlin/pmeet/pmeetserver/user/resume/ResumeIntegrationTest.kt
@@ -182,7 +182,7 @@ class ResumeIntegrationTest : BaseMongoDBTestForIntegration() {
             returnedResume.techStacks shouldBe resumeResponse.techStacks
             returnedResume.jobExperiences shouldBe resumeResponse.jobExperiences
             returnedResume.projectExperiences shouldBe resumeResponse.projectExperiences
-            returnedResume.portfolioFileUrl shouldNotBe resumeResponse.portfolioFileUrl
+            returnedResume.portfolioFileUrls shouldNotBe resumeResponse.portfolioFileUrls
             returnedResume.portfolioUrl shouldBe resumeResponse.portfolioUrl
             returnedResume.selfDescription shouldBe resumeResponse.selfDescription
           }
@@ -230,7 +230,7 @@ class ResumeIntegrationTest : BaseMongoDBTestForIntegration() {
             returnedResume.techStacks shouldBe resumeResponse.techStacks
             returnedResume.jobExperiences shouldBe resumeResponse.jobExperiences
             returnedResume.projectExperiences shouldBe resumeResponse.projectExperiences
-            returnedResume.portfolioFileUrl shouldNotBe resumeResponse.portfolioFileUrl
+            returnedResume.portfolioFileUrls shouldNotBe resumeResponse.portfolioFileUrls
             returnedResume.portfolioUrl shouldBe resumeResponse.portfolioUrl
             returnedResume.selfDescription shouldBe resumeResponse.selfDescription
           }
@@ -314,7 +314,7 @@ class ResumeIntegrationTest : BaseMongoDBTestForIntegration() {
             returnedResume.techStacks.first().name shouldBe resumeResponse.techStacks.first().name
             returnedResume.jobExperiences.first().companyName shouldBe resumeResponse.jobExperiences.first().companyName
             returnedResume.projectExperiences.first().projectName shouldBe resumeResponse.projectExperiences.first().projectName
-            returnedResume.portfolioFileUrl shouldNotBe resumeResponse.portfolioFileUrl
+            returnedResume.portfolioFileUrls shouldNotBe resumeResponse.portfolioFileUrls
             returnedResume.portfolioUrl shouldBe resumeResponse.portfolioUrl
             returnedResume.selfDescription shouldBe resumeResponse.selfDescription
             returnedResume.updatedAt shouldBeAfter requestTime
@@ -376,7 +376,7 @@ class ResumeIntegrationTest : BaseMongoDBTestForIntegration() {
             returnedResume.techStacks shouldBe resumeResponse.techStacks
             returnedResume.jobExperiences shouldBe resumeResponse.jobExperiences
             returnedResume.projectExperiences shouldBe resumeResponse.projectExperiences
-            returnedResume.portfolioFileUrl shouldNotBe resumeResponse.portfolioFileUrl
+            returnedResume.portfolioFileUrls shouldNotBe resumeResponse.portfolioFileUrls
             returnedResume.portfolioUrl shouldBe resumeResponse.portfolioUrl
             returnedResume.selfDescription shouldBe resumeResponse.selfDescription
           }

--- a/src/test/kotlin/pmeet/pmeetserver/user/resume/controller/ResumeControllerUnitTest.kt
+++ b/src/test/kotlin/pmeet/pmeetserver/user/resume/controller/ResumeControllerUnitTest.kt
@@ -119,7 +119,7 @@ internal class ResumeControllerUnitTest : DescribeSpec() {
             returnedResume.techStacks shouldBe resumeResponse.techStacks
             returnedResume.jobExperiences shouldBe resumeResponse.jobExperiences
             returnedResume.projectExperiences shouldBe resumeResponse.projectExperiences
-            returnedResume.portfolioFileUrl shouldBe resumeResponse.portfolioFileUrl
+            returnedResume.portfolioFileUrls shouldBe resumeResponse.portfolioFileUrls
             returnedResume.portfolioUrl shouldBe resumeResponse.portfolioUrl
             returnedResume.selfDescription shouldBe resumeResponse.selfDescription
           }
@@ -280,7 +280,7 @@ internal class ResumeControllerUnitTest : DescribeSpec() {
             returnedResume.techStacks.first().name shouldBe mockResume.techStacks.first().name
             returnedResume.jobExperiences.first().companyName shouldBe mockResume.jobExperiences.first().companyName
             returnedResume.projectExperiences.first().projectName shouldBe mockResume.projectExperiences.first().projectName
-            returnedResume.portfolioFileUrl shouldBe mockResume.portfolioFileUrl
+            returnedResume.portfolioFileUrls shouldBe mockResume.portfolioFileUrls
             returnedResume.portfolioUrl shouldBe mockResume.portfolioUrl
             returnedResume.selfDescription shouldBe mockResume.selfDescription
           }

--- a/src/test/kotlin/pmeet/pmeetserver/user/resume/repository/ResumeRepositoryUnitTest.kt
+++ b/src/test/kotlin/pmeet/pmeetserver/user/resume/repository/ResumeRepositoryUnitTest.kt
@@ -143,7 +143,7 @@ internal class ResumeRepositoryUnitTest(
           result?.techStacks?.first()?.name shouldBe resume.techStacks.first().name
           result?.jobExperiences?.first()?.companyName shouldBe resume.jobExperiences.first().companyName
           result?.projectExperiences?.first()?.projectName shouldBe resume.projectExperiences.first().projectName
-          result?.portfolioFileUrl shouldBe resume.portfolioFileUrl
+          result?.portfolioFileUrls shouldBe resume.portfolioFileUrls
           result?.portfolioUrl?.first() shouldBe resume.portfolioUrl.first()
           result?.selfDescription shouldBe resume.selfDescription
         }
@@ -169,7 +169,7 @@ internal class ResumeRepositoryUnitTest(
           result?.techStacks?.first()?.name shouldBe resume.techStacks.first().name
           result?.jobExperiences?.first()?.companyName shouldBe resume.jobExperiences.first().companyName
           result?.projectExperiences?.first()?.projectName shouldBe resume.projectExperiences.first().projectName
-          result?.portfolioFileUrl shouldBe resume.portfolioFileUrl
+          result?.portfolioFileUrls shouldBe resume.portfolioFileUrls
           result?.portfolioUrl?.first() shouldBe resume.portfolioUrl.first()
           result?.selfDescription shouldBe resume.selfDescription
         }

--- a/src/test/kotlin/pmeet/pmeetserver/user/resume/service/ResumeFacadeServiceUnitTest.kt
+++ b/src/test/kotlin/pmeet/pmeetserver/user/resume/service/ResumeFacadeServiceUnitTest.kt
@@ -92,9 +92,9 @@ class ResumeFacadeServiceUnitTest : DescribeSpec({
           coEvery { resumeService.save(any()) } answers { resume }
           val resumeCreateRequest = createMockCreateResumeRequestDto()
           val profileImageDownloadUrl = "profile-image-download-url"
-          val portfolioFileDownloadUrl = "portfolio-file-download-url"
+          val portfolioFileDownloadUrls = listOf("portfolio-file-download-url", "portfolio-file-download-url2")
           coEvery { fileService.generatePreSignedUrlToDownload(resume.userProfileImageUrl!!) } answers { profileImageDownloadUrl }
-          coEvery { fileService.generatePreSignedUrlToDownload(resume.portfolioFileUrl!!) } answers { portfolioFileDownloadUrl }
+          coEvery { fileService.generatePreSignedUrlsToDownload(resume.portfolioFileUrls) } answers { portfolioFileDownloadUrls }
 
           val result = resumeFacadeService.createResume(resumeCreateRequest)
 
@@ -111,7 +111,7 @@ class ResumeFacadeServiceUnitTest : DescribeSpec({
           result.techStacks.first().name shouldBe resume.techStacks.first().name
           result.jobExperiences.first().companyName shouldBe resume.jobExperiences.first().companyName
           result.projectExperiences.first().projectName shouldBe resume.projectExperiences.first().projectName
-          result.portfolioFileUrl shouldBe portfolioFileDownloadUrl
+          result.portfolioFileUrls shouldBe portfolioFileDownloadUrls
           result.portfolioUrl.first() shouldBe resume.portfolioUrl.first()
           result.selfDescription shouldBe resume.selfDescription
         }
@@ -126,9 +126,9 @@ class ResumeFacadeServiceUnitTest : DescribeSpec({
           val requestTime = LocalDateTime.now().minusMinutes(1L)
           val updateRequest = createMockUpdateResumeRequestDto()
           val profileImageDownloadUrl = "profile-image-download-url"
-          val portfolioFileDownloadUrl = "portfolio-file-download-url"
+          val portfolioFileDownloadUrls = listOf("portfolio-file-download-url", "portfolio-file-download-url2")
           coEvery { fileService.generatePreSignedUrlToDownload(updateRequest.userProfileImageUrl!!) } answers { profileImageDownloadUrl }
-          coEvery { fileService.generatePreSignedUrlToDownload(updateRequest.portfolioFileUrl!!) } answers { portfolioFileDownloadUrl }
+          coEvery { fileService.generatePreSignedUrlsToDownload(updateRequest.portfolioFileUrls) } answers { portfolioFileDownloadUrls }
           coEvery { resumeService.getByResumeId(any()) } answers { resume }
           coEvery { resumeService.update(any()) } answers { generateUpdatedResume() }
 
@@ -141,7 +141,7 @@ class ResumeFacadeServiceUnitTest : DescribeSpec({
           result.techStacks.first().name shouldBe updateRequest.techStacks.first().name
           result.jobExperiences.first().companyName shouldBe updateRequest.jobExperiences.first().companyName
           result.projectExperiences.first().projectName shouldBe updateRequest.projectExperiences.first().projectName
-          result.portfolioFileUrl shouldBe portfolioFileDownloadUrl
+          result.portfolioFileUrls shouldBe portfolioFileDownloadUrls
           result.portfolioUrl.first() shouldBe updateRequest.portfolioUrl.first()
           result.selfDescription shouldBe updateRequest.selfDescription
           result.updatedAt shouldBeAfter requestTime
@@ -159,7 +159,7 @@ class ResumeFacadeServiceUnitTest : DescribeSpec({
           resume.techStacks.first().name shouldBe originalResume.techStacks.first().name
           resume.jobExperiences.first().companyName shouldBe originalResume.jobExperiences.first().companyName
           resume.projectExperiences.first().projectName shouldBe originalResume.projectExperiences.first().projectName
-          resume.portfolioFileUrl shouldBe originalResume.portfolioFileUrl
+          resume.portfolioFileUrls shouldBe originalResume.portfolioFileUrls
           resume.portfolioUrl.first() shouldBe originalResume.portfolioUrl.first()
           resume.selfDescription shouldBe originalResume.selfDescription
         }
@@ -246,9 +246,9 @@ class ResumeFacadeServiceUnitTest : DescribeSpec({
           val originalResume = generateResume()
 
           val profileImageDownloadUrl = "profile-image-download-url"
-          val portfolioFileDownloadUrl = "portfolio-file-download-url"
+          val portfolioFileDownloadUrls = listOf("portfolio-file-download-url", "portfolio-file-download-url2")
           coEvery { fileService.generatePreSignedUrlToDownload(originalResume.userProfileImageUrl!!) } answers { profileImageDownloadUrl }
-          coEvery { fileService.generatePreSignedUrlToDownload(originalResume.portfolioFileUrl!!) } answers { portfolioFileDownloadUrl }
+          coEvery { fileService.generatePreSignedUrlsToDownload(originalResume.portfolioFileUrls) } answers { portfolioFileDownloadUrls }
 
           val result = resumeFacadeService.copyResume(resume.userId, copyRequest)
           result.title shouldBe "[복사] ${originalResume.title.toString()}"
@@ -258,7 +258,7 @@ class ResumeFacadeServiceUnitTest : DescribeSpec({
           result.techStacks.first().name shouldBe originalResume.techStacks.first().name
           result.jobExperiences.first().companyName shouldBe originalResume.jobExperiences.first().companyName
           result.projectExperiences.first().projectName shouldBe originalResume.projectExperiences.first().projectName
-          result.portfolioFileUrl shouldBe portfolioFileDownloadUrl
+          result.portfolioFileUrls shouldBe portfolioFileDownloadUrls
           result.portfolioUrl.first() shouldBe originalResume.portfolioUrl.first()
           result.selfDescription shouldBe originalResume.selfDescription
         }

--- a/src/test/kotlin/pmeet/pmeetserver/user/resume/service/ResumeServiceUnitTest.kt
+++ b/src/test/kotlin/pmeet/pmeetserver/user/resume/service/ResumeServiceUnitTest.kt
@@ -114,7 +114,7 @@ internal class ResumeServiceUnitTest : DescribeSpec({
           result.techStacks.first().name shouldBe resume.techStacks.first().name
           result.jobExperiences.first().companyName shouldBe resume.jobExperiences.first().companyName
           result.projectExperiences.first().projectName shouldBe resume.projectExperiences.first().projectName
-          result.portfolioFileUrl shouldBe resume.portfolioFileUrl
+          result.portfolioFileUrls shouldBe resume.portfolioFileUrls
           result.portfolioUrl.first() shouldBe resume.portfolioUrl.first()
           result.selfDescription shouldBe resume.selfDescription
           result.createdAt shouldBeAfter requestTime
@@ -151,7 +151,7 @@ internal class ResumeServiceUnitTest : DescribeSpec({
           result.techStacks.first().name shouldBe resumeUpdateRequestDto.techStacks.first().name
           result.jobExperiences.first().companyName shouldBe resumeUpdateRequestDto.jobExperiences.first().companyName
           result.projectExperiences.first().projectName shouldBe resumeUpdateRequestDto.projectExperiences.first().projectName
-          result.portfolioFileUrl shouldBe resumeUpdateRequestDto.portfolioFileUrl
+          result.portfolioFileUrls shouldBe resumeUpdateRequestDto.portfolioFileUrls
           result.portfolioUrl.first() shouldBe resumeUpdateRequestDto.portfolioUrl.first()
           result.selfDescription shouldBe resumeUpdateRequestDto.selfDescription
         }


### PR DESCRIPTION

## Related issue

## Description
 - 기획 상 포트폴리오 파일은 여러개 가능
- 요청 DTO에서의 portfolioFileUrls은 Null을 허용하지 않으며, 빈 배열은 허용한다.
- 응답 DTO에서 portfolioFileUrls는 Null을 허용한다.
- Document에서 portfolioFileUrls는 Null을 허용하지 않으며, 빈 배열은 허용한다.
## Changes detail
- 여러개의 objectName을 다루는 generatePreSignedUrlsToDownload 메서드 추가
- DTO의 portfolioFileUrl를 portfolioFileUrls로 변경 


### Checklist
- [x] Test case
- [x] End of work
