### PR TITLE
feat: 마이페이지 - 마이프로젝트 - 지원한 프로젝트 조회 기능

### DIFF
--- a/src/main/kotlin/pmeet/pmeetserver/project/controller/ProjectController.kt
+++ b/src/main/kotlin/pmeet/pmeetserver/project/controller/ProjectController.kt
@@ -25,6 +25,7 @@ import pmeet.pmeetserver.project.dto.request.SearchProjectRequestDto
 import pmeet.pmeetserver.project.dto.request.UpdateProjectRequestDto
 import pmeet.pmeetserver.project.dto.response.CompletedProjectResponseDto
 import pmeet.pmeetserver.project.dto.response.GetMyInProgressProjectResponseDto
+import pmeet.pmeetserver.project.dto.response.GetMyInReviewProjectResponseDto
 import pmeet.pmeetserver.project.dto.response.GetMyProjectResponseDto
 import pmeet.pmeetserver.project.dto.response.ProjectResponseDto
 import pmeet.pmeetserver.project.dto.response.ProjectWithUserResponseDto
@@ -181,5 +182,16 @@ class ProjectController(
     @RequestParam(defaultValue = "6") size: Int
   ): Slice<GetMyInProgressProjectResponseDto> {
     return projectFacadeService.getMyProjectSliceInProgress(userId.awaitSingle(), PageRequest.of(page, size))
+  }
+
+  @GetMapping("/my-project-slice/in-review")
+  @ResponseStatus(HttpStatus.OK)
+  @Operation(summary = "지원한 프밋 목록 조회", description = "마이페이지 - 마이 프로젝트 - 지원한 프로젝트")
+  suspend fun getInReviewProjectSlice(
+    @AuthenticationPrincipal userId: Mono<String>,
+    @RequestParam(defaultValue = "0") page: Int,
+    @RequestParam(defaultValue = "6") size: Int
+  ): Slice<GetMyInReviewProjectResponseDto> {
+    return projectFacadeService.getMyProjectSliceInReview(userId.awaitSingle(), PageRequest.of(page, size))
   }
 }

--- a/src/main/kotlin/pmeet/pmeetserver/project/dto/response/GetMyInReviewProjectResponseDto.kt
+++ b/src/main/kotlin/pmeet/pmeetserver/project/dto/response/GetMyInReviewProjectResponseDto.kt
@@ -1,0 +1,27 @@
+package pmeet.pmeetserver.project.dto.response
+
+data class GetMyInReviewProjectResponseDto(
+  val id: String,
+  val title: String,
+  val description: String,
+  val thumbNailUrl: String?,
+  val positionName: String?,
+) {
+  companion object {
+    fun of(
+      id: String,
+      title: String,
+      description: String,
+      thumbNailDownloadUrl: String?,
+      positionName: String?,
+    ): GetMyInReviewProjectResponseDto {
+      return GetMyInReviewProjectResponseDto(
+        id = id,
+        title = title,
+        description = description,
+        thumbNailUrl = thumbNailDownloadUrl,
+        positionName = positionName,
+      )
+    }
+  }
+}

--- a/src/main/kotlin/pmeet/pmeetserver/project/repository/CustomProjectRepository.kt
+++ b/src/main/kotlin/pmeet/pmeetserver/project/repository/CustomProjectRepository.kt
@@ -2,7 +2,9 @@ package pmeet.pmeetserver.project.repository
 
 import org.springframework.data.domain.Pageable
 import pmeet.pmeetserver.project.domain.Project
+import pmeet.pmeetserver.project.domain.enum.ProjectTryoutStatus
 import pmeet.pmeetserver.project.enums.ProjectFilterType
+import pmeet.pmeetserver.project.repository.vo.ProjectWithProjectTryout
 import reactor.core.publisher.Flux
 
 interface CustomProjectRepository {
@@ -45,4 +47,20 @@ interface CustomProjectRepository {
     isCompleted: Boolean,
     pageable: Pageable
   ): Flux<Project>
+
+
+  /**
+   * User ID로 내가 지원한 프로젝트와 지원서 목록 조회
+   *
+   * @param userId 사용자 ID
+   * @param isCompleted 완료 여부
+   * @param tryoutStatus 지원 상태
+   * @param pageable 페이징 정보
+   */
+  fun findProjectsByProjectTryoutUserIdAndIsCompletedOrderByCreatedAtDesc(
+    userId: String,
+    isCompleted: Boolean,
+    tryoutStatus: ProjectTryoutStatus,
+    pageable: Pageable
+  ): Flux<ProjectWithProjectTryout>
 }

--- a/src/main/kotlin/pmeet/pmeetserver/project/repository/vo/ProjectWithProjectTryout.kt
+++ b/src/main/kotlin/pmeet/pmeetserver/project/repository/vo/ProjectWithProjectTryout.kt
@@ -1,0 +1,19 @@
+package pmeet.pmeetserver.project.repository.vo
+
+import pmeet.pmeetserver.project.domain.enum.ProjectTryoutStatus
+
+data class ProjectWithProjectTryout(
+  var id: String,
+  val projectCreatedBy: String,
+  var title: String,
+  var thumbNailUrl: String? = null,
+  var description: String,
+  var isCompleted: Boolean = false,
+  val resumeId: String,
+  val userId: String,
+  val userName: String,
+  val userSelfDescription: String,
+  val userProfileImageUrl: String? = null,
+  val positionName: String,
+  var tryoutStatus: ProjectTryoutStatus,
+)

--- a/src/main/kotlin/pmeet/pmeetserver/project/service/ProjectFacadeService.kt
+++ b/src/main/kotlin/pmeet/pmeetserver/project/service/ProjectFacadeService.kt
@@ -24,6 +24,7 @@ import pmeet.pmeetserver.project.dto.request.SearchProjectRequestDto
 import pmeet.pmeetserver.project.dto.request.UpdateProjectRequestDto
 import pmeet.pmeetserver.project.dto.response.CompletedProjectResponseDto
 import pmeet.pmeetserver.project.dto.response.GetMyInProgressProjectResponseDto
+import pmeet.pmeetserver.project.dto.response.GetMyInReviewProjectResponseDto
 import pmeet.pmeetserver.project.dto.response.GetMyProjectResponseDto
 import pmeet.pmeetserver.project.dto.response.ProjectMemberInfoDto
 import pmeet.pmeetserver.project.dto.response.ProjectResponseDto
@@ -443,6 +444,27 @@ class ProjectFacadeService(
     }
 
     return SliceImpl(responseDtos, pageable, projects.hasNext())
+  }
+
+  suspend fun getMyProjectSliceInReview(
+    userId: String,
+    pageable: Pageable
+  ): Slice<GetMyInReviewProjectResponseDto> {
+    val projectsWithProjectTryout =
+      projectService.getProjectsByProjectTryoutInReviewUserIdAndIsCompletedOrderByCreatedAtDesc(userId, false, pageable)
+
+    val responseDtos = projectsWithProjectTryout.content.map { projectWithTryout ->
+      val thumbNailDownloadUrl = projectWithTryout.thumbNailUrl?.let { fileService.generatePreSignedUrlToDownload(it) }
+      GetMyInReviewProjectResponseDto.of(
+        projectWithTryout.id,
+        projectWithTryout.title,
+        projectWithTryout.description,
+        thumbNailDownloadUrl,
+        projectWithTryout.positionName
+      )
+    }
+
+    return SliceImpl(responseDtos, pageable, projectsWithProjectTryout.hasNext())
   }
 
   /**

--- a/src/main/kotlin/pmeet/pmeetserver/project/service/ProjectService.kt
+++ b/src/main/kotlin/pmeet/pmeetserver/project/service/ProjectService.kt
@@ -10,9 +10,11 @@ import pmeet.pmeetserver.common.ErrorCode
 import pmeet.pmeetserver.common.exception.EntityNotFoundException
 import pmeet.pmeetserver.common.utils.page.SliceResponse
 import pmeet.pmeetserver.project.domain.Project
+import pmeet.pmeetserver.project.domain.enum.ProjectTryoutStatus
 import pmeet.pmeetserver.project.dto.request.CompleteProjectRequestDto
 import pmeet.pmeetserver.project.enums.ProjectFilterType
 import pmeet.pmeetserver.project.repository.ProjectRepository
+import pmeet.pmeetserver.project.repository.vo.ProjectWithProjectTryout
 
 @Service
 class ProjectService(
@@ -98,6 +100,23 @@ class ProjectService(
       projectRepository.findProjectsByProjectMemberUserIdAndIsCompletedOrderByCreatedAtDesc(
         userId,
         isCompleted,
+        pageable
+      ).collectList().awaitSingle(),
+      pageable
+    )
+  }
+
+  @Transactional(readOnly = true)
+  suspend fun getProjectsByProjectTryoutInReviewUserIdAndIsCompletedOrderByCreatedAtDesc(
+    userId: String,
+    isCompleted: Boolean,
+    pageable: Pageable
+  ): Slice<ProjectWithProjectTryout> {
+    return SliceResponse.of(
+      projectRepository.findProjectsByProjectTryoutUserIdAndIsCompletedOrderByCreatedAtDesc(
+        userId,
+        isCompleted,
+        ProjectTryoutStatus.INREVIEW,
         pageable
       ).collectList().awaitSingle(),
       pageable

--- a/src/test/kotlin/pmeet/pmeetserver/project/controller/ProjectControllerUnitTest.kt
+++ b/src/test/kotlin/pmeet/pmeetserver/project/controller/ProjectControllerUnitTest.kt
@@ -26,6 +26,7 @@ import pmeet.pmeetserver.project.dto.request.SearchProjectRequestDto
 import pmeet.pmeetserver.project.dto.request.UpdateProjectRequestDto
 import pmeet.pmeetserver.project.dto.response.CompletedProjectResponseDto
 import pmeet.pmeetserver.project.dto.response.GetMyInProgressProjectResponseDto
+import pmeet.pmeetserver.project.dto.response.GetMyInReviewProjectResponseDto
 import pmeet.pmeetserver.project.dto.response.GetMyProjectResponseDto
 import pmeet.pmeetserver.project.dto.response.ProjectMemberInfoDto
 import pmeet.pmeetserver.project.dto.response.ProjectResponseDto
@@ -864,6 +865,74 @@ internal class ProjectControllerUnitTest : DescribeSpec() {
 
             performRequest.expectStatus().isUnauthorized
           }
+        }
+      }
+    }
+
+    describe("GET /api/v1/projects/my-project-slice/in-review") {
+      context("인증된 유저의 지원한 프로젝트 조회 요청이 들어오면") {
+        val userId = "1234"
+        val pageNumber = 0
+        val pageSize = 6
+        val pageable = PageRequest.of(pageNumber, pageSize)
+        val mockAuthentication = UsernamePasswordAuthenticationToken(userId, null, null)
+
+        val responseDto = mutableListOf<GetMyInReviewProjectResponseDto>()
+        for (i in 1..20) {
+          val getMyInReviewProjectResponseDto = GetMyInReviewProjectResponseDto(
+            id = "testId$i",
+            title = "testTitle$i",
+            description = "testDescription$i",
+            thumbNailUrl = "testThumbNailUrl$i",
+            positionName = "testPositionName$i"
+          ).also { responseDto.add(it) }
+        }
+
+        coEvery { projectFacadeService.getMyProjectSliceInReview(userId, pageable) } answers {
+          SliceImpl(responseDto.subList(0, pageSize), pageable, true)
+        }
+
+        it("서비스를 통해 데이터를 조회한다") {
+          val performRequest = webTestClient
+            .mutateWith(mockAuthentication(mockAuthentication))
+            .get()
+            .uri { uriBuilder ->
+              uriBuilder.path("/api/v1/projects/my-project-slice/in-review")
+                .queryParam("page", pageNumber)
+                .queryParam("size", pageSize)
+                .build()
+            }
+            .exchange()
+
+          coVerify(exactly = 1) { projectFacadeService.getMyProjectSliceInReview(userId, pageable) }
+          performRequest.expectStatus().isOk
+          performRequest.expectBody<RestSliceImpl<GetMyInReviewProjectResponseDto>>().consumeWith { response ->
+            response.responseBody?.content?.size shouldBe pageSize
+            response.responseBody?.content?.forEachIndexed { index, getMyInReviewProjectResponseDto ->
+              getMyInReviewProjectResponseDto.id shouldBe responseDto[index].id
+              getMyInReviewProjectResponseDto.title shouldBe responseDto[index].title
+              getMyInReviewProjectResponseDto.description shouldBe responseDto[index].description
+              getMyInReviewProjectResponseDto.thumbNailUrl shouldBe responseDto[index].thumbNailUrl
+              getMyInReviewProjectResponseDto.positionName shouldBe responseDto[index].positionName
+            }
+          }
+        }
+      }
+      context("인증되지 않은 사용자의 요청이면") {
+        it("요청은 실패한다") {
+          val pageNumber = 0
+          val pageSize = 6
+          val performRequest = webTestClient
+            .get()
+            .uri { uriBuilder ->
+              uriBuilder.path("/api/v1/projects/my-project-slice/in-review")
+                .queryParam("page", pageNumber)
+                .queryParam("size", pageSize)
+                .build()
+            }
+            .exchange()
+
+          performRequest.expectStatus().isUnauthorized
         }
       }
     }


### PR DESCRIPTION
## Related issue
resolves #187 
## Description
 - ProjectWithTryout VO를 사용해 projectRepository에서 project와 ProjectTryOut lookup한 결과 저장
## Changes detail
- 테스트에서 다운로드 URL 이터레이터 문제 수정
### Checklist
- [x] Test case
- [x] End of work
