### PR TITLE
fix: 이력서 필터 조회 필수 조건 제거

### DIFF
--- a/src/main/kotlin/pmeet/pmeetserver/user/controller/ResumeController.kt
+++ b/src/main/kotlin/pmeet/pmeetserver/user/controller/ResumeController.kt
@@ -130,8 +130,8 @@ class ResumeController(
   @ResponseStatus(HttpStatus.OK)
   suspend fun getResumeListByCondition(
     @AuthenticationPrincipal userId: Mono<String>,
-    @RequestParam(required = true) filterType: ResumeFilterType,
-    @RequestParam(required = true) filterValue: String,
+    @RequestParam(required = false) filterType: ResumeFilterType?,
+    @RequestParam(required = false) filterValue: String?,
     @RequestParam(required = true) orderType: ResumeOrderType,
     @RequestParam(defaultValue = "0") page: Int,
     @RequestParam(defaultValue = "8") size: Int,

--- a/src/main/kotlin/pmeet/pmeetserver/user/domain/resume/Resume.kt
+++ b/src/main/kotlin/pmeet/pmeetserver/user/domain/resume/Resume.kt
@@ -46,7 +46,7 @@ class Resume(
   var techStacks: List<TechStack>,
   var jobExperiences: List<JobExperience>,
   var projectExperiences: List<ProjectExperience>,
-  var portfolioFileUrls: List<String>,
+  var portfolioFileUrls: List<String>?,
   var portfolioUrl: List<String>,
   var selfDescription: String?,
   var bookmarkers: MutableList<ResumeBookMarker> = mutableListOf(),

--- a/src/main/kotlin/pmeet/pmeetserver/user/repository/resume/CustomResumeRepository.kt
+++ b/src/main/kotlin/pmeet/pmeetserver/user/repository/resume/CustomResumeRepository.kt
@@ -21,8 +21,8 @@ interface CustomResumeRepository {
    */
   fun findAllByFilter(
     searchedUserId: String,
-    filterType: ResumeFilterType,
-    filterValue: String,
+    filterType: ResumeFilterType?,
+    filterValue: String?,
     orderType: ResumeOrderType,
     pageable: Pageable
   ): Flux<Resume>

--- a/src/main/kotlin/pmeet/pmeetserver/user/repository/resume/CustomResumeRepositoryImpl.kt
+++ b/src/main/kotlin/pmeet/pmeetserver/user/repository/resume/CustomResumeRepositoryImpl.kt
@@ -43,8 +43,8 @@ class CustomResumeRepositoryImpl(
 
   override fun findAllByFilter(
     searchedUserId: String,
-    filterType: ResumeFilterType,
-    filterValue: String,
+    filterType: ResumeFilterType?,
+    filterValue: String?,
     orderType: ResumeOrderType,
     pageable: Pageable
   ): Flux<Resume> {
@@ -80,8 +80,8 @@ class CustomResumeRepositoryImpl(
    * @param filterType 필터 타입(TOTAL, TITLE, JOB, NICKNAME)
    * @param filterValue 필터 값
    */
-  private fun createCriteria(filterType: ResumeFilterType, filterValue: String): Criteria {
-    return if (filterValue == "") {
+  private fun createCriteria(filterType: ResumeFilterType?, filterValue: String?): Criteria {
+    return if (filterValue == null || filterType == null) {
       Criteria()
     } else {
       when (filterType) {

--- a/src/main/kotlin/pmeet/pmeetserver/user/service/resume/ResumeFacadeService.kt
+++ b/src/main/kotlin/pmeet/pmeetserver/user/service/resume/ResumeFacadeService.kt
@@ -32,7 +32,7 @@ class ResumeFacadeService(
     return ResumeResponseDto.of(
       resumeService.save(resume),
       resume.userProfileImageUrl?.let { fileService.generatePreSignedUrlToDownload(it) },
-      resume.portfolioFileUrls.let { fileService.generatePreSignedUrlsToDownload(it) }
+      resume.portfolioFileUrls?.let { fileService.generatePreSignedUrlsToDownload(it) }
     )
   }
 
@@ -42,7 +42,7 @@ class ResumeFacadeService(
     return ResumeResponseDto.of(
       resume,
       resume.userProfileImageUrl?.let { fileService.generatePreSignedUrlToDownload(it) },
-      resume.portfolioFileUrls.let { fileService.generatePreSignedUrlsToDownload(it) }
+      resume.portfolioFileUrls?.let { fileService.generatePreSignedUrlsToDownload(it) }
     )
   }
 
@@ -53,7 +53,7 @@ class ResumeFacadeService(
       ResumeResponseDto.of(
         it,
         it.userProfileImageUrl?.let { fileService.generatePreSignedUrlToDownload(it) },
-        it.portfolioFileUrls.let { fileService.generatePreSignedUrlsToDownload(it) }
+        it.portfolioFileUrls?.let { fileService.generatePreSignedUrlsToDownload(it) }
       )
     }
   }
@@ -79,7 +79,7 @@ class ResumeFacadeService(
     return ResumeResponseDto.of(
       updatedResume,
       updatedResume.userProfileImageUrl?.let { fileService.generatePreSignedUrlToDownload(it) },
-      updatedResume.portfolioFileUrls.let { fileService.generatePreSignedUrlsToDownload(it) }
+      updatedResume.portfolioFileUrls?.let { fileService.generatePreSignedUrlsToDownload(it) }
     )
   }
 
@@ -102,7 +102,7 @@ class ResumeFacadeService(
     return ResumeResponseDto.of(
       copiedResume,
       copiedResume.userProfileImageUrl?.let { fileService.generatePreSignedUrlToDownload(it) },
-      copiedResume.portfolioFileUrls.let { fileService.generatePreSignedUrlsToDownload(it) }
+      copiedResume.portfolioFileUrls?.let { fileService.generatePreSignedUrlsToDownload(it) }
     )
   }
 
@@ -151,8 +151,8 @@ class ResumeFacadeService(
   @Transactional
   suspend fun searchResumeSlice(
     userId: String,
-    filterType: ResumeFilterType,
-    filterValue: String,
+    filterType: ResumeFilterType?,
+    filterValue: String?,
     orderType: ResumeOrderType,
     pageable: PageRequest
   ): Slice<SearchedResumeResponseDto> {

--- a/src/main/kotlin/pmeet/pmeetserver/user/service/resume/ResumeService.kt
+++ b/src/main/kotlin/pmeet/pmeetserver/user/service/resume/ResumeService.kt
@@ -63,8 +63,8 @@ class ResumeService(private val resumeRepository: ResumeRepository) {
   @Transactional(readOnly = true)
   suspend fun searchSliceByFilter(
     searchedUserId: String,
-    filterType: ResumeFilterType,
-    filterValue: String,
+    filterType: ResumeFilterType?,
+    filterValue: String?,
     orderType: ResumeOrderType,
     pageable: PageRequest
   ): Slice<Resume> {

--- a/src/test/kotlin/pmeet/pmeetserver/user/resume/service/ResumeFacadeServiceUnitTest.kt
+++ b/src/test/kotlin/pmeet/pmeetserver/user/resume/service/ResumeFacadeServiceUnitTest.kt
@@ -94,7 +94,7 @@ class ResumeFacadeServiceUnitTest : DescribeSpec({
           val profileImageDownloadUrl = "profile-image-download-url"
           val portfolioFileDownloadUrls = listOf("portfolio-file-download-url", "portfolio-file-download-url2")
           coEvery { fileService.generatePreSignedUrlToDownload(resume.userProfileImageUrl!!) } answers { profileImageDownloadUrl }
-          coEvery { fileService.generatePreSignedUrlsToDownload(resume.portfolioFileUrls) } answers { portfolioFileDownloadUrls }
+          coEvery { fileService.generatePreSignedUrlsToDownload(resume.portfolioFileUrls!!) } answers { portfolioFileDownloadUrls }
 
           val result = resumeFacadeService.createResume(resumeCreateRequest)
 
@@ -248,7 +248,7 @@ class ResumeFacadeServiceUnitTest : DescribeSpec({
           val profileImageDownloadUrl = "profile-image-download-url"
           val portfolioFileDownloadUrls = listOf("portfolio-file-download-url", "portfolio-file-download-url2")
           coEvery { fileService.generatePreSignedUrlToDownload(originalResume.userProfileImageUrl!!) } answers { profileImageDownloadUrl }
-          coEvery { fileService.generatePreSignedUrlsToDownload(originalResume.portfolioFileUrls) } answers { portfolioFileDownloadUrls }
+          coEvery { fileService.generatePreSignedUrlsToDownload(originalResume.portfolioFileUrls!!) } answers { portfolioFileDownloadUrls }
 
           val result = resumeFacadeService.copyResume(resume.userId, copyRequest)
           result.title shouldBe "[복사] ${originalResume.title.toString()}"


### PR DESCRIPTION
## Related issue
resolves #issue_number

## Description
- 필터 타입, 필터 벨류 둘 중 하나라도 Null이면 Empty Criteria() 생성
## Changes detail
 - 이미 생성된 resume들은 portfolioFileUrls이 null이므로 portfolioFileUrls을 Null 허용했음
### Checklist
- [x] Test case
- [x] End of work
