### PR TITLE
feat: 마이페이지 - 마이 프로젝트 - 완료된 프로젝트 조회

### DIFF
--- a/src/main/kotlin/pmeet/pmeetserver/project/controller/ProjectController.kt
+++ b/src/main/kotlin/pmeet/pmeetserver/project/controller/ProjectController.kt
@@ -24,6 +24,7 @@ import pmeet.pmeetserver.project.dto.request.CreateProjectRequestDto
 import pmeet.pmeetserver.project.dto.request.SearchProjectRequestDto
 import pmeet.pmeetserver.project.dto.request.UpdateProjectRequestDto
 import pmeet.pmeetserver.project.dto.response.CompletedProjectResponseDto
+import pmeet.pmeetserver.project.dto.response.GetMyCompletedProjectResponseDto
 import pmeet.pmeetserver.project.dto.response.GetMyInProgressProjectResponseDto
 import pmeet.pmeetserver.project.dto.response.GetMyInReviewProjectResponseDto
 import pmeet.pmeetserver.project.dto.response.GetMyProjectResponseDto
@@ -193,5 +194,16 @@ class ProjectController(
     @RequestParam(defaultValue = "6") size: Int
   ): Slice<GetMyInReviewProjectResponseDto> {
     return projectFacadeService.getMyProjectSliceInReview(userId.awaitSingle(), PageRequest.of(page, size))
+  }
+
+  @GetMapping("/my-project-slice/completed")
+  @ResponseStatus(HttpStatus.OK)
+  @Operation(summary = "완료된 프밋 목록 조회", description = "마이페이지 - 마이 프로젝트 - 완료된 프로젝트")
+  suspend fun getCompletedProjectSlice(
+    @AuthenticationPrincipal userId: Mono<String>,
+    @RequestParam(defaultValue = "0") page: Int,
+    @RequestParam(defaultValue = "6") size: Int
+  ): Slice<GetMyCompletedProjectResponseDto> {
+    return projectFacadeService.getMyProjectSliceCompleted(userId.awaitSingle(), PageRequest.of(page, size))
   }
 }

--- a/src/main/kotlin/pmeet/pmeetserver/project/dto/response/GetMyCompletedProjectResponseDto.kt
+++ b/src/main/kotlin/pmeet/pmeetserver/project/dto/response/GetMyCompletedProjectResponseDto.kt
@@ -2,7 +2,7 @@ package pmeet.pmeetserver.project.dto.response
 
 import pmeet.pmeetserver.project.domain.Project
 
-data class GetMyInProgressProjectResponseDto(
+data class GetMyCompletedProjectResponseDto(
   val id: String,
   val title: String,
   val description: String,
@@ -10,15 +10,15 @@ data class GetMyInProgressProjectResponseDto(
   val positionName: String?,
   val userInfos: List<ProjectMemberInfoDto>,
 ) {
-
+  
   companion object {
     fun of(
       project: Project,
       positionName: String?,
       thumbNailDownloadUrl: String?,
       userInfos: List<ProjectMemberInfoDto>
-    ): GetMyInProgressProjectResponseDto {
-      return GetMyInProgressProjectResponseDto(
+    ): GetMyCompletedProjectResponseDto {
+      return GetMyCompletedProjectResponseDto(
         id = project.id!!,
         title = project.title,
         description = project.description,

--- a/src/main/kotlin/pmeet/pmeetserver/project/dto/response/ProjectMemberInfoDto.kt
+++ b/src/main/kotlin/pmeet/pmeetserver/project/dto/response/ProjectMemberInfoDto.kt
@@ -1,0 +1,21 @@
+package pmeet.pmeetserver.project.dto.response
+
+data class ProjectMemberInfoDto(
+  val userId: String,
+  val userName: String,
+  val profileImageUrl: String?,
+) {
+  companion object {
+    fun of(
+      userId: String,
+      userName: String,
+      profileImageDownloadUrl: String?
+    ): ProjectMemberInfoDto {
+      return ProjectMemberInfoDto(
+        userId = userId,
+        userName = userName,
+        profileImageUrl = profileImageDownloadUrl
+      )
+    }
+  }
+}

--- a/src/main/kotlin/pmeet/pmeetserver/project/repository/CustomProjectRepository.kt
+++ b/src/main/kotlin/pmeet/pmeetserver/project/repository/CustomProjectRepository.kt
@@ -63,4 +63,10 @@ interface CustomProjectRepository {
     tryoutStatus: ProjectTryoutStatus,
     pageable: Pageable
   ): Flux<ProjectWithProjectTryout>
+
+  fun findProjectsByProjectMemberUserIdAndIsCompletedOrderByCompletedAtDesc(
+    userId: String,
+    isCompleted: Boolean,
+    pageable: Pageable
+  ): Flux<Project>
 }

--- a/src/main/kotlin/pmeet/pmeetserver/project/service/ProjectService.kt
+++ b/src/main/kotlin/pmeet/pmeetserver/project/service/ProjectService.kt
@@ -122,4 +122,19 @@ class ProjectService(
       pageable
     )
   }
+
+  suspend fun getProjectsByProjectMemberUserIdAndIsCompletedOrderByCompletedAtDesc(
+    userId: String,
+    isCompleted: Boolean,
+    pageable: Pageable
+  ): Slice<Project> {
+    return SliceResponse.of(
+      projectRepository.findProjectsByProjectMemberUserIdAndIsCompletedOrderByCompletedAtDesc(
+        userId,
+        isCompleted,
+        pageable
+      ).collectList().awaitSingle(),
+      pageable
+    )
+  }
 }

--- a/src/test/kotlin/pmeet/pmeetserver/project/ProjectIntegrationTest.kt
+++ b/src/test/kotlin/pmeet/pmeetserver/project/ProjectIntegrationTest.kt
@@ -33,6 +33,7 @@ import pmeet.pmeetserver.project.dto.comment.ProjectCommentWithChildDto
 import pmeet.pmeetserver.project.dto.request.CreateProjectRequestDto
 import pmeet.pmeetserver.project.dto.request.RecruitmentRequestDto
 import pmeet.pmeetserver.project.dto.request.UpdateProjectRequestDto
+import pmeet.pmeetserver.project.dto.response.GetMyCompletedProjectResponseDto
 import pmeet.pmeetserver.project.dto.response.GetMyInProgressProjectResponseDto
 import pmeet.pmeetserver.project.dto.response.GetMyInReviewProjectResponseDto
 import pmeet.pmeetserver.project.dto.response.GetMyProjectResponseDto
@@ -1435,6 +1436,91 @@ internal class ProjectIntegrationTest : BaseMongoDBTestForIntegration() {
         }
       }
     }
+
+    describe("GET /api/v1/projects/my-project-slice/completed") {
+      context("인증된 유저의 완료된 Project Slice 조회 요청이 들어오면") {
+        val userId = "anotherTestUserId"
+        val pageNumber = 0
+        val pageSize = 10
+        val mockAuthentication = UsernamePasswordAuthenticationToken(userId, null, null)
+        for (i in 1..20) {
+          val newProject = Project(
+            userId = userId + i,
+            title = "testTitle$i",
+            startDate = LocalDateTime.of(2021, 1, 1, 0, 0, 0),
+            endDate = LocalDateTime.of(2021, 12, 31, 23, 59, 59),
+            thumbNailUrl = "testThumbNailUrl$i",
+            techStacks = listOf("testTechStack1", "testTechStack2"),
+            recruitments = recruitments,
+            description = "testDescription$i",
+            isCompleted = true,
+            completedAt = LocalDateTime.of(2024, 11, 16, 0, 0, 0).minusMinutes(i.toLong())
+          )
+          withContext(Dispatchers.IO) {
+            projectRepository.save(newProject).block()
+          }
+
+          val projectMember = ProjectMember(
+            projectId = newProject.id!!,
+            userId = "userId$i",
+            resumeId = "resumeId$i",
+            userName = "testUser$i",
+            userThumbnail = "userThumbNail$i",
+            userSelfDescription = "description$i",
+            positionName = "position$i",
+            createdAt = LocalDateTime.of(2024, 8, 1, 0, 0, 0).plusDays(i.toLong())
+          )
+
+          val projectMember2 = ProjectMember(
+            projectId = newProject.id!!,
+            userId = userId,
+            resumeId = "resumeId$i",
+            userName = "testUser$i",
+            userThumbnail = "userThumbNail$i",
+            userSelfDescription = "description$i",
+            positionName = "realPositionName$i",
+            createdAt = LocalDateTime.of(2024, 8, 1, 0, 0, 0).minusMinutes(i.toLong())
+          )
+
+          withContext(Dispatchers.IO) {
+            projectMemberRepository.save(projectMember).block()
+            projectMemberRepository.save(projectMember2).block()
+          }
+        }
+        val performRequest = webTestClient
+          .mutateWith(mockAuthentication(mockAuthentication))
+          .get()
+          .uri {
+            it.path("/api/v1/projects/my-project-slice/completed")
+              .queryParam("page", pageNumber)
+              .queryParam("size", pageSize)
+              .build()
+          }
+          .accept(MediaType.APPLICATION_JSON)
+          .exchange()
+
+        it("요청은 성공한다") {
+          performRequest.expectStatus().isOk
+        }
+
+        it("내가 속한 완료된 Project를 대상으로 PageSize만큼 완료일 순으로 Slice를 반환한다") {
+          performRequest.expectBody<RestSliceImpl<GetMyCompletedProjectResponseDto>>().consumeWith { response ->
+            response.responseBody?.content?.size shouldBe pageSize
+            response.responseBody?.isFirst shouldBe true
+            response.responseBody?.isLast shouldBe false
+            response.responseBody?.hasNext() shouldBe true
+            response.responseBody?.content?.forEachIndexed { index, getMyCompletedProjectResponseDto ->
+              getMyCompletedProjectResponseDto.title shouldBe "testTitle${index + 1}"
+              getMyCompletedProjectResponseDto.description shouldBe "testDescription${index + 1}"
+              getMyCompletedProjectResponseDto.positionName shouldBe "realPositionName${index + 1}"
+              getMyCompletedProjectResponseDto.id shouldNotBe null
+              getMyCompletedProjectResponseDto.thumbNailUrl shouldNotBe "testThumbNailUrl${index + 1}"
+              getMyCompletedProjectResponseDto.userInfos.size shouldBe 1
+              getMyCompletedProjectResponseDto.userInfos[0].userId shouldBe "userId${index + 1}"
+            }
+          }
+        }
+      }
+    }
   }
 }
-


### PR DESCRIPTION
## Related issue
resolves #189 

## Description
 - 기존의 findProjectsByProjectMemberUserIdAndIsCompletedOrderByCreatedAtDesc와는 Sort 적용 순서가 달라서 분리
## Changes detail
- 
-
### Checklist
- [x] Test case
- [x] End of work
